### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,30 +1541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-client-consensus-relay-chain"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.25#390042a01940a0a4d0b28eb196a2e9251f3cec33"
-dependencies = [
- "async-trait",
- "cumulus-client-consensus-common",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
- "futures 0.3.21",
- "parking_lot 0.12.1",
- "sc-client-api",
- "sc-consensus",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "substrate-prometheus-endpoint",
- "tracing",
-]
-
-[[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.25#390042a01940a0a4d0b28eb196a2e9251f3cec33"
@@ -1712,24 +1688,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "cumulus-pallet-xcmp-queue"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.25#390042a01940a0a4d0b28eb196a2e9251f3cec33"
-dependencies = [
- "cumulus-primitives-core",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "sp-runtime",
- "sp-std",
- "xcm",
- "xcm-executor",
 ]
 
 [[package]]
@@ -2033,7 +1991,6 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-rpc",
  "sp-runtime",
 ]
 
@@ -2043,7 +2000,6 @@ version = "1.6.2"
 dependencies = [
  "did",
  "kilt-support",
- "pallet-did-lookup",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -3606,7 +3562,6 @@ dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
- "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core",
@@ -3622,11 +3577,7 @@ dependencies = [
  "hex-literal",
  "jsonrpsee",
  "log",
- "node-executor",
- "pallet-conviction-voting",
  "pallet-did-lookup",
- "pallet-ranked-collective",
- "pallet-referenda",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -4635,9 +4586,7 @@ dependencies = [
  "jsonrpsee",
  "log",
  "mashnet-node-runtime",
- "pallet-conviction-voting",
  "pallet-did-lookup",
- "pallet-referenda",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "runtime-common",
@@ -4709,7 +4658,6 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
- "pallet-vesting",
  "pallet-web3-names",
  "parity-scale-codec",
  "runtime-common",
@@ -5099,125 +5047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "node-executor"
-version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "node-primitives",
- "node-runtime",
- "parity-scale-codec",
- "sc-executor",
- "scale-info",
- "sp-core",
- "sp-keystore",
- "sp-state-machine",
- "sp-tracing",
- "sp-trie",
-]
-
-[[package]]
-name = "node-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
-]
-
-[[package]]
-name = "node-runtime"
-version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "log",
- "node-primitives",
- "pallet-alliance",
- "pallet-asset-tx-payment",
- "pallet-assets",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-collective",
- "pallet-contracts",
- "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
- "pallet-conviction-voting",
- "pallet-democracy",
- "pallet-election-provider-multi-phase",
- "pallet-elections-phragmen",
- "pallet-gilt",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
- "pallet-lottery",
- "pallet-membership",
- "pallet-mmr",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-offences",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-randomness-collective-flip",
- "pallet-ranked-collective",
- "pallet-recovery",
- "pallet-referenda",
- "pallet-remark",
- "pallet-scheduler",
- "pallet-session",
- "pallet-society",
- "pallet-staking",
- "pallet-staking-reward-curve",
- "pallet-state-trie-migration",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-tips",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-transaction-storage",
- "pallet-treasury",
- "pallet-uniques",
- "pallet-utility",
- "pallet-vesting",
- "pallet-whitelist",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-offchain",
- "sp-runtime",
- "sp-sandbox",
- "sp-session",
- "sp-staking",
- "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "static_assertions",
- "substrate-wasm-builder",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5427,53 +5256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "pallet-alliance"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "pallet-identity",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-asset-tx-payment"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-transaction-payment",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-assets"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -5736,87 +5518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-contracts"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "bitflags",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-contracts-primitives",
- "pallet-contracts-proc-macro",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "smallvec",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-sandbox",
- "sp-std",
- "wasm-instrument",
- "wasmi-validation",
-]
-
-[[package]]
-name = "pallet-contracts-primitives"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "bitflags",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-contracts-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pallet-contracts-rpc-runtime-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "pallet-contracts-primitives",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-conviction-voting"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
@@ -6020,19 +5721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-lottery"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
@@ -6219,24 +5907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-ranked-collective"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
@@ -6246,40 +5916,6 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-referenda"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "assert_matches",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-remark"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -6396,23 +6032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-state-trie-migration"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
@@ -6506,24 +6125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-transaction-storage"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-balances",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-transaction-storage-proof",
-]
-
-[[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
@@ -6536,21 +6137,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-uniques"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -6601,20 +6187,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-keystore",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-whitelist"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.25#3348e144f0a2b39ce08bd8e3b976c42fe0c990b9"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
  "sp-runtime",
  "sp-std",
 ]
@@ -6674,8 +6246,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal",
- "kilt-support",
  "log",
  "pallet-aura",
  "pallet-authorship",
@@ -6885,7 +6455,6 @@ dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "delegation",
@@ -6928,7 +6497,6 @@ dependencies = [
  "parachain-staking",
  "parity-scale-codec",
  "polkadot-parachain",
- "rococo-runtime",
  "runtime-common",
  "scale-info",
  "serde",
@@ -8935,7 +8503,6 @@ dependencies = [
  "attestation",
  "frame-support",
  "frame-system",
- "frame-try-runtime",
  "log",
  "pallet-authorship",
  "pallet-balances",
@@ -11264,7 +10831,6 @@ dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "delegation",
@@ -11306,7 +10872,6 @@ dependencies = [
  "parachain-staking",
  "parity-scale-codec",
  "polkadot-parachain",
- "rococo-runtime",
  "runtime-common",
  "scale-info",
  "serde",

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -73,7 +73,6 @@ cumulus-client-cli = {git = "https://github.com/paritytech/cumulus", branch = "p
 cumulus-client-collator = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
 cumulus-client-consensus-aura = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
 cumulus-client-consensus-common = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
-cumulus-client-consensus-relay-chain = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
 cumulus-client-network = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
 cumulus-client-service = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
 cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.25"}
@@ -94,10 +93,6 @@ frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = 
 frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25"}
 
 # Runtime tests
-node-executor = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
-pallet-conviction-voting = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
-pallet-ranked-collective = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
-pallet-referenda = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
 try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
 
 [features]
@@ -107,16 +102,12 @@ fast-gov = [
   "runtime-common/fast-gov",
 ]
 runtime-benchmarks = [
-  "pallet-conviction-voting/runtime-benchmarks",
   "pallet-did-lookup/runtime-benchmarks",
-  "pallet-ranked-collective/runtime-benchmarks",
-  "pallet-referenda/runtime-benchmarks",
   "polkadot-service/runtime-benchmarks",
   "peregrine-runtime/runtime-benchmarks",
   "spiritnet-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-  "node-executor",
   "peregrine-runtime/try-runtime",
   "spiritnet-runtime/try-runtime",
   "try-runtime-cli",

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -68,17 +68,13 @@ frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = 
 frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25"}
 
 # Runtime tests
-pallet-conviction-voting = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
-pallet-referenda = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
 try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", optional = true}
 
 [features]
 default = []
 runtime-benchmarks = [
   "mashnet-node-runtime/runtime-benchmarks",
-  "pallet-conviction-voting/runtime-benchmarks",
   "pallet-did-lookup/runtime-benchmarks",
-  "pallet-referenda/runtime-benchmarks",
   "runtime-common/runtime-benchmarks",
 ]
 try-runtime = [

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -13,13 +13,10 @@ sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25"}
 
 [dependencies]
-hex-literal = "0.3.4"
 log = "0.4.17"
 parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 serde = {version = "1.0.137", optional = true}
-
-kilt-support = {default-features = false, path = "../../support"}
 
 frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", default-features = false}
 frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.25", default-features = false}
@@ -43,7 +40,6 @@ runtime-benchmarks = [
 std = [
   "frame-support/std",
   "frame-system/std",
-  "kilt-support/std",
   "log/std",
   "pallet-authorship/std",
   "pallet-balances/std",
@@ -57,5 +53,4 @@ std = [
 ]
 try-runtime = [
   "frame-support/try-runtime",
-  "kilt-support/try-runtime",
 ]

--- a/rpc/did/Cargo.toml
+++ b/rpc/did/Cargo.toml
@@ -14,7 +14,6 @@ did-rpc-runtime-api = {version = "1.6.2", path = "./runtime-api"}
 sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 sp-blockchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
-sp-rpc = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 
 [features]

--- a/rpc/did/runtime-api/Cargo.toml
+++ b/rpc/did/runtime-api/Cargo.toml
@@ -15,7 +15,6 @@ sp-runtime = {git = "https://github.com/paritytech/substrate", default-features 
 sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 
 did = {path = "../../../pallets/did", default-features = false}
-pallet-did-lookup = {path = "../../../pallets/pallet-did-lookup", default-features = false}
 kilt-support = {path = "../../../support", default-features = false}
 
 [features]
@@ -29,5 +28,4 @@ std = [
   "scale-info/std",
   "did/std",
   "kilt-support/std",
-  "pallet-did-lookup/std",
 ]

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -29,9 +29,6 @@ sp-io = {git = "https://github.com/paritytech/substrate", default-features = fal
 sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25"}
 
-# Runtime tests
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25", optional = true}
-
 [features]
 default = ["std"]
 fast-gov = []
@@ -61,5 +58,4 @@ std = [
 ]
 try-runtime = [
   "frame-support/try-runtime",
-  "frame-try-runtime",
 ]

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -76,7 +76,6 @@ pallet-vesting = {git = "https://github.com/paritytech/substrate", default-featu
 # Cumulus dependencies
 cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
@@ -90,7 +89,6 @@ xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features
 # Benchmarking
 cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "polkadot-v0.9.25"}
 frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.25"}
-rococo-runtime = {git = "https://github.com/paritytech/polkadot", default-features = false, optional = true, branch = "release-v0.9.25"}
 
 # Runtime tests
 frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25", optional = true}
@@ -120,6 +118,7 @@ runtime-benchmarks = [
   "pallet-inflation/runtime-benchmarks",
   "pallet-membership/runtime-benchmarks",
   "pallet-preimage/runtime-benchmarks",
+  "pallet-proxy/runtime-benchmarks",
   "pallet-scheduler/runtime-benchmarks",
   "pallet-timestamp/runtime-benchmarks",
   "pallet-tips/runtime-benchmarks",
@@ -128,7 +127,6 @@ runtime-benchmarks = [
   "pallet-web3-names/runtime-benchmarks",
   "pallet-utility/runtime-benchmarks",
   "parachain-staking/runtime-benchmarks",
-  "rococo-runtime/runtime-benchmarks",
   "runtime-common/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
 ]
@@ -138,7 +136,6 @@ std = [
   "ctype/std",
   "cumulus-pallet-aura-ext/std",
   "cumulus-pallet-parachain-system/std",
-  "cumulus-pallet-xcmp-queue/std",
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "delegation/std",
@@ -176,7 +173,6 @@ std = [
   "parachain-info/std",
   "parachain-staking/std",
   "polkadot-parachain/std",
-  "rococo-runtime/std",
   "runtime-common/std",
   "scale-info/std",
   "serde",

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -75,7 +75,6 @@ pallet-vesting = {git = "https://github.com/paritytech/substrate", default-featu
 # Cumulus dependencies
 cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
 parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.25"}
@@ -89,7 +88,6 @@ xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features
 # Benchmarking
 cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "polkadot-v0.9.25"}
 frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.25"}
-rococo-runtime = {git = "https://github.com/paritytech/polkadot", default-features = false, optional = true, branch = "release-v0.9.25"}
 
 # Runtime tests
 frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.25", optional = true}
@@ -129,7 +127,6 @@ runtime-benchmarks = [
   "pallet-utility/runtime-benchmarks",
   "pallet-vesting/runtime-benchmarks",
   "parachain-staking/runtime-benchmarks",
-  "rococo-runtime/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
 ]
 std = [
@@ -138,7 +135,6 @@ std = [
   "ctype/std",
   "cumulus-pallet-aura-ext/std",
   "cumulus-pallet-parachain-system/std",
-  "cumulus-pallet-xcmp-queue/std",
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "delegation/std",
@@ -176,7 +172,6 @@ std = [
   "parachain-info/std",
   "parachain-staking/std",
   "polkadot-parachain/std",
-  "rococo-runtime/std",
   "runtime-common/std",
   "scale-info/std",
   "serde",

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -51,7 +51,6 @@ pallet-sudo = {branch = "polkadot-v0.9.25", default-features = false, git = "htt
 pallet-timestamp = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
 pallet-transaction-payment = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
 pallet-utility = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-vesting = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
 sp-api = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
 sp-arithmetic = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
 sp-block-builder = {branch = "polkadot-v0.9.25", default-features = false, git = "https://github.com/paritytech/substrate"}
@@ -89,7 +88,6 @@ runtime-benchmarks = [
   "pallet-indices/runtime-benchmarks",
   "pallet-timestamp/runtime-benchmarks",
   "pallet-web3-names/runtime-benchmarks",
-  "pallet-vesting/runtime-benchmarks",
   "pallet-proxy/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
 ]
@@ -121,7 +119,6 @@ std = [
   "pallet-transaction-payment/std",
   "pallet-transaction-payment-rpc-runtime-api/std",
   "pallet-web3-names/std",
-  "pallet-vesting/std",
   "runtime-common/std",
   "scale-info/std",
   "serde",
@@ -162,5 +159,4 @@ try-runtime = [
   "pallet-web3-names/try-runtime",
   "pallet-utility/try-runtime",
   "pallet-transaction-payment/try-runtime",
-  "pallet-vesting/try-runtime",
 ]

--- a/scripts/all.fish
+++ b/scripts/all.fish
@@ -6,25 +6,13 @@ echo "Features check started..."
 
 for features in "--features default" "--all-features" "--features runtime-benchmarks" "--features try-runtime"
 	for package in (cargo workspaces list)
-		cargo check -p $package (echo $features | string split " ") > /dev/null ^ /dev/null
+		cargo clippy -p $package --all-targets (echo $features | string split " ") > /dev/null ^ /dev/null
 		if [ "$status" = "0" ]
 			echo -n "[ok]   "
 		else
 			echo -n "[fail] "
 		end
-		echo cargo check -p $package (echo $features | string split " ")
-	end
-end
-
-for features in "--features default" "--all-features" "--features runtime-benchmarks" "--features try-runtime"
-	for package in (cargo workspaces list)
-		cargo test -p $package (echo $features | string split " ") > /dev/null ^ /dev/null
-		if [ "$status" = "0" ]
-			echo -n "[ok]   "
-		else
-			echo -n "[fail] "
-		end
-		echo cargo test -p $package (echo $features | string split " ")
+		echo cargo clippy -p $package --all-targets (echo $features | string split " ")
 	end
 end
 


### PR DESCRIPTION
Remove unused dependencies using `cargo udeps`. It also updates the `all.fish` script to check for `--all-targets` and remove the actual tests running, since we do not need those.