### PR TITLE
chore: check for unused dependencies in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,14 @@ clippy:
   stage: test
   timeout: 1 hours
   script:
-    - rustup component add clippy --toolchain nightly
-    - cargo +nightly install cargo-udeps
-    - cargo +nightly clippy --all-features --all-targets --locked -- -D warnings
+    - rustup component list --installed
+    - rustup toolchain list
+    - rustup component add clippy
+    - cargo clippy --all-features --all-targets --locked -- -D warnings
+    - cargo install cargo-udeps
     # Unless there is a way to conditionally execute part of a job, cargo-udeps can only run after the project metadata has been correctly pulled in.
     # Open issue: https://github.com/est31/cargo-udeps/issues/97
-    - cargo +nightly udeps --all-features --all-targets --locked
+    - cargo udeps --all-features --all-targets --locked
 
 fmt:
   # Corresponds to paritytech/ci-linux:production at the time of this PR
@@ -23,8 +25,8 @@ fmt:
   stage: test
   timeout: 1 hours
   script:
-    - rustup component add rustfmt --toolchain nightly
-    - cargo +nightly fmt -- --check
+    - rustup component add rustfmt
+    - cargo fmt -- --check
 
 test:
   # Corresponds to paritytech/ci-linux:production at the time of this PR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ udeps:
     - rustup component list --installed
     - rustup toolchain list
     - cargo install cargo-udeps
-    - cargo check --all-features --all-targets --locked -- -D warnings
+    - cargo check --all-features --all-targets --locked
     # Unless there is a way to conditionally execute part of a job, cargo-udeps can only run after the project metadata has been correctly pulled in, which happens with `cargo check`.
     # Open issue: https://github.com/est31/cargo-udeps/issues/97
     - cargo udeps --all-features --all-targets --locked

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,11 @@ clippy:
   timeout: 1 hours
   script:
     - rustup component add clippy --toolchain nightly
+    - cargo +nightly install cargo-udeps
     - cargo +nightly clippy --all-features --all-targets --locked -- -D warnings
+    # Unless there is a way to conditionally execute part of a job, cargo-udeps can only run after the project metadata has been correctly pulled in.
+    # Open issue: https://github.com/est31/cargo-udeps/issues/97
+    - cargo +nightly udeps --all-features --all-targets --locked
 
 fmt:
   # Corresponds to paritytech/ci-linux:production at the time of this PR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,15 @@ clippy:
   stage: test
   timeout: 1 hours
   script:
-    - rustup component list --installed
-    - rustup toolchain list
     - rustup component add clippy
     - cargo clippy --all-features --all-targets --locked -- -D warnings
+
+udeps:
+    - rustup component list --installed
+    - rustup toolchain list
     - cargo install cargo-udeps
-    # Unless there is a way to conditionally execute part of a job, cargo-udeps can only run after the project metadata has been correctly pulled in.
+    - cargo check --all-features --all-targets --locked -- -D warnings
+    # Unless there is a way to conditionally execute part of a job, cargo-udeps can only run after the project metadata has been correctly pulled in, which happens with `cargo check`.
     # Open issue: https://github.com/est31/cargo-udeps/issues/97
     - cargo udeps --all-features --all-targets --locked
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,12 @@ clippy:
     - cargo clippy --all-features --all-targets --locked -- -D warnings
 
 udeps:
+  # Corresponds to paritytech/ci-linux:production at the time of this PR
+  # https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-c75cee0971ca54e57a875fac8714eea2db754e621841cde702478783fc28ab90?context=explore
+  image: paritytech/ci-linux@sha256:c75cee0971ca54e57a875fac8714eea2db754e621841cde702478783fc28ab90
+  stage: test
+  timeout: 1 hours
+  script:
     - rustup component list --installed
     - rustup toolchain list
     - cargo install cargo-udeps


### PR DESCRIPTION
This PR adds one additional check in the `clippy` job for the `test` stage.

Although it is not desirable to run it for every commit, `cargo udeps` runs in few seconds, and because of an open issue it cannot be run into its own job without first running one of `cargo check`, `cargo clippy`, or `cargo build`. Hence, I would suggest to run it on every commit to capture any unused dependencies, and reduce both compilation times and the size of the produced binaries.