### PR TITLE
ci: Remove older docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,7 @@ build:
     - "if [[ ! -z ${CI_COMMIT_BRANCH} ]]; then ./.maintain/push-image.sh build latest-${CI_COMMIT_BRANCH}; fi"
     - "if [[ ! -z ${CI_COMMIT_TAG} ]]; then ./.maintain/push-image.sh build ${CI_COMMIT_TAG}; fi"
     - "if [[ ! -z ${CI_COMMIT_TAG} ]]; then ./.maintain/push-image.sh build latest; fi"
+    - "if [[ ! -z ${CI_COMMIT_TAG} ]]; then ./.maintain/remove-image.sh; fi"
 
 build-wasm-peregrine:
   image:

--- a/.maintain/remove-image.sh
+++ b/.maintain/remove-image.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+TAGS_TO_KEEP=10  #Keep recent 10 tags and delete the rest
+
+for REPOSITORY_NAME in  {DOCKER_HUB_STANDALONE} ${DOCKER_HUB_PARACHAIN} $AWS_REGISTRY/kilt/prototype-chain $AWS_REGISTRY/kilt-parachain/collator
+do
+    TAGS=$(docker images ${REPOSITORY_NAME} -a -q)
+
+    idx=0
+    for TAG in ${TAGS}
+    do
+
+        idx=$((idx+1))
+
+        if [[ ${idx} -gt ${TAGS_TO_KEEP} ]]; then
+
+            IMAGE="${REPOSITORY_NAME}:${TAG}"
+
+            echo "Deleting docker rmi -f ${IMAGE} ..."
+
+            docker rmi -f ${IMAGE}
+
+        else
+
+            echo "Skipping ${IMAGE} at ${idx}"
+
+        fi
+
+    done
+
+done


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2046
CI will skip recent 10 docker images of kilt-standalone or parachain taged in both public and private repositories

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
