### PR TITLE
refactor: DID authorisation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8874,6 +8874,7 @@ name = "runtime-common"
 version = "1.7.0"
 dependencies = [
  "attestation",
+ "did",
  "frame-support",
  "frame-system",
  "frame-try-runtime",

--- a/pallets/did/src/did_details.rs
+++ b/pallets/did/src/did_details.rs
@@ -18,6 +18,7 @@
 
 use codec::{Decode, Encode, MaxEncodedLen, WrapperTypeEncode};
 use frame_support::{
+	dispatch::Weight,
 	ensure,
 	storage::{bounded_btree_map::BoundedBTreeMap, bounded_btree_set::BoundedBTreeSet},
 	traits::Get,
@@ -25,7 +26,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_core::{ecdsa, ed25519, sr25519};
-use sp_runtime::{traits::Verify, MultiSignature};
+use sp_runtime::{traits::Verify, DispatchError, MultiSignature};
 use sp_std::convert::TryInto;
 
 use kilt_support::deposit::Deposit;
@@ -544,7 +545,22 @@ pub enum RelationshipDeriveError {
 	InvalidCallParameter,
 }
 
-pub type DeriveDidCallKeyRelationshipResult = Result<DidVerificationKeyRelationship, RelationshipDeriveError>;
+pub enum DidVerificationType {
+	Inline,
+	StoredVerificationKey(DidVerificationKeyRelationship),
+}
+
+impl DidVerificationType {
+	pub fn inline() -> Self {
+		Self::Inline
+	}
+
+	pub fn with_verification_key(relationship: DidVerificationKeyRelationship) -> Self {
+		Self::StoredVerificationKey(relationship)
+	}
+}
+
+pub type DeriveDidVerificationTypeResult = Result<DidVerificationType, RelationshipDeriveError>;
 
 /// Trait for extrinsic DID-based authorization.
 ///
@@ -553,10 +569,10 @@ pub type DeriveDidCallKeyRelationshipResult = Result<DidVerificationKeyRelations
 /// extrinsic to specify what DID key to use to perform signature validation
 /// over the byte-encoded operation. A result of None indicates that the
 /// extrinsic does not support DID-based authorization.
-pub trait DeriveDidCallAuthorizationVerificationKeyRelationship {
+pub trait DeriveDidCallAuthorizationVerificationType {
 	/// The type of the verification key to be used to validate the
 	/// wrapped extrinsic.
-	fn derive_verification_key_relationship(&self) -> DeriveDidCallKeyRelationshipResult;
+	fn derive_verification_key_relationship(&self) -> DeriveDidVerificationTypeResult;
 
 	// Return a call to dispatch in order to test the pallet proxy feature.
 	#[cfg(feature = "runtime-benchmarks")]
@@ -620,3 +636,13 @@ impl<T: Config> core::ops::Deref for DidAuthorizedCallOperationWithVerificationR
 // [DidAuthorizedCallOperationWithVerificationRelationship] encodes to
 // [DidAuthorizedCallOperation].
 impl<T: Config> WrapperTypeEncode for DidAuthorizedCallOperationWithVerificationRelationship<T> {}
+
+pub trait DidCallProxy<T: Config> {
+	fn weight(call: &DidCallableOf<T>) -> Weight;
+
+	fn authorise(
+		call: &DidCallableOf<T>,
+		did: &DidIdentifierOf<T>,
+		signature: &DidSignature,
+	) -> Result<(), DispatchError>;
+}

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -99,11 +99,7 @@ mod utils;
 
 pub use crate::{
 	default_weights::WeightInfo,
-	did_details::{
-		DeriveDidCallAuthorizationVerificationType, DeriveDidVerificationTypeResult,
-		DidAuthorizedCallOperationWithVerificationRelationship, DidCallProxy, DidSignature, DidVerificationKeyRelationship,
-		RelationshipDeriveError,
-	},
+	did_details::*,
 	origin::{DidRawOrigin, EnsureDidOrigin},
 	pallet::*,
 	signature::DidSignatureVerify,
@@ -134,13 +130,11 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use kilt_support::traits::CallSources;
-	use sp_runtime::traits::BadOrigin;
 
 	use crate::{
 		did_details::{
-			DeriveDidCallAuthorizationVerificationType, DidAuthorizedCallOperation, DidCreationDetails,
-			DidDetails, DidEncryptionKey, DidSignature, DidVerifiableIdentifier, DidVerificationKey,
-			RelationshipDeriveError,
+			DeriveDidCallAuthorizationVerificationType, DidAuthorizedCallOperation, DidCreationDetails, DidDetails,
+			DidEncryptionKey, DidSignature, DidVerifiableIdentifier, DidVerificationKey, RelationshipDeriveError,
 		},
 		errors::{DidError, InputError, SignatureError, StorageError},
 		service_endpoints::{DidEndpoint, ServiceEndpointId},
@@ -473,18 +467,16 @@ pub mod pallet {
 		/// - Reads: [Origin Account], Did, DidBlacklist
 		/// - Writes: Did
 		/// # </weight>
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::create_ed25519_key().max(<T as pallet::Config>::WeightInfo::create_sr25519_key()).max(<T as pallet::Config>::WeightInfo::create_ecdsa_key()))]
-		pub fn create(origin: OriginFor<T>, details: DidCreationDetails<T>, signature: DidSignature) -> DispatchResult {
-			let sender = ensure_signed(origin)?;
+		#[pallet::weight(0)]
+		pub fn create(origin: OriginFor<T>, auth_key: DidVerificationKey) -> DispatchResult {
+			let origin = T::EnsureOrigin::ensure_origin(origin)?;
 
-			ensure!(sender == details.submitter, BadOrigin);
-
-			let did_identifier = details.did.clone();
+			let did_identifier = origin.subject().clone();
 
 			// Check the free balance before we do any heavy work.
 			ensure!(
 				<T::Currency as ReservableCurrency<AccountIdOf<T>>>::can_reserve(
-					&sender,
+					&origin.sender(),
 					<T as Config>::Deposit::get() + <T as Config>::Fee::get()
 				),
 				Error::<T>::UnableToPayFees
@@ -500,12 +492,8 @@ pub mod pallet {
 			// otherwise generate a DidAlreadyPresent error.
 			ensure!(!Did::<T>::contains_key(&did_identifier), Error::<T>::DidAlreadyPresent);
 
-			let account_did_auth_key = did_identifier
-				.verify_and_recover_signature(&details.encode(), &signature)
+			let did_entry = DidDetails::from_creation_details(DidCreationDetails { auth_key }, origin.sender().clone())
 				.map_err(Error::<T>::from)?;
-
-			let did_entry =
-				DidDetails::from_creation_details(details, account_did_auth_key).map_err(Error::<T>::from)?;
 
 			// *** No Fail beyond this call ***
 
@@ -526,7 +514,7 @@ pub mod pallet {
 
 			Did::<T>::insert(&did_identifier, did_entry);
 
-			Self::deposit_event(Event::DidCreated(sender, did_identifier));
+			Self::deposit_event(Event::DidCreated(origin.sender(), did_identifier));
 
 			Ok(())
 		}
@@ -976,7 +964,7 @@ pub mod pallet {
 
 			let did_identifier = did_call.did.clone();
 
-			T::DidCallProxy::authorise(&did_call.call, &did_call.did, &signature)?;
+			T::DidCallProxy::authorise(&did_call, &signature)?;
 
 			log::debug!("Dispatch call from DID {:?}", did_identifier);
 

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -34,7 +34,7 @@ use sp_std::vec::Vec;
 use crate::{
 	self as did,
 	did_details::{
-		DeriveDidCallAuthorizationVerificationKeyRelationship, DeriveDidCallKeyRelationshipResult,
+		DeriveDidCallAuthorizationVerificationType, DeriveDidVerificationTypeResult,
 		DidAuthorizedCallOperation, DidAuthorizedCallOperationWithVerificationRelationship, DidDetails,
 		DidEncryptionKey, DidPublicKey, DidPublicKeyDetails, DidVerificationKey, DidVerificationKeyRelationship,
 		RelationshipDeriveError,
@@ -354,8 +354,8 @@ pub(crate) fn get_none_key_call() -> Call {
 	})
 }
 
-impl DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
-	fn derive_verification_key_relationship(&self) -> DeriveDidCallKeyRelationshipResult {
+impl DeriveDidCallAuthorizationVerificationType for Call {
+	fn derive_verification_key_relationship(&self) -> DeriveDidVerificationTypeResult {
 		if *self == get_attestation_key_call() {
 			Ok(DidVerificationKeyRelationship::AssertionMethod)
 		} else if *self == get_authentication_key_call() {

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -34,10 +34,9 @@ use sp_std::vec::Vec;
 use crate::{
 	self as did,
 	did_details::{
-		DeriveDidCallAuthorizationVerificationType, DeriveDidVerificationTypeResult,
-		DidAuthorizedCallOperation, DidAuthorizedCallOperationWithVerificationRelationship, DidDetails,
-		DidEncryptionKey, DidPublicKey, DidPublicKeyDetails, DidVerificationKey, DidVerificationKeyRelationship,
-		RelationshipDeriveError,
+		DeriveDidCallAuthorizationVerificationType, DeriveDidVerificationTypeResult, DidAuthorizedCallOperation,
+		DidAuthorizedCallOperationWithVerificationRelationship, DidDetails, DidEncryptionKey, DidPublicKey,
+		DidPublicKeyDetails, DidVerificationKey, DidVerificationKeyRelationship, RelationshipDeriveError,
 	},
 	service_endpoints::DidEndpoint,
 	utils as crate_utils, AccountIdOf, Config, CurrencyOf, DidBlacklist, DidEndpointsCount, KeyIdOf, ServiceEndpoints,

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -5,6 +5,7 @@ name = "runtime-common"
 version = "1.7.0"
 
 [dev-dependencies]
+did = {features = ["mock"], path = "../../pallets/did"}
 sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24"}
 
 [dependencies]
@@ -15,6 +16,7 @@ serde = {version = "1.0.137", optional = true, features = ["derive"]}
 smallvec = "1.8.0"
 
 attestation = {default-features = false, path = "../../pallets/attestation"}
+did = {default-features = false, path = "../../pallets/did"}
 parachain-staking = {default-features = false, path = "../../pallets/parachain-staking"}
 
 frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.24"}
@@ -45,6 +47,7 @@ std = [
   "attestation/std",
   "parachain-staking/std",
   "codec/std",
+  "did/std",
   "frame-support/std",
   "frame-system/std",
   "pallet-transaction-payment/std",

--- a/runtimes/common/src/did.rs
+++ b/runtimes/common/src/did.rs
@@ -1,0 +1,296 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2022 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use codec::Encode;
+
+use frame_support::dispatch::Weight;
+use sp_runtime::DispatchError;
+
+use did::{DeriveDidCallAuthorizationVerificationType, DidAuthorizedCallOperation, DidAuthorizedCallOperationWithVerificationRelationship, DidVerificationType, DidVerifiableIdentifier};
+
+pub struct DidCallProxy<Config>(sp_std::marker::PhantomData<Config>);
+impl<T: did::Config> did::DidCallProxy<T> for DidCallProxy<T> {
+	fn weight(did_call: &DidAuthorizedCallOperation<T>) -> Weight {
+		// TODO: Use runtime-specific weights for the inline and stored signature verification
+		todo!()
+	}
+
+	fn authorise(
+		did_call: &DidAuthorizedCallOperation<T>,
+		signature: &did::DidSignature,
+	) -> Result<(), DispatchError> {
+		let verification_key_relationship = did_call
+			.call
+			.derive_verification_key_relationship()
+			.map_err(did::Error::<T>::from)?;
+
+		match verification_key_relationship {
+			DidVerificationType::Inline => {
+				did_call.did
+					.verify_and_recover_signature(&did_call.encode(), &signature)
+					.map_err(did::Error::<T>::from)?;
+				Ok(())
+			}
+			DidVerificationType::StoredVerificationKey(key_relationship) => {
+				let wrapped_operation = DidAuthorizedCallOperationWithVerificationRelationship {
+					operation: did_call.clone(),
+					verification_key_relationship: key_relationship,
+				};
+
+				did::Pallet::<T>::verify_did_operation_signature_and_increase_nonce(&wrapped_operation, &signature)
+					.map_err(did::Error::<T>::from)?;
+				Ok(())
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use super::DidCallProxy as Proxy;
+
+	use frame_support::{
+		assert_err,
+		assert_ok,
+		parameter_types,
+		weights::constants::RocksDbWeight,
+	};
+	use frame_system::EnsureSigned;
+	use sp_core::{ed25519, sr25519, Pair};
+	use sp_runtime::{
+		testing::Header,
+		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+		MultiSignature, MultiSigner,
+	};
+	use sp_std::vec::Vec;
+
+	use did::{DidDetails, DidSignature, DidCallProxy};
+
+	pub(crate) type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
+	pub(crate) type Block = frame_system::mocking::MockBlock<TestRuntime>;
+	pub(crate) type Hash = sp_core::H256;
+	pub(crate) type Balance = u128;
+	pub(crate) type Signature = MultiSignature;
+	pub(crate) type AccountPublic = <Signature as Verify>::Signer;
+	pub(crate) type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+	pub(crate) type Index = u64;
+	pub(crate) type BlockNumber = u64;
+
+	pub(crate) type DidIdentifier = AccountId;
+
+	const MICRO_KILT: Balance = 10u128.pow(9);
+
+	frame_support::construct_runtime!(
+		pub enum TestRuntime where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			Did: did::{Pallet, Call, Storage, Event<T>, Origin<T>},
+			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		}
+	);
+
+	impl did::DeriveDidCallAuthorizationVerificationType for Call {
+		fn derive_verification_key_relationship(&self) -> did::DeriveDidVerificationTypeResult {
+			match *self {
+				Call::System(frame_system::Call::remark { .. }) => Ok(did::DidVerificationType::inline()),
+				Call::System(frame_system::Call::remark_with_event { .. }) => Ok(did::DidVerificationType::StoredVerificationKey(did::DidVerificationKeyRelationship::Authentication)),
+				_ => Err(did::RelationshipDeriveError::NotCallableByDid)
+			}
+		}
+	}
+
+	parameter_types! {
+		pub const SS58Prefix: u8 = 38;
+		pub const BlockHashCount: u64 = 250;
+	}
+
+	impl frame_system::Config for TestRuntime {
+		type Origin = Origin;
+		type Call = Call;
+		type Index = Index;
+		type BlockNumber = BlockNumber;
+		type Hash = Hash;
+		type Hashing = BlakeTwo256;
+		type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Header = Header;
+		type Event = ();
+		type BlockHashCount = BlockHashCount;
+		type DbWeight = RocksDbWeight;
+		type Version = ();
+
+		type PalletInfo = PalletInfo;
+		type AccountData = pallet_balances::AccountData<Balance>;
+		type OnNewAccount = ();
+		type OnKilledAccount = ();
+		type BaseCallFilter = frame_support::traits::Everything;
+		type SystemWeightInfo = ();
+		type BlockWeights = ();
+		type BlockLength = ();
+		type SS58Prefix = SS58Prefix;
+		type OnSetCode = ();
+		type MaxConsumers = frame_support::traits::ConstU32<16>;
+	}
+
+	parameter_types! {
+		#[derive(Debug, Clone, PartialEq)]
+		pub const MaxUrlLength: u32 = 200u32;
+		#[derive(Debug, Clone, PartialEq)]
+		pub const MaxTotalKeyAgreementKeys: u32 = 10u32;
+		// IMPORTANT: Needs to be at least MaxTotalKeyAgreementKeys + 3 (auth, delegation, attestation keys) for benchmarks!
+		#[derive(Debug, Clone)]
+		pub const MaxPublicKeysPerDid: u32 = 13u32;
+		pub const MaxBlocksTxValidity: u64 = 300u64;
+		pub const Deposit: Balance = 10 * MICRO_KILT;
+		pub const DidFee: Balance = MICRO_KILT;
+		pub const MaxNumberOfServicesPerDid: u32 = 25u32;
+		pub const MaxServiceIdLength: u32 = 50u32;
+		pub const MaxServiceTypeLength: u32 = 50u32;
+		pub const MaxServiceUrlLength: u32 = 100u32;
+		pub const MaxNumberOfTypesPerService: u32 = 1u32;
+		pub const MaxNumberOfUrlsPerService: u32 = 1u32;
+	}
+
+	impl did::Config for TestRuntime {
+		type DidIdentifier = DidIdentifier;
+		type Origin = Origin;
+		type Call = Call;
+		type DidCallProxy = super::DidCallProxy<Self>;
+		type EnsureOrigin = EnsureSigned<DidIdentifier>;
+		type OriginSuccess = AccountId;
+		type Event = ();
+		type Currency = ();
+		type Deposit = ();
+		type Fee = ();
+		type FeeCollector = ();
+		type MaxTotalKeyAgreementKeys = MaxTotalKeyAgreementKeys;
+		type MaxPublicKeysPerDid = MaxPublicKeysPerDid;
+		type MaxBlocksTxValidity = MaxBlocksTxValidity;
+		type WeightInfo = ();
+		type MaxNumberOfServicesPerDid = MaxNumberOfServicesPerDid;
+		type MaxServiceIdLength = MaxServiceIdLength;
+		type MaxServiceTypeLength = MaxServiceTypeLength;
+		type MaxServiceUrlLength = MaxServiceUrlLength;
+		type MaxNumberOfTypesPerService = MaxNumberOfTypesPerService;
+		type MaxNumberOfUrlsPerService = MaxNumberOfUrlsPerService;
+	}
+
+	#[derive(Clone, Default)]
+	struct ExtBuilder {
+		dids_stored: Vec<(DidIdentifier, DidDetails<TestRuntime>)>,
+	}
+
+	impl ExtBuilder {
+		#[must_use]
+		pub fn with_dids(mut self, dids: Vec<(DidIdentifier, DidDetails<TestRuntime>)>) -> Self {
+			self.dids_stored = dids;
+			self
+		}
+
+		pub fn build(self, ext: Option<sp_io::TestExternalities>) -> sp_io::TestExternalities {
+			let mut ext = if let Some(ext) = ext {
+				ext
+			} else {
+				let storage = frame_system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
+				sp_io::TestExternalities::new(storage)
+			};
+
+			ext.execute_with(|| {
+				for did in self.dids_stored.iter() {
+					did::Did::<TestRuntime>::insert(&did.0, did.1.clone());
+				}
+			});
+
+			ext
+		}
+	}
+
+	const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
+	const DEFAULT_AUTH_SEED: [u8; 32] = [4u8; 32];
+	const ALTERNATIVE_AUTH_SEED: [u8; 32] = [40u8; 32];
+
+	fn get_ed25519_authentication_key(default: bool) -> ed25519::Pair {
+		if default {
+			ed25519::Pair::from_seed(&DEFAULT_AUTH_SEED)
+		} else {
+			ed25519::Pair::from_seed(&ALTERNATIVE_AUTH_SEED)
+		}
+	}
+
+	fn get_sr25519_authentication_key(default: bool) -> sr25519::Pair {
+		if default {
+			sr25519::Pair::from_seed(&DEFAULT_AUTH_SEED)
+		} else {
+			sr25519::Pair::from_seed(&ALTERNATIVE_AUTH_SEED)
+		}
+	}
+
+	fn get_did_identifier_from_ed25519_key(public_key: ed25519::Public) -> DidIdentifier {
+		MultiSigner::from(public_key).into_account()
+	}
+
+	fn get_did_identifier_from_sr25519_key(public_key: sr25519::Public) -> DidIdentifier {
+		MultiSigner::from(public_key).into_account()
+	}
+
+	#[test]
+	fn test_correct_inline_operation() {
+		let auth_key = get_ed25519_authentication_key(true);
+		let alice_did = get_did_identifier_from_ed25519_key(auth_key.public());
+
+		let call = Call::System(frame_system::Call::<TestRuntime>::remark { remark: vec![1; 32] });
+		let did_call = DidAuthorizedCallOperation::<TestRuntime> { block_number: 0u64.into(), call, did: alice_did, submitter: ACCOUNT_00, tx_counter: 0 };
+		let encoded_did_call = did_call.encode();
+		let did_signature = DidSignature::from(auth_key.sign(&encoded_did_call));
+
+		assert_ok!(Proxy::authorise(&did_call, &did_signature));
+	}
+
+	#[test]
+	fn test_wrong_signature_format_inline_operation() {
+		let auth_key = get_ed25519_authentication_key(true);
+		let alice_did = get_did_identifier_from_ed25519_key(auth_key.public());
+
+		let call = Call::System(frame_system::Call::<TestRuntime>::remark { remark: vec![1; 32] });
+		let did_call = DidAuthorizedCallOperation::<TestRuntime> { block_number: 0u64.into(), call, did: alice_did, submitter: ACCOUNT_00, tx_counter: 0 };
+		let encoded_did_call = did_call.encode();
+
+		let alternative_auth_key = get_sr25519_authentication_key(true);
+		let did_signature = DidSignature::from(alternative_auth_key.sign(&encoded_did_call));
+
+		// Fails with InvalidSignature because it tries to re-create an Sr25519 key given the Sr25519 signature but of course it fails.
+		assert_err!(Proxy::authorise(&did_call, &did_signature), did::Error::<TestRuntime>::InvalidSignature);
+	}
+
+	#[test]
+	fn test_wrong_signature_inline_operation() {
+		let auth_key = get_ed25519_authentication_key(true);
+		let alice_did = get_did_identifier_from_ed25519_key(auth_key.public());
+
+		let call = Call::System(frame_system::Call::<TestRuntime>::remark { remark: vec![1; 32] });
+		let did_call = DidAuthorizedCallOperation::<TestRuntime> { block_number: 0u64.into(), call, did: alice_did, submitter: ACCOUNT_00, tx_counter: 0 };
+		// Sign a random byte array
+		let did_signature = DidSignature::from(auth_key.sign(&vec![10; 64]));
+
+		// Fails with InvalidSignature because it tries to re-create an Sr25519 key given the Sr25519 signature but of course it fails.
+		assert_err!(Proxy::authorise(&did_call, &did_signature), did::Error::<TestRuntime>::InvalidSignature);
+	}
+}

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -44,6 +44,7 @@ use sp_std::marker::PhantomData;
 
 pub mod authorization;
 pub mod constants;
+pub mod did;
 pub mod fees;
 pub mod migrations;
 pub mod pallet_id;

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -910,8 +910,6 @@ impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
 			Call::Attestation { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Ctype { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Delegation { .. } => Ok(did::DidVerificationKeyRelationship::CapabilityDelegation),
-			// DID creation is not allowed through the DID proxy.
-			Call::Did(did::Call::create { .. }) => Err(did::RelationshipDeriveError::NotCallableByDid),
 			Call::Did { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Web3Names { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::DidLookup { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -884,10 +884,10 @@ construct_runtime! {
 	}
 }
 
-impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
-	fn derive_verification_key_relationship(&self) -> did::DeriveDidCallKeyRelationshipResult {
+impl did::DeriveDidCallAuthorizationVerificationType for Call {
+	fn derive_verification_key_relationship(&self) -> did::DeriveDidVerificationTypeResult {
 		/// ensure that all calls have the same VerificationKeyRelationship
-		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidCallKeyRelationshipResult {
+		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidVerificationTypeResult {
 			let init = calls
 				.get(0)
 				.ok_or(did::RelationshipDeriveError::InvalidCallParameter)?

--- a/runtimes/peregrine/src/tests.rs
+++ b/runtimes/peregrine/src/tests.rs
@@ -19,7 +19,7 @@
 use codec::MaxEncodedLen;
 use frame_support::{traits::Currency, BoundedVec};
 
-use did::DeriveDidCallAuthorizationVerificationKeyRelationship;
+use did::DeriveDidCallAuthorizationVerificationType;
 use pallet_treasury::BalanceOf;
 use pallet_web3_names::{Web3NameOf, Web3OwnershipOf};
 use runtime_common::constants::{

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -903,8 +903,6 @@ impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
 			Call::Attestation { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Ctype { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Delegation { .. } => Ok(did::DidVerificationKeyRelationship::CapabilityDelegation),
-			// DID creation is not allowed through the DID proxy.
-			Call::Did(did::Call::create { .. }) => Err(did::RelationshipDeriveError::NotCallableByDid),
 			Call::Did { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Web3Names { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::DidLookup { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -877,10 +877,10 @@ construct_runtime! {
 	}
 }
 
-impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
-	fn derive_verification_key_relationship(&self) -> did::DeriveDidCallKeyRelationshipResult {
+impl did::DeriveDidCallAuthorizationVerificationType for Call {
+	fn derive_verification_key_relationship(&self) -> did::DeriveDidVerificationTypeResult {
 		/// ensure that all calls have the same VerificationKeyRelationship
-		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidCallKeyRelationshipResult {
+		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidVerificationTypeResult {
 			let init = calls
 				.get(0)
 				.ok_or(did::RelationshipDeriveError::InvalidCallParameter)?

--- a/runtimes/spiritnet/src/tests.rs
+++ b/runtimes/spiritnet/src/tests.rs
@@ -19,7 +19,7 @@
 use codec::MaxEncodedLen;
 use frame_support::{traits::Currency, BoundedVec};
 
-use did::DeriveDidCallAuthorizationVerificationKeyRelationship;
+use did::DeriveDidCallAuthorizationVerificationType;
 use pallet_treasury::BalanceOf;
 use pallet_web3_names::{Web3NameOf, Web3OwnershipOf};
 use runtime_common::constants::{

--- a/runtimes/standalone/src/access_control.rs
+++ b/runtimes/standalone/src/access_control.rs
@@ -1,0 +1,108 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2022 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{traits::InstanceFilter, ensure, RuntimeDebug};
+
+use crate::Call;
+
+impl did::DeriveDidCallAuthorizationVerificationType for Call {
+	fn derive_verification_key_relationship(&self) -> did::DeriveDidVerificationTypeResult {
+		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidVerificationTypeResult {
+			let first_call_key = calls
+				.get(0)
+				.ok_or(did::RelationshipDeriveError::InvalidCallParameter)?
+				.derive_verification_key_relationship()?;
+
+			match first_call_key {
+				// If the first call in the batch requires an inline signature, only certain DID operations can be part
+				// of the batch.
+				did::DidVerificationType::Inline => {
+					let are_calls_allowed = calls
+						.iter()
+						.skip(1)
+						.all(|call| {
+							matches!(
+								call,
+								Call::Did(
+									did::Call::set_delegation_key { .. }
+										| did::Call::set_attestation_key { .. } | did::Call::add_key_agreement_key { .. }
+										| did::Call::add_service_endpoint { .. }
+								)
+							)
+						});
+					ensure!(are_calls_allowed, did::RelationshipDeriveError::InvalidCallParameter);
+					// The verification logic for the whole batch is therefore `inline`
+					Ok(first_call_key)
+				}
+				// If the first call in the batch requires a stored key, then all calls must have the same key
+				// relationship. This means that Inline calls are not allowed, e.g., it is not possible to squeeze in a
+				// DID creation operation.
+				did::DidVerificationType::StoredVerificationKey(key_rel) => calls
+					.iter()
+					.skip(1)
+					.map(Call::derive_verification_key_relationship)
+					.try_fold(
+						did::DidVerificationType::with_verification_key(key_rel),
+						|acc, next| match next {
+							// Step successful if the next key relationship is of the same type as the current one.
+							Ok(key_type) if key_type == acc => Ok(acc),
+							Err(_) => next,
+							_ => Err(did::RelationshipDeriveError::InvalidCallParameter),
+						},
+					),
+			}
+		}
+
+		match self {
+			Call::Attestation { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::AssertionMethod,
+			)),
+			Call::Ctype { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::AssertionMethod,
+			)),
+			Call::Delegation { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::CapabilityDelegation,
+			)),
+			// DID creation requires inline verification.
+			Call::Did(did::Call::create { .. }) => Ok(did::DidVerificationType::inline()),
+			Call::Did { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::Authentication,
+			)),
+			Call::Web3Names { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::Authentication,
+			)),
+			Call::DidLookup { .. } => Ok(did::DidVerificationType::with_verification_key(
+				did::DidVerificationKeyRelationship::Authentication,
+			)),
+			Call::Utility(pallet_utility::Call::batch { calls }) => single_key_relationship(&calls[..]),
+			Call::Utility(pallet_utility::Call::batch_all { calls }) => single_key_relationship(&calls[..]),
+			#[cfg(not(feature = "runtime-benchmarks"))]
+			_ => Err(did::RelationshipDeriveError::NotCallableByDid),
+			// By default, returns the authentication key
+			#[cfg(feature = "runtime-benchmarks")]
+			_ => Ok(did::DidVerificationKeyRelationship::Authentication),
+		}
+	}
+
+	// Always return a System::remark() extrinsic call
+	#[cfg(feature = "runtime-benchmarks")]
+	fn get_call_for_did_call_benchmark() -> Call {
+		Call::System(frame_system::Call::remark { remark: vec![] })
+	}
+}

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -657,9 +657,6 @@ impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
 			Call::Attestation { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Ctype { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Delegation { .. } => Ok(did::DidVerificationKeyRelationship::CapabilityDelegation),
-			// DID creation is not allowed through the DID proxy.
-			Call::Did(did::Call::create { .. }) => Err(did::RelationshipDeriveError::NotCallableByDid),
-			Call::Did { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Web3Names { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::DidLookup { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Utility(pallet_utility::Call::batch { calls }) => single_key_relationship(&calls[..]),

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -634,9 +634,9 @@ construct_runtime!(
 	}
 );
 
-impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
-	fn derive_verification_key_relationship(&self) -> did::DeriveDidCallKeyRelationshipResult {
-		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidCallKeyRelationshipResult {
+impl did::DeriveDidCallAuthorizationVerificationType for Call {
+	fn derive_verification_key_relationship(&self) -> did::DeriveDidVerificationTypeResult {
+		fn single_key_relationship(calls: &[Call]) -> did::DeriveDidVerificationTypeResult {
 			let init = calls
 				.get(0)
 				.ok_or(did::RelationshipDeriveError::InvalidCallParameter)?
@@ -654,9 +654,12 @@ impl did::DeriveDidCallAuthorizationVerificationKeyRelationship for Call {
 				})
 		}
 		match self {
-			Call::Attestation { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
+			Call::Attestation { .. } => Ok(did::DidVerificationKeyType:: DidVerificationKeyRelationship::AssertionMethod),
 			Call::Ctype { .. } => Ok(did::DidVerificationKeyRelationship::AssertionMethod),
 			Call::Delegation { .. } => Ok(did::DidVerificationKeyRelationship::CapabilityDelegation),
+			// DID creation requires inline verification.
+			Call::Did(did::Call::create { .. }) => Err(did::RelationshipDeriveError::NotCallableByDid),
+			Call::Did { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Web3Names { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::DidLookup { .. } => Ok(did::DidVerificationKeyRelationship::Authentication),
 			Call::Utility(pallet_utility::Call::batch { calls }) => single_key_relationship(&calls[..]),


### PR DESCRIPTION
This PR fixes https://github.com/KILTprotocol/ticket/issues/1897.

It is based on top of https://github.com/KILTprotocol/mashnet-node/pull/350, as they are meant to be considered two parts of the same solution.

## What it does

In short, this PR allows DID creation calls to use a `DidOrigin` instead of a `SignedOrigin`, meaning that it will go through `submit_did_call` and, when batched with other DID management extrinsics, will not require an additional signature.