### PR TITLE
feat: remove multiple delegations

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1477,7 +1477,7 @@ pub mod pallet {
 			.into())
 		}
 
-		/// Leave the set of delegators and, by implication, revoke the ingoing
+		/// Leave the set of delegators and, by implication, revoke the ongoing
 		/// delegation.
 		///
 		/// All staked funds are not unlocked immediately, but they are added to
@@ -1489,7 +1489,7 @@ pub mod pallet {
 		/// their chances to be included in the set of candidates in the next
 		/// rounds.
 		///
-		/// Automatically increments the accumulated rewards of the origin the
+		/// Automatically increments the accumulated rewards of the origin of the
 		/// current delegation.
 		///
 		/// Emits `DelegatorLeft`.

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -740,12 +740,6 @@ pub mod pallet {
 		/// ShouldEndSession<_>>::should_end_session.
 		///
 		/// The dispatch origin must be Root.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: [Origin Account]
-		/// - Writes: ForceNewRound
-		/// # </weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_inflation())]
 		pub fn force_new_round(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -769,12 +763,6 @@ pub mod pallet {
 		/// The dispatch origin must be Root.
 		///
 		/// Emits `RoundInflationSet`.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: [Origin Account]
-		/// - Writes: InflationConfig
-		/// # </weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_inflation())]
 		pub fn set_inflation(
 			origin: OriginFor<T>,
@@ -831,20 +819,6 @@ pub mod pallet {
 		/// The dispatch origin must be Root.
 		///
 		/// Emits `MaxSelectedCandidatesSet`.
-		///
-		///
-		/// # <weight>
-		/// - The transaction's complexity is mainly dependent on updating the
-		///   `SelectedCandidates` storage in `select_top_candidates` which in
-		///   return depends on the number of `MaxSelectedCandidates` (N).
-		/// - For each N, we read `CandidatePool` from the storage.
-		/// ---------
-		/// Weight: O(N + D) where N is `MaxSelectedCandidates` bounded by
-		/// `MaxTopCandidates` and D is the number of delegators of a
-		/// candidate bounded by `MaxDelegatorsPerCollator`.
-		/// - Reads: MaxSelectedCandidates, TopCandidates, N * CandidatePool
-		/// - Writes: MaxSelectedCandidates
-		/// # </weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_max_selected_candidates(
 			*new,
 			T::MaxDelegatorsPerCollator::get()
@@ -913,12 +887,6 @@ pub mod pallet {
 		/// The dispatch origin must be Root.
 		///
 		/// Emits `BlocksPerRoundSet`.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: [Origin Account], Round
-		/// - Writes: Round
-		/// # </weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_blocks_per_round())]
 		pub fn set_blocks_per_round(origin: OriginFor<T>, new: T::BlockNumber) -> DispatchResult {
 			ensure_root(origin)?;
@@ -948,12 +916,6 @@ pub mod pallet {
 		/// The dispatch origin must be Root.
 		///
 		/// Emits `MaxCandidateStakeChanged`.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: [Origin Account], MaxCollatorCandidateStake
-		/// - Writes: Round
-		/// # </weight>
 		#[pallet::weight(<T as Config>::WeightInfo::set_max_candidate_stake())]
 		pub fn set_max_candidate_stake(origin: OriginFor<T>, new: BalanceOf<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -1047,8 +1009,6 @@ pub mod pallet {
 		/// candidates nor of the delegators set.
 		///
 		/// Emits `JoinedCollatorCandidates`.
-		///
-		/// # <weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::join_candidates(
 			T::MaxTopCandidates::get(),
 			T::MaxDelegatorsPerCollator::get()
@@ -1641,14 +1601,6 @@ pub mod pallet {
 		/// allowed range as set in the pallet's configuration.
 		///
 		/// Emits `DelegatorStakedLess`.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: [Origin Account], DelegatorState, BlockNumber, Unstaking,
-		///   TopCandidates, CandidatePool, MaxSelectedCandidates
-		/// - Writes: Unstaking, DelegatorState, CandidatePool,
-		///   TotalCollatorStake
-		/// # </weight>
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::delegator_stake_less(
 			T::MaxTopCandidates::get(),
 			T::MaxDelegatorsPerCollator::get()
@@ -1882,11 +1834,6 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		/// Check whether an account is currently delegating.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: DelegatorState
-		/// # </weight>
 		pub fn is_delegator(acc: &T::AccountId) -> bool {
 			DelegatorState::<T>::get(acc).is_some()
 		}
@@ -1895,11 +1842,6 @@ pub mod pallet {
 		/// whether their state is CollatorStatus::Active.
 		///
 		/// Returns Some(is_active) if the account is a candidate, else None.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: CandidatePool
-		/// # </weight>
 		pub fn is_active_candidate(acc: &T::AccountId) -> Option<bool> {
 			if let Some(state) = CandidatePool::<T>::get(acc) {
 				Some(state.status == CandidateStatus::Active)
@@ -1913,12 +1855,6 @@ pub mod pallet {
 		///
 		/// NOTE: It is assumed that the calling context checks whether the
 		/// collator candidate is currently active before calling this function.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: TopCandidates, CandidatePool, TotalCollatorStake
-		/// - Writes: TopCandidates, TotalCollatorStake
-		/// # </weight>
 		fn update_top_candidates(
 			candidate: T::AccountId,
 			old_self: BalanceOf<T>,
@@ -2136,11 +2072,6 @@ pub mod pallet {
 		/// In case a collator from last round was replaced by a candidate with
 		/// the same total stake during sorting, we revert this swap to
 		/// prioritize collators over candidates.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: TopCandidates, MaxSelectedCandidates
-		/// # </weight>
 		pub fn selected_candidates() -> BoundedVec<T::AccountId, T::MaxTopCandidates> {
 			let candidates = TopCandidates::<T>::get();
 
@@ -2174,12 +2105,6 @@ pub mod pallet {
 		///
 		/// Emits `DelegationReplaced` if the stake exceeds one of the current
 		/// delegations.
-		///
-		/// # <weight>
-		/// Weight: O(D) where D is the number of delegators for this collator
-		/// bounded by `MaxDelegatorsPerCollator`.
-		/// - Reads/Writes: 0
-		/// # </weight>
 		#[allow(clippy::type_complexity)]
 		fn do_update_delegator(
 			stake: Stake<T::AccountId, BalanceOf<T>>,
@@ -2229,13 +2154,6 @@ pub mod pallet {
 		///
 		/// Consumes unstaked balance which can be unlocked in the future up to
 		/// amount and updates `Unstaking` storage accordingly.
-		///
-		/// # <weight>
-		/// Weight: O(U) where U is the number of locked unstaking requests
-		/// bounded by `MaxUnstakeRequests`.
-		/// - Reads: Unstaking, Locks
-		/// - Writes: Unstaking, Locks
-		/// # </weight>
 		fn increase_lock(who: &T::AccountId, amount: BalanceOf<T>, more: BalanceOf<T>) -> Result<u32, DispatchError> {
 			ensure!(
 				pallet_balances::Pallet::<T>::free_balance(who) >= amount.into(),
@@ -2288,12 +2206,6 @@ pub mod pallet {
 		/// Throws if the amount is zero (unlikely) or if active unlocking
 		/// requests exceed limit. The latter defends against stake reduction
 		/// spamming.
-		///
-		/// # <weight>
-		/// Weight: O(1)
-		/// - Reads: BlockNumber, Unstaking
-		/// - Writes: Unstaking
-		/// # </weight>
 		fn prep_unstake(who: &T::AccountId, amount: BalanceOf<T>, is_removal: bool) -> DispatchResult {
 			// should never occur but let's be safe
 			ensure!(!amount.is_zero(), Error::<T>::StakeNotFound);
@@ -2327,16 +2239,6 @@ pub mod pallet {
 		/// Clear the CandidatePool of the candidate and remove all delegations
 		/// to the candidate. Moreover, prepare unstaking for the candidate and
 		/// their former delegations.
-		///
-		/// # <weight>
-		/// Weight: O(D + U) where D is the number of delegators of the collator
-		/// candidate bounded by `MaxDelegatorsPerCollator` and U is the
-		/// number of locked unstaking requests bounded by `MaxUnstakeRequests`.
-		/// - Reads: BlockNumber, D * DelegatorState, D * Unstaking
-		/// - Writes: D * DelegatorState, (D + 1) * Unstaking
-		/// - Kills: CandidatePool, DelegatorState for all delegators which only
-		///   delegated to the candidate
-		/// # </weight>
 		fn remove_candidate(
 			collator: &T::AccountId,
 			state: &CandidateOf<T, T::MaxDelegatorsPerCollator>,
@@ -2382,14 +2284,6 @@ pub mod pallet {
 
 		/// Withdraw all staked currency which was unstaked at least
 		/// `StakeDuration` blocks ago.
-		///
-		/// # <weight>
-		/// Weight: O(U) where U is the number of locked unstaking
-		/// requests bounded by `MaxUnstakeRequests`.
-		/// - Reads: Unstaking, Locks
-		/// - Writes: Unstaking, Locks
-		/// - Kills: Unstaking & Locks if no balance is locked anymore
-		/// # </weight>
 		fn do_unlock(who: &T::AccountId) -> Result<u32, DispatchError> {
 			let now = <frame_system::Pallet<T>>::block_number();
 			let mut unstaking = <Unstaking<T>>::get(who);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -3057,7 +3057,7 @@ pub mod pallet {
 		fn note_author(author: T::AccountId) {
 			// should always include state except if the collator has been forcedly removed
 			// via `force_remove_candidate` in the current or previous round
-			if CandidatePool::<T>::get(author.clone()).is_some() {
+			if CandidatePool::<T>::get(&author).is_some() {
 				// necessary to compensate for a potentially fluctuating number of collators
 				let authors = pallet_session::Pallet::<T>::validators();
 				RewardCount::<T>::mutate(&author, |count| {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -134,15 +134,13 @@ parameter_types! {
 	pub const ExitQueueDelay: u32 = 2;
 	pub const DefaultBlocksPerRound: BlockNumber = BLOCKS_PER_ROUND;
 	pub const MinCollators: u32 = 2;
+	pub const MaxDelegationsPerRound: u32 = 2;
 	#[derive(Debug, PartialEq)]
 	pub const MaxDelegatorsPerCollator: u32 = 4;
-	#[derive(Debug, PartialEq)]
-	pub const MaxCollatorsPerDelegator: u32 = 4;
 	pub const MinCollatorStake: Balance = 10;
 	#[derive(Debug, PartialEq)]
 	pub const MaxCollatorCandidates: u32 = 10;
 	pub const MinDelegatorStake: Balance = 5;
-	pub const MinDelegation: Balance = 3;
 	pub const MaxUnstakeRequests: u32 = 6;
 	pub const NetworkRewardRate: Perquintill = Perquintill::from_percent(10);
 	pub const NetworkRewardStart: BlockNumber = 5 * 5 * 60 * 24 * 36525 / 100;
@@ -166,14 +164,12 @@ impl Config for Test {
 	type ExitQueueDelay = ExitQueueDelay;
 	type MinCollators = MinCollators;
 	type MinRequiredCollators = MinCollators;
-	type MaxDelegationsPerRound = MaxDelegatorsPerCollator;
+	type MaxDelegationsPerRound = MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;
-	type MaxCollatorsPerDelegator = MaxCollatorsPerDelegator;
 	type MinCollatorStake = MinCollatorStake;
 	type MinCollatorCandidateStake = MinCollatorStake;
 	type MaxTopCandidates = MaxCollatorCandidates;
 	type MinDelegatorStake = MinDelegatorStake;
-	type MinDelegation = MinDelegation;
 	type MaxUnstakeRequests = MaxUnstakeRequests;
 	type NetworkRewardRate = NetworkRewardRate;
 	type NetworkRewardStart = NetworkRewardStart;

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -26,10 +26,8 @@ use sp_runtime::{
 use sp_staking::SessionIndex;
 use sp_std::{
 	cmp::Ordering,
-	convert::TryInto,
 	fmt::Debug,
 	ops::{Add, Sub},
-	vec,
 };
 
 use crate::{set::OrderedSet, Config};
@@ -211,100 +209,60 @@ where
 	}
 }
 
-#[derive(Encode, Decode, RuntimeDebug, PartialEq, TypeInfo, MaxEncodedLen)]
-#[scale_info(skip_type_params(MaxCollatorsPerDelegator))]
-#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen))]
-pub struct Delegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
-	pub delegations: OrderedSet<Stake<AccountId, Balance>, MaxCollatorsPerDelegator>,
-	pub total: Balance,
-}
-
-impl<AccountId, Balance, MaxCollatorsPerDelegator> Delegator<AccountId, Balance, MaxCollatorsPerDelegator>
+pub type Delegator<AccountId, Balance> = Stake<Option<AccountId>, Balance>;
+impl<AccountId, Balance> Delegator<AccountId, Balance>
 where
 	AccountId: Eq + Ord + Clone + Debug,
-	Balance: Copy + Add<Output = Balance> + Saturating + PartialOrd + Eq + Ord + Debug + Zero,
-	MaxCollatorsPerDelegator: Get<u32> + Debug + PartialEq,
+	Balance: Copy + Add<Output = Balance> + Saturating + PartialOrd + Eq + Ord + Debug + Zero + Default,
 {
-	pub fn try_new(collator: AccountId, amount: Balance) -> Result<Self, ()> {
-		Ok(Delegator {
-			delegations: OrderedSet::from(
-				vec![Stake {
-					owner: collator,
-					amount,
-				}]
-				.try_into()?,
-			),
-			total: amount,
-		})
-	}
-
 	/// Adds a new delegation.
 	///
-	/// If already delegating to the same account, this call returns false and
-	/// doesn't insert the new delegation.
-	pub fn add_delegation(&mut self, stake: Stake<AccountId, Balance>) -> Result<bool, ()> {
-		let amt = stake.amount;
-		if self.delegations.try_insert(stake).map_err(|_| ())? {
-			self.total = self.total.saturating_add(amt);
-			Ok(true)
+	/// If already delegating to someone, this call will fail.
+	pub fn add_delegation(&mut self, stake: Stake<AccountId, Balance>) -> Result<(), ()> {
+		if self.owner.is_none() && self.amount.is_zero() {
+			self.owner = Some(stake.owner);
+			self.amount = stake.amount;
+			Ok(())
 		} else {
-			Ok(false)
+			Err(())
 		}
 	}
 
-	/// Returns Some(remaining stake for delegator) if the delegation for the
-	/// collator exists. Returns `None` otherwise.
-	pub fn rm_delegation(&mut self, collator: &AccountId) -> Option<Balance> {
-		let amt = self.delegations.remove(&Stake::<AccountId, Balance> {
-			owner: collator.clone(),
-			// amount is irrelevant for removal
-			amount: Balance::zero(),
-		});
-
-		if let Some(Stake::<AccountId, Balance> { amount: balance, .. }) = amt {
-			self.total = self.total.saturating_sub(balance);
-			Some(self.total)
+	/// Returns Ok if the delegation for the
+	/// collator exists and `Err` otherwise.
+	pub fn rm_delegation(&mut self, collator: AccountId) -> Result<(), ()> {
+		if self.owner == Some(collator) {
+			self.amount = Balance::zero();
+			self.owner = None;
+			Ok(())
 		} else {
-			None
+			Err(())
 		}
 	}
 
-	/// Returns Some(delegated_amount) if successfull, None if delegation was
+	/// Returns Ok(delegated_amount) if successfull, `Err` if delegation was
 	/// not found.
-	pub fn inc_delegation(&mut self, collator: AccountId, more: Balance) -> Option<Balance> {
-		if let Ok(i) = self.delegations.linear_search(&Stake::<AccountId, Balance> {
-			owner: collator,
-			amount: Balance::zero(),
-		}) {
-			self.delegations
-				.mutate(|vec| vec[i].amount = vec[i].amount.saturating_add(more));
-			self.total = self.total.saturating_add(more);
-			self.delegations.sort_greatest_to_lowest();
-			Some(self.delegations[i].amount)
+	pub fn inc_delegation(&mut self, collator: AccountId, more: Balance) -> Result<Balance, ()> {
+		if self.owner == Some(collator) {
+			self.amount = self.amount.saturating_add(more);
+			Ok(self.amount)
 		} else {
-			None
+			Err(())
 		}
 	}
 
-	/// Returns Some(Some(delegated_amount)) if successful, None if delegation
-	/// was not found and Some(None) if delegated stake would underflow.
-	pub fn dec_delegation(&mut self, collator: AccountId, less: Balance) -> Option<Option<Balance>> {
-		if let Ok(i) = self.delegations.linear_search(&Stake::<AccountId, Balance> {
-			owner: collator,
-			amount: Balance::zero(),
-		}) {
-			if self.delegations[i].amount > less {
-				self.delegations
-					.mutate(|vec| vec[i].amount = vec[i].amount.saturating_sub(less));
-				self.total = self.total.saturating_sub(less);
-				self.delegations.sort_greatest_to_lowest();
-				Some(Some(self.delegations[i].amount))
+	/// Returns Ok(Some(delegated_amount)) if successful, `Err` if delegation
+	/// was not found and Ok(None) if delegated stake would underflow.
+	pub fn dec_delegation(&mut self, collator: AccountId, less: Balance) -> Result<Option<Balance>, ()> {
+		if self.owner == Some(collator) {
+			if self.amount > less {
+				self.amount = self.amount.saturating_sub(less);
+				Ok(Some(self.amount))
 			} else {
-				// underflow error; should rm entire delegation
-				Some(None)
+				Ok(None)
 			}
 		} else {
-			None
+			Err(())
 		}
 	}
 }
@@ -370,13 +328,6 @@ pub struct DelegationCounter {
 	pub round: SessionIndex,
 	/// The number of delegations made within round.
 	pub counter: u32,
-}
-
-/// Internal type which is only used when a delegator is replaced by another
-/// one to delay the storage entry removal until failure cannot happen anymore.
-pub(crate) struct ReplacedDelegator<T: Config> {
-	pub who: AccountIdOf<T>,
-	pub state: Option<Delegator<AccountIdOf<T>, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
 }
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -203,9 +203,6 @@ pub mod staking {
 		/// Maximum 25 delegators per collator at launch, might be increased later
 		#[derive(Debug, PartialEq)]
 		pub const MaxDelegatorsPerCollator: u32 = MAX_DELEGATORS_PER_COLLATOR;
-		/// Maximum 1 collator per delegator at launch, will be increased later
-		#[derive(Debug, PartialEq)]
-		pub const MaxCollatorsPerDelegator: u32 = 1;
 		/// Minimum stake required to be reserved to be a collator is 10_000
 		pub const MinCollatorStake: Balance = 10_000 * KILT;
 		/// Minimum stake required to be reserved to be a delegator is 1000

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -624,11 +624,9 @@ impl parachain_staking::Config for Runtime {
 	type MinRequiredCollators = constants::staking::MinRequiredCollators;
 	type MaxDelegationsPerRound = constants::staking::MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = constants::staking::MaxDelegatorsPerCollator;
-	type MaxCollatorsPerDelegator = constants::staking::MaxCollatorsPerDelegator;
 	type MinCollatorStake = constants::staking::MinCollatorStake;
 	type MinCollatorCandidateStake = constants::staking::MinCollatorStake;
 	type MaxTopCandidates = constants::staking::MaxCollatorCandidates;
-	type MinDelegation = constants::staking::MinDelegatorStake;
 	type MinDelegatorStake = constants::staking::MinDelegatorStake;
 	type MaxUnstakeRequests = constants::staking::MaxUnstakeRequests;
 	type NetworkRewardRate = constants::staking::NetworkRewardRate;

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -619,11 +619,9 @@ impl parachain_staking::Config for Runtime {
 	type MinRequiredCollators = constants::staking::MinRequiredCollators;
 	type MaxDelegationsPerRound = constants::staking::MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = constants::staking::MaxDelegatorsPerCollator;
-	type MaxCollatorsPerDelegator = constants::staking::MaxCollatorsPerDelegator;
 	type MinCollatorStake = constants::staking::MinCollatorStake;
 	type MinCollatorCandidateStake = constants::staking::MinCollatorStake;
 	type MaxTopCandidates = constants::staking::MaxCollatorCandidates;
-	type MinDelegation = constants::staking::MinDelegatorStake;
 	type MinDelegatorStake = constants::staking::MinDelegatorStake;
 	type MaxUnstakeRequests = constants::staking::MaxUnstakeRequests;
 	type NetworkRewardRate = constants::staking::NetworkRewardRate;


### PR DESCRIPTION
## No Ticket - part of #384 

This PR removes unused code from the staking pallet, mainly the unusable `delegate_another_candidate` extrinsic, `revoke_delegation` extrinsic and two useless staking parameters.

While working on #384 I just stumbled the problem in the current redesign introduced by allowing for more than one delegation per delegator (which we do in the unit test environment). As discussed, we don't seem to plan supporting multiple delegations from the same account in the future.

### What was removed?

- `delegate_another_candidate` extrinsic
- `revoke_delegation` extrinsic (not needed because of `leave_delegators`)
- Comments about the `weight` of functions in the Staking Pallet
- `Delegator` struct (it's just `Stake`)
- `ReplacedDelegator` struct, not needed anymore
- `NomStakeBelowMin` error (redundant because of `DelegationBelowMin`)
- `prep_kick_delegator` function --> was only required because of potentially still existent delegations of kicked delegator

### Open tasks

- [ ] The benchmark unit tests are currently failing for the staking pallet --> #384.
- [ ] Writing a migration for the breaking `DelegatorState` Storage Map --> #384.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
