### PR TITLE
fix: rococo protocol id

### DIFF
--- a/dev-specs/kilt-parachain/rococo-v2-relay.json
+++ b/dev-specs/kilt-parachain/rococo-v2-relay.json
@@ -18,7 +18,7 @@
       0
     ]
   ],
-  "protocolId": "rococo_v2_2",
+  "protocolId": "rococo",
   "properties": {
     "ss58Format": 42,
     "tokenDecimals": 12,


### PR DESCRIPTION
## NO TICKET

## Checklist:
We should have downloaded via wget with init container yet for now Check line 21 : https://paritytech.github.io/chainspecs/rococo/relaychain/chainspec.json
- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
