### PR TITLE
feat: call in did creation

### DIFF
--- a/pallets/did/src/did_details.rs
+++ b/pallets/did/src/did_details.rs
@@ -26,7 +26,7 @@ use frame_support::{
 use scale_info::TypeInfo;
 use sp_core::{ecdsa, ed25519, sr25519};
 use sp_runtime::{traits::Verify, MultiSignature};
-use sp_std::convert::TryInto;
+use sp_std::{boxed::Box, convert::TryInto};
 
 use kilt_support::deposit::Deposit;
 
@@ -522,6 +522,8 @@ pub struct DidCreationDetails<T: Config> {
 	pub did: DidIdentifierOf<T>,
 	/// The authorised submitter of the creation operation.
 	pub submitter: AccountIdOf<T>,
+	/// A follow up did call that will be executed after the DID was created.
+	pub call: Option<Box<DidCallableOf<T>>>,
 }
 
 impl<T: Config> sp_std::fmt::Debug for DidCreationDetails<T> {

--- a/pallets/did/src/mock_utils.rs
+++ b/pallets/did/src/mock_utils.rs
@@ -86,7 +86,11 @@ pub(crate) fn generate_base_did_creation_details<T: Config>(
 	did: DidIdentifierOf<T>,
 	submitter: AccountIdOf<T>,
 ) -> DidCreationDetails<T> {
-	DidCreationDetails { did, submitter }
+	DidCreationDetails {
+		did,
+		submitter,
+		call: None,
+	}
 }
 
 pub(crate) fn generate_base_did_details<T>(authentication_key: DidVerificationKey) -> DidDetails<T>


### PR DESCRIPTION
## Convenience for the DID creation
fixes https://github.com/KILTprotocol/ticket/issues/1897

Creating a DID and setting all keys requires two signatures. Submitting a call with the create op reduces this to one.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
