### PR TITLE
[DO NOT MERGE] feat: add weights v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "beefy-primitives",
@@ -477,12 +477,12 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "beefy-primitives",
  "sp-api",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "beefy-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.24",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1799,13 +1799,13 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "derive_more",
  "futures 0.3.24",
- "jsonrpsee-core 0.15.1",
+ "jsonrpsee-core",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-overseer",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1830,7 +1830,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.24",
  "futures-timer",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-service",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2011,7 +2011,7 @@ name = "did-rpc"
 version = "1.6.2"
 dependencies = [
  "did-rpc-runtime-api",
- "jsonrpsee 0.14.0",
+ "jsonrpsee",
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
@@ -2490,7 +2490,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "log",
@@ -2722,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3462,30 +3462,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e017217fcd18da0a25296d3693153dd19c8a6aadab330b3595285d075385d1"
-dependencies = [
- "jsonrpsee-core 0.14.0",
- "jsonrpsee-http-server 0.14.0",
- "jsonrpsee-proc-macros 0.14.0",
- "jsonrpsee-types 0.14.0",
- "jsonrpsee-ws-server 0.14.0",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
 dependencies = [
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-http-server 0.15.1",
- "jsonrpsee-proc-macros 0.15.1",
- "jsonrpsee-types 0.15.1",
+ "jsonrpsee-core",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
  "jsonrpsee-ws-client",
- "jsonrpsee-ws-server 0.15.1",
+ "jsonrpsee-ws-server",
  "tracing",
 ]
 
@@ -3497,8 +3483,8 @@ checksum = "8752740ecd374bcbf8b69f3e80b0327942df76f793f8d4e60d3355650c31fb74"
 dependencies = [
  "futures-util",
  "http",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -3508,34 +3494,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16efcd4477de857d4a2195a45769b2fe9ebb54f3ef5a4221d3b014a4fe33ec0b"
-dependencies = [
- "anyhow",
- "arrayvec 0.7.2",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-util",
- "globset",
- "hyper",
- "jsonrpsee-types 0.14.0",
- "lazy_static",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rustc-hash",
- "serde",
- "serde_json",
- "soketto",
- "thiserror",
- "tokio",
- "tracing",
- "unicase",
 ]
 
 [[package]]
@@ -3555,7 +3513,7 @@ dependencies = [
  "globset",
  "http",
  "hyper",
- "jsonrpsee-types 0.15.1",
+ "jsonrpsee-types",
  "lazy_static",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3572,23 +3530,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-server"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd69efeb3ce2cba767f126872f4eeb4624038a29098e75d77608b2b4345ad03"
-dependencies = [
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-core 0.14.0",
- "jsonrpsee-types 0.14.0",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-server"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
@@ -3596,25 +3537,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874cf3f6a027cebf36cae767feca9aa2e8a8f799880e49eb5540819fcbd8eada"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3627,20 +3556,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcf76cd316f5d3ad48138085af1f45e2c58c98e02f0779783dbb034d43f7c86"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -3665,26 +3580,8 @@ checksum = "6ee5feddd5188e62ac08fcf0e56478138e581509d4730f3f7be9b57dd402a4ff"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
-]
-
-[[package]]
-name = "jsonrpsee-ws-server"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2e4d266774a671f8def3794255b28eddd09b18d76e0b913fa439f34588c0a"
-dependencies = [
- "futures-channel",
- "futures-util",
- "jsonrpsee-core 0.14.0",
- "jsonrpsee-types 0.14.0",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3696,8 +3593,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "jsonrpsee-core 0.15.1",
- "jsonrpsee-types 0.15.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde_json",
  "soketto",
  "tokio",
@@ -3748,7 +3645,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.24",
  "hex-literal",
- "jsonrpsee 0.14.0",
+ "jsonrpsee",
  "log",
  "pallet-did-lookup",
  "pallet-transaction-payment-rpc",
@@ -3820,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3913,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -4726,7 +4623,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "frame-system",
  "futures 0.3.24",
- "jsonrpsee 0.14.0",
+ "jsonrpsee",
  "log",
  "mashnet-node-runtime",
  "pallet-did-lookup",
@@ -5331,7 +5228,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orchestra"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -5347,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "orchestra-proc-macro"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "expander 0.0.6",
  "itertools",
@@ -5385,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5401,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5417,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5432,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5456,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5476,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5491,7 +5388,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "beefy-primitives",
  "frame-support",
@@ -5507,7 +5404,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -5530,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5548,7 +5445,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5567,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5587,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5604,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5665,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5688,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5701,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5719,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5734,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5757,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5773,7 +5670,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5793,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5827,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5844,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5862,9 +5759,9 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -5877,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5892,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5909,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5928,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5938,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5955,7 +5852,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5978,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5994,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6009,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6023,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6061,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6077,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6098,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6114,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6128,7 +6025,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6151,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6162,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6171,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6185,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6203,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6222,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6238,9 +6135,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -6253,7 +6150,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6264,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6281,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6297,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6331,7 +6228,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6349,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6366,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c4c7fa0929cbf59b30aa9510ee31f3ec1b580923"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6773,7 +6670,7 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "polkadot-node-network-protocol",
@@ -6788,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "polkadot-node-network-protocol",
@@ -6802,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6825,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "fatality",
  "futures 0.3.24",
@@ -6846,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -6872,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6912,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "always-assert",
  "fatality",
@@ -6933,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6946,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6969,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6983,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "futures-timer",
@@ -7003,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7027,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "parity-scale-codec",
@@ -7045,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7074,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitvec",
  "futures 0.3.24",
@@ -7094,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7113,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "polkadot-node-subsystem",
@@ -7128,7 +7025,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -7146,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "polkadot-node-subsystem",
@@ -7161,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "futures-timer",
@@ -7178,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "fatality",
  "futures 0.3.24",
@@ -7197,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -7214,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7232,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7264,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "polkadot-node-primitives",
@@ -7280,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "futures 0.3.24",
  "memory-lru",
@@ -7296,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7314,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bs58",
  "futures 0.3.24",
@@ -7333,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7355,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bounded-vec",
  "futures 0.3.24",
@@ -7377,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7387,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7410,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7443,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -7466,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7483,7 +7380,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "env_logger",
  "kusama-runtime",
@@ -7498,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7528,11 +7425,11 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "pallet-mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -7560,7 +7457,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7648,7 +7545,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7695,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7707,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -7719,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -7762,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7866,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -7887,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7953,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "prioritized-metered-channel"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
@@ -8391,10 +8288,10 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "env_logger",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "serde",
@@ -8463,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -8532,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8744,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "sp-core",
@@ -8755,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -8782,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "futures-timer",
@@ -8805,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8821,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.7",
@@ -8838,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8849,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "chrono",
  "clap",
@@ -8888,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "fnv",
  "futures 0.3.24",
@@ -8916,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8941,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -8965,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -8994,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9036,10 +8933,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -9058,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9071,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -9096,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "lazy_static",
  "lru 0.7.8",
@@ -9123,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9139,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9154,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9175,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ahash",
  "async-trait",
@@ -9216,11 +9113,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -9237,7 +9134,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ansi_term",
  "futures 0.3.24",
@@ -9254,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "hex",
@@ -9269,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -9318,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -9341,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ahash",
  "futures 0.3.24",
@@ -9359,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "hex",
@@ -9380,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "fork-tree",
  "futures 0.3.24",
@@ -9408,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "bytes",
  "fnv",
@@ -9438,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "libp2p",
@@ -9451,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9460,11 +9357,11 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "hash-db",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9490,10 +9387,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9513,10 +9410,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -9526,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "directories",
@@ -9534,7 +9431,7 @@ dependencies = [
  "futures 0.3.24",
  "futures-timer",
  "hash-db",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
@@ -9593,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9607,9 +9504,9 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -9626,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "libc",
@@ -9645,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "chrono",
  "futures 0.3.24",
@@ -9663,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9694,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9705,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "futures-timer",
@@ -9731,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "log",
@@ -9744,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "futures-timer",
@@ -10115,7 +10012,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10191,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "hash-db",
  "log",
@@ -10209,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10221,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10234,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10249,7 +10146,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10262,7 +10159,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10274,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10286,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures 0.3.24",
  "log",
@@ -10304,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -10323,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10341,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10364,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10378,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10391,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "base58",
  "bitflags",
@@ -10437,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10451,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10462,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10471,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10481,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10492,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10510,7 +10407,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10524,7 +10421,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "bytes",
  "futures 0.3.24",
@@ -10550,7 +10447,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10561,7 +10458,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures 0.3.24",
@@ -10578,7 +10475,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "thiserror",
  "zstd",
@@ -10587,7 +10484,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10602,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10616,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10626,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10636,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10646,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10668,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10686,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -10698,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10712,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10726,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10737,7 +10634,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "hash-db",
  "log",
@@ -10759,12 +10656,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10777,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "log",
  "sp-core",
@@ -10790,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10806,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10818,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10827,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "async-trait",
  "log",
@@ -10843,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10866,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10883,7 +10780,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10894,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -11100,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "platforms",
 ]
@@ -11108,11 +11005,11 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.24",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -11129,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "futures-util",
  "hyper",
@@ -11142,9 +11039,9 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -11163,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -11511,7 +11408,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -11522,7 +11419,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -11649,11 +11546,11 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
+source = "git+https://github.com/paritytech/substrate?branch=master#dcfaa41d11e70cfc976e292b2975c7285cf3668c"
 dependencies = [
  "clap",
  "frame-try-runtime",
- "jsonrpsee 0.15.1",
+ "jsonrpsee",
  "log",
  "parity-scale-codec",
  "remote-externalities",
@@ -12219,7 +12116,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -12308,7 +12205,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12483,7 +12380,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12497,7 +12394,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12517,7 +12414,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12535,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.28"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
+source = "git+https://github.com/paritytech/polkadot?branch=master#d1002106ab43f7b01cc86ad9aa2fe41d4b4a8f5f"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,11 +441,12 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
+ "async-trait",
  "beefy-primitives",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "hex",
  "log",
@@ -453,6 +454,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "sc-chain-spec",
  "sc-client-api",
+ "sc-consensus",
  "sc-finality-grandpa",
  "sc-keystore",
  "sc-network",
@@ -475,12 +477,12 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -495,7 +497,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "beefy-primitives",
  "sp-api",
@@ -504,7 +506,7 @@ dependencies = [
 [[package]]
 name = "beefy-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -812,6 +814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -930,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1377,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1392,13 +1403,13 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",
@@ -1416,12 +1427,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-primitives-core",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
@@ -1445,12 +1456,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
  "dyn-clone",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "polkadot-primitives",
  "sc-client-api",
@@ -1466,12 +1477,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
  "derive_more",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -1491,11 +1502,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -1515,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1543,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1561,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1579,8 +1590,9 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
+ "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
@@ -1609,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1620,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1634,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -1651,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1668,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1686,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -1702,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1725,10 +1737,10 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "sp-inherents",
  "sp-std",
@@ -1738,10 +1750,11 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
+ "log",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain",
@@ -1757,14 +1770,13 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
- "parking_lot 0.12.1",
  "polkadot-cli",
  "polkadot-client",
  "polkadot-service",
@@ -1787,13 +1799,13 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "derive_more",
- "futures 0.3.23",
- "jsonrpsee-core",
+ "futures 0.3.24",
+ "jsonrpsee-core 0.15.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-overseer",
@@ -1810,15 +1822,15 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "async-trait",
  "backoff",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-service",
@@ -1837,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -1999,7 +2011,7 @@ name = "did-rpc"
 version = "1.6.2"
 dependencies = [
  "did-rpc-runtime-api",
- "jsonrpsee",
+ "jsonrpsee 0.14.0",
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
@@ -2177,6 +2189,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-zebra"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "hex",
+ "rand_core 0.6.3",
+ "sha2 0.9.9",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,7 +2321,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
 ]
 
 [[package]]
@@ -2417,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
 dependencies = [
  "either",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "num-traits",
@@ -2464,7 +2490,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2482,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2494,6 +2520,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-application-crypto",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
@@ -2504,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2555,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2566,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2582,10 +2609,11 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
+ "frame-try-runtime",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -2610,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2624,6 +2652,7 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
@@ -2640,10 +2669,12 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "Inflector",
+ "cfg-expr",
  "frame-support-procedural-tools",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2652,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2664,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2674,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "log",
@@ -2691,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2706,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2715,9 +2746,10 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
+ "parity-scale-codec",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -2771,9 +2803,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2786,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2796,15 +2828,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2814,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -2835,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2857,15 +2889,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -2875,9 +2907,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -3280,7 +3312,7 @@ dependencies = [
  "async-io",
  "core-foundation",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "if-addrs",
  "ipnet",
  "log",
@@ -3434,25 +3466,39 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e017217fcd18da0a25296d3693153dd19c8a6aadab330b3595285d075385d1"
 dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-server",
- "jsonrpsee-proc-macros",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-http-server 0.14.0",
+ "jsonrpsee-proc-macros 0.14.0",
+ "jsonrpsee-types 0.14.0",
+ "jsonrpsee-ws-server 0.14.0",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
+dependencies = [
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-http-server 0.15.1",
+ "jsonrpsee-proc-macros 0.15.1",
+ "jsonrpsee-types 0.15.1",
  "jsonrpsee-ws-client",
- "jsonrpsee-ws-server",
+ "jsonrpsee-ws-server 0.15.1",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce395539a14d3ad4ec1256fde105abd36a2da25d578a291cabe98f45adfdb111"
+checksum = "8752740ecd374bcbf8b69f3e80b0327942df76f793f8d4e60d3355650c31fb74"
 dependencies = [
  "futures-util",
  "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -3472,15 +3518,13 @@ checksum = "16efcd4477de857d4a2195a45769b2fe9ebb54f3ef5a4221d3b014a4fe33ec0b"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
- "async-lock",
  "async-trait",
  "beef",
  "futures-channel",
- "futures-timer",
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.14.0",
  "lazy_static",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3495,6 +3539,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.2",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "globset",
+ "http",
+ "hyper",
+ "jsonrpsee-types 0.15.1",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "unicase",
+]
+
+[[package]]
 name = "jsonrpsee-http-server"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,8 +3579,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
  "serde",
  "serde_json",
  "tokio",
@@ -3512,10 +3588,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-http-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "jsonrpsee-proc-macros"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "874cf3f6a027cebf36cae767feca9aa2e8a8f799880e49eb5540819fcbd8eada"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd67957d4280217247588ac86614ead007b301ca2fa9f19c19f880a536f029e3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3538,14 +3644,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-ws-client"
-version = "0.14.0"
+name = "jsonrpsee-types"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee043cb5dd0d51d3eb93432e998d5bae797691a7b10ec4a325e036bcdb48c48a"
+checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
 dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee5feddd5188e62ac08fcf0e56478138e581509d4730f3f7be9b57dd402a4ff"
+dependencies = [
+ "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
 ]
 
 [[package]]
@@ -3556,14 +3677,34 @@ checksum = "2bd2e4d266774a671f8def3794255b28eddd09b18d76e0b913fa439f34588c0a"
 dependencies = [
  "futures-channel",
  "futures-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
  "serde_json",
  "soketto",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d488ba74fb369e5ab68926feb75a483458b88e768d44319f37e4ecad283c7325"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "jsonrpsee-core 0.15.1",
+ "jsonrpsee-types 0.15.1",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -3605,9 +3746,9 @@ dependencies = [
  "did-rpc",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.23",
+ "futures 0.3.24",
  "hex-literal",
- "jsonrpsee",
+ "jsonrpsee 0.14.0",
  "log",
  "pallet-did-lookup",
  "pallet-transaction-payment-rpc",
@@ -3678,8 +3819,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3771,8 +3912,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime-constants"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -3880,7 +4021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81327106887e42d004fbdab1fef93675be2e2e07c1b95fce45e2cc813485611d"
 dependencies = [
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "getrandom 0.2.7",
  "instant",
@@ -3924,7 +4065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4decc51f3573653a9f4ecacb31b1b922dd20c25a6322bb15318ec04287ec46f9"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -3947,7 +4088,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "lazy_static",
@@ -3978,7 +4119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0183dc2a3da1fbbf85e5b6cf51217f55b14f5daea0c455a9536eef646bfec71"
 dependencies = [
  "flate2",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
 ]
 
@@ -3989,7 +4130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbf54723250fa5d521383be789bf60efdabe6bacfb443f87da261019a49b4b5"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "log",
  "parking_lot 0.12.1",
@@ -4005,7 +4146,7 @@ checksum = "98a4b6ffd53e355775d24b76f583fdda54b3284806f678499b57913adb94f231"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -4026,7 +4167,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "hex_fmt",
  "instant",
  "libp2p-core",
@@ -4050,7 +4191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c50b585518f8efd06f93ac2f976bd672e17cdac794644b3117edd078e96bda06"
 dependencies = [
  "asynchronous-codec",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
@@ -4075,7 +4216,7 @@ dependencies = [
  "bytes",
  "either",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4101,7 +4242,7 @@ dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.23",
+ "futures 0.3.24",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -4137,7 +4278,7 @@ checksum = "61fd1b20638ec209c5075dfb2e8ce6a7ea4ec3cd3ad7b77f7a477c06d53322e2"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -4155,7 +4296,7 @@ checksum = "762408cb5d84b49a600422d7f9a42c18012d8da6ebcd570f9a4a4290ba41fb6f"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
- "futures 0.3.23",
+ "futures 0.3.24",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -4175,7 +4316,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100a6934ae1dbf8a693a4e7dd1d730fd60b774dafc45688ed63b554497c6c925"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4193,7 +4334,7 @@ checksum = "be27bf0820a6238a4e06365b096d428271cce85a129cf16f2fe9eb1610c4df86"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "log",
  "prost",
@@ -4208,7 +4349,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "pin-project",
  "rand 0.7.3",
@@ -4225,7 +4366,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "either",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4250,7 +4391,7 @@ checksum = "9511c9672ba33284838e349623319c8cad2d18cfad243ae46c6b7e8a2982ea4e"
 dependencies = [
  "asynchronous-codec",
  "bimap",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4273,7 +4414,7 @@ checksum = "508a189e2795d892c8f5c1fa1e9e0b1845d32d7b0b249dbf7b05b18811361843"
 dependencies = [
  "async-trait",
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
@@ -4291,7 +4432,7 @@ checksum = "95ac5be6c2de2d1ff3f7693fda6faf8a827b1f3e808202277783fea9f527d114"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4320,7 +4461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a6771dc19aa3c65d6af9a8c65222bfc8fcd446630ddca487acd161fa6096f3b"
 dependencies = [
  "async-io",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "if-watch",
  "ipnet",
@@ -4337,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d125e3e5f0d58f3c6ac21815b20cf4b6a88b8db9dc26368ea821838f4161fd4d"
 dependencies = [
  "async-std",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "log",
 ]
@@ -4348,7 +4489,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec894790eec3c1608f8d1a8a0bdf0dbeb79ed4de2dce964222011c2896dfa05a"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -4363,7 +4504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9808e57e81be76ff841c106b4c5974fb4d41a233a7bdd2afbf1687ac6def3818"
 dependencies = [
  "either",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-rustls",
  "libp2p-core",
  "log",
@@ -4381,7 +4522,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6dea686217a06072033dc025631932810e2f6ad784e4fafa42e27d311c7a81c"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p-core",
  "parking_lot 0.12.1",
  "thiserror",
@@ -4584,8 +4725,8 @@ dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.14.0",
  "log",
  "mashnet-node-runtime",
  "pallet-did-lookup",
@@ -4798,7 +4939,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "rand 0.8.5",
  "thrift",
 ]
@@ -4909,7 +5050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "pin-project",
  "smallvec",
@@ -5005,7 +5146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -5021,7 +5162,7 @@ checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
  "async-io",
  "bytes",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libc",
  "log",
 ]
@@ -5190,11 +5331,11 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orchestra"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
  "dyn-clonable",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "orchestra-proc-macro",
  "pin-project",
@@ -5206,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "orchestra-proc-macro"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "expander 0.0.6",
  "itertools",
@@ -5244,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5260,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5276,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5291,7 +5432,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5315,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5335,7 +5476,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5350,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "beefy-primitives",
  "frame-support",
@@ -5366,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -5389,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5407,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5426,7 +5567,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5446,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5463,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5524,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5547,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5560,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5578,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5593,7 +5734,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5616,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5632,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5652,7 +5793,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5686,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5703,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5721,9 +5862,9 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -5736,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5751,7 +5892,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5768,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5787,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5797,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5814,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5837,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5853,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5868,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5882,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5920,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5936,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5957,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5973,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5987,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6010,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6021,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6030,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6044,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6062,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6081,7 +6222,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6097,9 +6238,9 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -6112,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6123,7 +6264,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6140,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6156,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6189,8 +6330,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6207,8 +6348,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6225,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.27#66b684f88eba6c755651b8c47dccad2c2d9ac3db"
+source = "git+https://github.com/paritytech/cumulus?branch=master#c2d9753b25371e5e86e5348829eb2d80d0a7e560"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6287,6 +6428,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
  "byte-slice-cast",
+ "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
@@ -6630,10 +6772,10 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -6645,10 +6787,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6659,12 +6801,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "derive_more",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "lru 0.7.8",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -6682,11 +6824,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "lru 0.7.8",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -6703,12 +6845,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "polkadot-client",
  "polkadot-node-core-pvf",
@@ -6729,8 +6871,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-client"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6769,12 +6911,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "always-assert",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6790,8 +6932,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6803,12 +6945,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "derive_more",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "lru 0.7.8",
  "parity-scale-codec",
  "polkadot-erasure-coding",
@@ -6826,8 +6968,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6840,10 +6982,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -6860,14 +7002,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "always-assert",
  "async-trait",
  "bytes",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-network-protocol",
@@ -6876,6 +7018,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-network",
+ "sc-network-common",
  "sp-consensus",
  "thiserror",
  "tracing-gum",
@@ -6883,10 +7026,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
@@ -6901,12 +7044,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitvec",
  "derive_more",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "kvdb",
  "lru 0.7.8",
@@ -6930,11 +7073,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitvec",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -6950,12 +7093,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -6969,10 +7112,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -6984,11 +7127,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
@@ -7002,10 +7145,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -7017,10 +7160,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -7034,11 +7177,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "kvdb",
  "lru 0.7.8",
  "parity-scale-codec",
@@ -7053,11 +7196,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -7070,12 +7213,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -7088,14 +7231,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "always-assert",
  "assert_matches",
  "async-process",
  "async-std",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
@@ -7120,10 +7263,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -7136,10 +7279,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "memory-lru",
  "parity-util-mem",
  "polkadot-node-subsystem",
@@ -7152,8 +7295,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7170,11 +7313,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bs58",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -7189,13 +7332,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
+ "hex",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
@@ -7210,11 +7354,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bounded-vec",
- "futures 0.3.23",
+ "futures 0.3.24",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-primitives",
@@ -7232,8 +7376,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7242,12 +7386,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.23",
+ "futures 0.3.24",
  "orchestra",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
@@ -7265,13 +7409,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "itertools",
  "kvdb",
  "lru 0.7.8",
@@ -7298,11 +7442,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "lru 0.7.8",
  "orchestra",
@@ -7321,8 +7465,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7338,8 +7482,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-performance-test"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "env_logger",
  "kusama-runtime",
@@ -7353,8 +7497,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7383,12 +7527,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "pallet-mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
@@ -7415,8 +7559,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7448,6 +7592,9 @@ dependencies = [
  "pallet-indices",
  "pallet-membership",
  "pallet-multisig",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
  "pallet-offences",
  "pallet-offences-benchmarking",
  "pallet-preimage",
@@ -7500,8 +7647,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7547,8 +7694,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-constants"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7559,8 +7706,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -7571,8 +7718,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -7614,14 +7761,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "async-trait",
  "beefy-gadget",
  "beefy-primitives",
+ "frame-support",
  "frame-system-rpc-runtime-api",
- "futures 0.3.23",
+ "futures 0.3.24",
  "hex-literal",
  "kusama-runtime",
  "kvdb",
@@ -7677,11 +7825,11 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-babe",
  "sc-consensus-slots",
- "sc-consensus-uncles",
  "sc-executor",
  "sc-finality-grandpa",
  "sc-keystore",
  "sc-network",
+ "sc-network-common",
  "sc-offchain",
  "sc-service",
  "sc-sync-state-rpc",
@@ -7717,12 +7865,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
- "futures 0.3.23",
+ "futures 0.3.24",
  "indexmap",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
@@ -7738,8 +7886,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7805,12 +7953,12 @@ dependencies = [
 [[package]]
 name = "prioritized-metered-channel"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
  "derive_more",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "nanorand",
  "thiserror",
@@ -8243,10 +8391,10 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "env_logger",
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "serde",
@@ -8275,12 +8423,6 @@ dependencies = [
  "hostname",
  "quick-error",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -8320,8 +8462,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -8389,8 +8531,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8401,9 +8543,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "5.0.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+checksum = "26b763cb66df1c928432cc35053f8bd4cec3335d8559fc16010017d16b3c1680"
 dependencies = [
  "libc",
  "winapi",
@@ -8416,7 +8558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
  "async-global-executor",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "netlink-packet-route",
  "netlink-proto",
@@ -8561,7 +8703,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "pin-project",
  "static_assertions",
 ]
@@ -8602,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "sp-core",
@@ -8613,10 +8755,10 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "ip_network",
  "libp2p",
@@ -8626,7 +8768,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sc-client-api",
- "sc-network",
+ "sc-network-common",
  "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
@@ -8640,9 +8782,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -8663,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8679,13 +8821,13 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.7",
  "parity-scale-codec",
  "sc-chain-spec-derive",
- "sc-network",
+ "sc-network-common",
  "sc-telemetry",
  "serde",
  "serde_json",
@@ -8696,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8707,12 +8849,12 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "chrono",
  "clap",
  "fdlimit",
- "futures 0.3.23",
+ "futures 0.3.24",
  "hex",
  "libp2p",
  "log",
@@ -8746,10 +8888,10 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "hash-db",
  "log",
  "parity-scale-codec",
@@ -8774,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8799,10 +8941,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "libp2p",
  "log",
@@ -8823,10 +8965,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -8852,11 +8994,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "fork-tree",
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "merlin",
  "num-bigint",
@@ -8865,7 +9007,6 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "retain_mut",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-epochs",
@@ -8895,10 +9036,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "sc-consensus-babe",
  "sc-consensus-epochs",
  "sc-rpc-api",
@@ -8917,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8930,10 +9071,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -8953,20 +9094,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-uncles"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
-dependencies = [
- "sc-client-api",
- "sp-authorship",
- "sp-runtime",
- "thiserror",
-]
-
-[[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "lazy_static",
  "lru 0.7.8",
@@ -8993,14 +9123,13 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "environmental",
  "parity-scale-codec",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-sandbox",
- "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
@@ -9010,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9025,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9033,6 +9162,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
+ "rustix 0.33.7",
  "rustix 0.35.9",
  "sc-allocator",
  "sc-executor-common",
@@ -9045,14 +9175,14 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ahash",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "hex",
  "log",
@@ -9086,11 +9216,11 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "finality-grandpa",
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -9107,15 +9237,15 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ansi_term",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "parity-util-mem",
  "sc-client-api",
- "sc-network",
+ "sc-network-common",
  "sc-transaction-pool-api",
  "sp-blockchain",
  "sp-runtime",
@@ -9124,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "hex",
@@ -9139,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -9149,7 +9279,7 @@ dependencies = [
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "hex",
  "ip_network",
@@ -9188,33 +9318,39 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
+ "async-trait",
  "bitflags",
- "futures 0.3.23",
+ "bytes",
+ "futures 0.3.24",
  "libp2p",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
  "sc-peerset",
+ "serde",
  "smallvec",
+ "sp-blockchain",
  "sp-consensus",
  "sp-finality-grandpa",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ahash",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "libp2p",
  "log",
  "lru 0.7.8",
- "sc-network",
+ "sc-network-common",
+ "sc-peerset",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -9223,9 +9359,10 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
+ "hex",
  "libp2p",
  "log",
  "parity-scale-codec",
@@ -9243,10 +9380,11 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "fork-tree",
- "futures 0.3.23",
+ "futures 0.3.24",
+ "hex",
  "libp2p",
  "log",
  "lru 0.7.8",
@@ -9270,22 +9408,24 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "bytes",
  "fnv",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "hex",
  "hyper",
  "hyper-rustls",
+ "libp2p",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.7.3",
  "sc-client-api",
- "sc-network",
+ "sc-network-common",
+ "sc-peerset",
  "sc-utils",
  "sp-api",
  "sp-core",
@@ -9298,9 +9438,9 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p",
  "log",
  "sc-utils",
@@ -9311,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9320,11 +9460,11 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "hash-db",
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9350,10 +9490,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9373,10 +9513,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -9386,15 +9526,15 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "hash-db",
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
@@ -9453,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9467,9 +9607,9 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-client-api",
@@ -9486,9 +9626,9 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "libc",
  "log",
  "rand 0.7.3",
@@ -9505,10 +9645,10 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "chrono",
- "futures 0.3.23",
+ "futures 0.3.24",
  "libp2p",
  "log",
  "parking_lot 0.12.1",
@@ -9523,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9554,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9565,16 +9705,15 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.1",
- "retain_mut",
  "sc-client-api",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -9592,9 +9731,9 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "serde",
  "sp-blockchain",
@@ -9605,9 +9744,9 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "lazy_static",
  "log",
@@ -9975,8 +10114,8 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "slot-range-helper"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10042,7 +10181,7 @@ dependencies = [
  "base64",
  "bytes",
  "flate2",
- "futures 0.3.23",
+ "futures 0.3.24",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -10052,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "hash-db",
  "log",
@@ -10062,6 +10201,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-trie",
  "sp-version",
  "thiserror",
 ]
@@ -10069,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10081,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10094,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10109,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10122,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10134,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10146,9 +10286,9 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "lru 0.7.8",
  "parity-scale-codec",
@@ -10164,10 +10304,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -10183,7 +10323,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10201,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10224,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10238,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10251,15 +10391,15 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "base58",
  "bitflags",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
- "ed25519-dalek",
- "futures 0.3.23",
+ "ed25519-zebra",
+ "futures 0.3.24",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -10297,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10311,7 +10451,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10322,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10331,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10341,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10352,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10370,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10384,9 +10524,10 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "futures 0.3.23",
+ "bytes",
+ "futures 0.3.24",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -10409,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10420,10 +10561,10 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
- "futures 0.3.23",
+ "futures 0.3.24",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10437,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "thiserror",
  "zstd",
@@ -10446,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10461,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10475,7 +10616,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10485,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10495,7 +10636,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10505,7 +10646,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10527,8 +10668,9 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
+ "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
@@ -10544,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -10556,7 +10698,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10568,18 +10710,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10593,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10604,7 +10737,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "hash-db",
  "log",
@@ -10626,12 +10759,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10644,7 +10777,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "log",
  "sp-core",
@@ -10657,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -10673,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10685,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10694,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "async-trait",
  "log",
@@ -10710,15 +10843,22 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
+ "ahash",
  "hash-db",
+ "hashbrown 0.12.3",
+ "lazy_static",
+ "lru 0.7.8",
  "memory-db",
+ "nohash-hasher",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "scale-info",
  "sp-core",
  "sp-std",
  "thiserror",
+ "tracing",
  "trie-db",
  "trie-root",
 ]
@@ -10726,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10743,7 +10883,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10754,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -10960,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "platforms",
 ]
@@ -10968,11 +11108,11 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.23",
- "jsonrpsee",
+ "futures 0.3.24",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -10989,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "futures-util",
  "hyper",
@@ -11002,9 +11142,9 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -11023,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -11130,18 +11270,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11243,9 +11383,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
  "bytes",
@@ -11370,8 +11510,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -11381,8 +11521,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum-proc-macro"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -11437,9 +11577,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
+checksum = "004e1e8f92535694b4cb1444dc5a8073ecf0815e3357f729638b9f8fc4062908"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.3",
@@ -11509,10 +11649,11 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+source = "git+https://github.com/paritytech/substrate?branch=master#20037d573c0c2b319998541c6140df4c3d07eb56"
 dependencies = [
  "clap",
- "jsonrpsee",
+ "frame-try-runtime",
+ "jsonrpsee 0.15.1",
  "log",
  "parity-scale-codec",
  "remote-externalities",
@@ -11826,7 +11967,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -12077,8 +12218,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -12166,8 +12307,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12341,8 +12482,8 @@ dependencies = [
 
 [[package]]
 name = "xcm"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12355,8 +12496,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-builder"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12375,8 +12516,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-executor"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12393,8 +12534,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "0.9.27"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.27#b017bad50d360a1c6e3cdf9652bdb85e5f479fea"
+version = "0.9.28"
+source = "git+https://github.com/paritytech/polkadot?branch=master#b2ff4c05ab3b299c1601952c1b1233ef62f0a7fd"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -12408,7 +12549,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
- "futures 0.3.23",
+ "futures 0.3.24",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -29,10 +29,10 @@ codec = {package = "parity-scale-codec", version = "3.1.5"}
 derive_more = "0.99.17"
 futures = {version = "0.3.21", features = ["compat"]}
 hex-literal = "0.3.4"
-jsonrpsee = {version = "0.14.0", features = ["server"]}
+jsonrpsee = {version = "0.15.1", features = ["server"]}
 log = "0.4.17"
 parking_lot = "0.12.1"
-serde = {version = "1.0.142", features = ["derive"]}
+serde = {version = "1.0.144", features = ["derive"]}
 serde_json = "1.0.83"
 
 # Substrate dependencies

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -11,7 +11,7 @@ name = "kilt-parachain"
 path = "src/main.rs"
 
 [build-dependencies]
-substrate-build-script-utils = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-build-script-utils = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 
@@ -24,7 +24,7 @@ runtime-common = {path = "../../runtimes/common"}
 spiritnet-runtime = {path = "../../runtimes/spiritnet"}
 
 # External dependencies
-clap = {version = "3.2.10", features = ["derive"]}
+clap = {version = "3.2.20", features = ["derive"]}
 codec = {package = "parity-scale-codec", version = "3.1.5"}
 derive_more = "0.99.17"
 futures = {version = "0.3.21", features = ["compat"]}
@@ -36,65 +36,65 @@ serde = {version = "1.0.142", features = ["derive"]}
 serde_json = "1.0.83"
 
 # Substrate dependencies
-frame-rpc-system = {package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-basic-authorship = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-chain-spec = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-cli = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "polkadot-v0.9.27"}
-sc-client-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-consensus = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-executor = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "polkadot-v0.9.27"}
-sc-keystore = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-network = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-service = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "polkadot-v0.9.27"}
-sc-sysinfo = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-telemetry = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-tracing = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-transaction-pool-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-consensus = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-keystore = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-offchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-session = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-timestamp = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-substrate-prometheus-endpoint = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+frame-rpc-system = {package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"}
+pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-basic-authorship = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-chain-spec = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-cli = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "master"}
+sc-client-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-consensus = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-executor = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "master"}
+sc-keystore = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-network = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-service = {git = "https://github.com/paritytech/substrate", features = ["wasmtime"], branch = "master"}
+sc-sysinfo = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-telemetry = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-tracing = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-transaction-pool-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-block-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-consensus = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-inherents = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-keystore = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-offchain = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-session = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-timestamp = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "master"}
+substrate-prometheus-endpoint = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 # Cumulus dependencies
-cumulus-client-cli = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-client-collator = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-client-consensus-aura = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-client-consensus-common = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-client-network = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-client-service = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-primitives-parachain-inherent = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-relay-chain-inprocess-interface = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-relay-chain-interface = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
-cumulus-relay-chain-rpc-interface = {git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27"}
+cumulus-client-cli = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-client-collator = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-client-consensus-aura = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-client-consensus-common = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-client-network = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-client-service = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-primitives-parachain-inherent = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-relay-chain-inprocess-interface = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-relay-chain-interface = {git = "https://github.com/paritytech/cumulus", branch = "master"}
+cumulus-relay-chain-rpc-interface = {git = "https://github.com/paritytech/cumulus", branch = "master"}
 
 # Polkadot dependencies
-polkadot-cli = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27"}
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27"}
-polkadot-primitives = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27"}
-polkadot-service = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27"}
-xcm = {git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27"}
+polkadot-cli = {git = "https://github.com/paritytech/polkadot", branch = "master"}
+polkadot-parachain = {git = "https://github.com/paritytech/polkadot", branch = "master"}
+polkadot-primitives = {git = "https://github.com/paritytech/polkadot", branch = "master"}
+polkadot-service = {git = "https://github.com/paritytech/polkadot", branch = "master"}
+xcm = {git = "https://github.com/paritytech/polkadot", branch = "master"}
 
 # Benchmarking
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "master"}
+frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 # Runtime tests
-try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", optional = true}
+try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "master", optional = true}
 
 [features]
 default = []

--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -524,7 +524,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 	fn base_path(&self) -> Result<Option<BasePath>> {
 		Ok(self
 			.shared_params()
-			.base_path()
+			.base_path()?
 			.or_else(|| self.base_path.clone().map(Into::into)))
 	}
 
@@ -579,8 +579,8 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.transaction_pool(is_dev)
 	}
 
-	fn state_cache_child_ratio(&self) -> Result<Option<usize>> {
-		self.base.base.state_cache_child_ratio()
+	fn trie_cache_maximum_size(&self) -> Result<Option<usize>> {
+		self.base.base.trie_cache_maximum_size()
 	}
 
 	fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {

--- a/nodes/parachain/src/service.rs
+++ b/nodes/parachain/src/service.rs
@@ -29,11 +29,12 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::RelayChainRPCInterface;
+use cumulus_relay_chain_rpc_interface::{create_client_and_start_worker, RelayChainRpcInterface};
 use polkadot_service::{CollatorPair, NativeExecutionDispatch};
 use sc_client_api::ExecutorProvider;
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::NetworkService;
+use sc_network::NetworkBlock;
 use sc_service::{Configuration, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sp_api::ConstructRuntimeApi;
@@ -205,10 +206,10 @@ async fn build_relay_chain_interface(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) => Ok((
-			Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>,
-			None,
-		)),
+		Some(relay_chain_url) => {
+			let client = create_client_and_start_worker(relay_chain_url, task_manager).await?;
+			Ok((Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>, None))
+		},
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -24,7 +24,7 @@ runtime-common = {path = "../../runtimes/common"}
 clap = {version = "3.2.20", features = ["derive"]}
 futures = "0.3.21"
 log = "0.4.17"
-serde = {version = "1.0.142", features = ["derive"]}
+serde = {version = "1.0.144", features = ["derive"]}
 serde_json = "1.0.83"
 
 # Substrate dependencies
@@ -58,7 +58,7 @@ sp-transaction-pool = {git = "https://github.com/paritytech/substrate", branch =
 
 # RPC related dependencies
 frame-rpc-system = {package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"}
-jsonrpsee = { version = "0.14.0", features = ["server"] }
+jsonrpsee = { version = "0.15.1", features = ["server"] }
 pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
 sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "master"}

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -10,7 +10,7 @@ name = "mashnet-node"
 path = "src/main.rs"
 
 [build-dependencies]
-substrate-build-script-utils = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-build-script-utils = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 
@@ -21,54 +21,54 @@ mashnet-node-runtime = {path = "../../runtimes/standalone"}
 runtime-common = {path = "../../runtimes/common"}
 
 # External dependencies
-clap = {version = "3.2.10", features = ["derive"]}
+clap = {version = "3.2.20", features = ["derive"]}
 futures = "0.3.21"
 log = "0.4.17"
 serde = {version = "1.0.142", features = ["derive"]}
 serde_json = "1.0.83"
 
 # Substrate dependencies
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-basic-authorship = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-client-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-consensus = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-executor = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-finality-grandpa = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-keyring = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-keystore = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-network = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-service = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-telemetry = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-transaction-pool-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-consensus = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-finality-grandpa = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-timestamp = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "master"}
+pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-basic-authorship = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-cli = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-client-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-consensus = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-executor = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-finality-grandpa = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-keyring = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-keystore = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-network = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-service = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-telemetry = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-transaction-pool-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-block-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-blockchain = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-consensus = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-finality-grandpa = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-inherents = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-timestamp = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-transaction-pool = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 # RPC related dependencies
-frame-rpc-system = {package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+frame-rpc-system = {package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "master"}
 jsonrpsee = { version = "0.14.0", features = ["server"] }
-pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+pallet-transaction-payment-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-rpc = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sc-rpc-api = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 # Benchmarking
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "master"}
+frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 # Runtime tests
-try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", optional = true}
+try-runtime-cli = {git = "https://github.com/paritytech/substrate", branch = "master", optional = true}
 
 [features]
 default = []

--- a/nodes/standalone/src/command.rs
+++ b/nodes/standalone/src/command.rs
@@ -167,7 +167,7 @@ pub fn run() -> sc_cli::Result<()> {
 						let PartialComponents { client, .. } = service::new_partial(&config)?;
 						let ext_builder = RemarkBuilder::new(client.clone());
 
-						cmd.run(config, client, inherent_benchmark_data()?, &ext_builder)
+						cmd.run(config, client, inherent_benchmark_data()?, Vec::new(), &ext_builder)
 					}
 					BenchmarkCmd::Extrinsic(cmd) => {
 						let PartialComponents { client, .. } = service::new_partial(&config)?;
@@ -181,7 +181,7 @@ pub fn run() -> sc_cli::Result<()> {
 							)),
 						]);
 
-						cmd.run(client, inherent_benchmark_data()?, &ext_factory)
+						cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
 					}
 					BenchmarkCmd::Machine(cmd) => cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
 				}

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -17,7 +17,7 @@ ctype = {features = ["mock"], path = "../ctype"}
 kilt-support = {features = ["mock"], path = "../../support"}
 
 pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
-serde = "1.0.142"
+serde = "1.0.144"
 sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
 sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
 sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
@@ -26,7 +26,7 @@ sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
 log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true}
+serde = {version = "1.0.144", optional = true}
 
 # Internal dependencies
 ctype = {default-features = false, path = "../ctype"}

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -10,17 +10,17 @@ version = "1.7.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dev-dependencies]
 ctype = {features = ["mock"], path = "../ctype"}
 kilt-support = {features = ["mock"], path = "../../support"}
 
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
 serde = "1.0.142"
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -33,15 +33,15 @@ ctype = {default-features = false, path = "../ctype"}
 kilt-support = {default-features = false, path = "../../support"}
 
 #External dependencies
-frame-benchmarking = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-keystore = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-keystore = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/attestation/src/access_control.rs
+++ b/pallets/attestation/src/access_control.rs
@@ -94,12 +94,12 @@ where
 		Default::default()
 	}
 	fn can_attest_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 	fn can_revoke_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 	fn can_remove_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 }

--- a/pallets/attestation/src/default_weights.rs
+++ b/pallets/attestation/src/default_weights.rs
@@ -56,59 +56,59 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn add() -> Weight {
-		(74_496_000_u64)
-			.saturating_add(T::DbWeight::get().reads(6_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
+		Weight::from_ref_time(74_496_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	fn revoke() -> Weight {
-		(37_029_000_u64)
+		Weight::from_ref_time(37_029_000 as u64)
 			// Standard Error: 44_000
-			.saturating_add(6_325_000_u64)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+			.saturating_add(Weight::from_ref_time(6_325_000 as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove() -> Weight {
-		(64_058_000_u64)
+		Weight::from_ref_time(64_058_000 as u64)
 			// Standard Error: 44_000
-			.saturating_add(6_317_000_u64)
-			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
+			.saturating_add(Weight::from_ref_time(6_317_000 as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	fn reclaim_deposit() -> Weight {
-		(56_873_000_u64)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
+		Weight::from_ref_time(56_873_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn add() -> Weight {
-		(74_496_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+		Weight::from_ref_time(74_496_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	fn revoke() -> Weight {
-		(37_029_000_u64)
+		Weight::from_ref_time(37_029_000 as u64)
 			// Standard Error: 44_000
-			.saturating_add(6_325_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(Weight::from_ref_time(6_325_000 as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove() -> Weight {
-		(64_058_000_u64)
+		Weight::from_ref_time(64_058_000 as u64)
 			// Standard Error: 44_000
-			.saturating_add(6_317_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(Weight::from_ref_time(6_317_000 as u64))
+			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	fn reclaim_deposit() -> Weight {
-		(56_873_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+		Weight::from_ref_time(56_873_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 }

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -242,7 +242,7 @@ pub mod pallet {
 		/// # </weight>
 		#[pallet::weight(
 			<T as pallet::Config>::WeightInfo::add()
-			.saturating_add(authorization.as_ref().map(|ac| ac.can_attest_weight()).unwrap_or(0))
+			.saturating_add(authorization.as_ref().map(|ac| ac.can_attest_weight()).unwrap_or(Weight::zero()))
 		)]
 		pub fn add(
 			origin: OriginFor<T>,
@@ -315,7 +315,7 @@ pub mod pallet {
 		/// # </weight>
 		#[pallet::weight(
 			<T as pallet::Config>::WeightInfo::revoke()
-			.saturating_add(authorization.as_ref().map(|ac| ac.can_revoke_weight()).unwrap_or(0))
+			.saturating_add(authorization.as_ref().map(|ac| ac.can_revoke_weight()).unwrap_or(Weight::zero()))
 		)]
 		pub fn revoke(
 			origin: OriginFor<T>,
@@ -374,7 +374,7 @@ pub mod pallet {
 		/// # </weight>
 		#[pallet::weight(
 			<T as pallet::Config>::WeightInfo::remove()
-			.saturating_add(authorization.as_ref().map(|ac| ac.can_remove_weight()).unwrap_or(0))
+			.saturating_add(authorization.as_ref().map(|ac| ac.can_remove_weight()).unwrap_or(Weight::zero()))
 		)]
 		pub fn remove(
 			origin: OriginFor<T>,

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -91,7 +91,7 @@ where
 		_claim: &ClaimHashOf<T>,
 	) -> Result<Weight, DispatchError> {
 		if who == &self.0 {
-			Ok(0)
+			Ok(Weight::zero())
 		} else {
 			Err(DispatchError::Other("Unauthorized"))
 		}
@@ -105,7 +105,7 @@ where
 		authorization_id: &T::AuthorizationId,
 	) -> Result<Weight, DispatchError> {
 		if authorization_id == who {
-			Ok(0)
+			Ok(Weight::zero())
 		} else {
 			Err(DispatchError::Other("Unauthorized"))
 		}
@@ -119,7 +119,7 @@ where
 		authorization_id: &T::AuthorizationId,
 	) -> Result<Weight, DispatchError> {
 		if authorization_id == who {
-			Ok(0)
+			Ok(Weight::zero())
 		} else {
 			Err(DispatchError::Other("Unauthorized"))
 		}
@@ -130,13 +130,13 @@ where
 	}
 
 	fn can_attest_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 	fn can_revoke_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 	fn can_remove_weight(&self) -> Weight {
-		0
+		Weight::zero()
 	}
 }
 

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -15,7 +15,7 @@ substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branc
 [dev-dependencies]
 kilt-support = {features = ["mock"], path = "../../support"}
 pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
-serde = "1.0.142"
+serde = "1.0.144"
 sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
 sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
@@ -23,7 +23,7 @@ sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
 log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true}
+serde = {version = "1.0.144", optional = true}
 
 # Internal dependencies
 kilt-support = {default-features = false, path = "../../support"}

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -10,14 +10,14 @@ version = "1.7.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dev-dependencies]
 kilt-support = {features = ["mock"], path = "../../support"}
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
 serde = "1.0.142"
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -29,15 +29,15 @@ serde = {version = "1.0.142", optional = true}
 kilt-support = {default-features = false, path = "../../support"}
 
 # Substrate dependencies
-frame-benchmarking = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-keystore = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-keystore = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/ctype/src/default_weights.rs
+++ b/pallets/ctype/src/default_weights.rs
@@ -56,21 +56,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Ctype Ctypes (r:1 w:1)
 	fn add(l: u32, ) -> Weight {
-		(5_346_000_u64)
+		Weight::from_ref_time(5_346_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000_u64).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn add(l: u32, ) -> Weight {
-		(5_346_000_u64)
+		Weight::from_ref_time(5_346_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000_u64).saturating_mul(l as Weight))
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 }

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -19,7 +19,7 @@ kilt-support = {features = ["mock"], path = "../../support"}
 
 # External dependencies
 env_logger = "0.9.0"
-serde = "1.0.142"
+serde = "1.0.144"
 
 # Substrate dependencies
 pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
@@ -37,7 +37,7 @@ bitflags = {default-features = false, version = "1.3.2"}
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
 log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true}
+serde = {version = "1.0.144", optional = true}
 
 # Substrate dependencies
 frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -10,7 +10,7 @@ version = "1.7.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dev-dependencies]
 attestation = {features = ["mock"], path = "../attestation"}
@@ -22,9 +22,9 @@ env_logger = "0.9.0"
 serde = "1.0.142"
 
 # Substrate dependencies
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 # Internal dependencies
@@ -40,15 +40,15 @@ scale-info = {version = "2.1.1", default-features = false, features = ["derive"]
 serde = {version = "1.0.142", optional = true}
 
 # Substrate dependencies
-frame-benchmarking = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-keystore = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-keystore = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/delegation/src/default_weights.rs
+++ b/pallets/delegation/src/default_weights.rs
@@ -65,86 +65,86 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationNodes (r:0 w:1)
 	fn create_hierarchy() -> Weight {
-		(37_014_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(37_014_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn add_delegation() -> Weight {
-		(44_986_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(44_986_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_root_child(r: u32, c: u32, ) -> Weight {
-		(19_082_000 as Weight)
+		Weight::from_ref_time(19_082_000 as u64)
 			// Standard Error: 51_000
-			.saturating_add((13_360_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(13_360_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 51_000
-			.saturating_add((169_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(169_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:6 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_leaf(r: u32, c: u32, ) -> Weight {
-		(32_789_000 as Weight)
+		Weight::from_ref_time(32_789_000 as u64)
 			// Standard Error: 41_000
-			.saturating_add((13_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(13_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 41_000
-			.saturating_add((5_095_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(5_095_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:1)
 	fn remove_delegation(r: u32, ) -> Weight {
-		(51_863_000 as Weight)
+		Weight::from_ref_time(51_863_000 as u64)
 			// Standard Error: 59_000
-			.saturating_add((23_235_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(23_235_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:0 w:1)
 	fn reclaim_deposit(r: u32, ) -> Weight {
-		(44_669_000 as Weight)
+		Weight::from_ref_time(44_669_000 as u64)
 			// Standard Error: 56_000
-			.saturating_add((23_133_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(23_133_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:0)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn can_attest() -> Weight {
-		(12_484_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+		Weight::from_ref_time(12_484_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_revoke(c: u32, ) -> Weight {
-		(8_127_000 as Weight)
+		Weight::from_ref_time(8_127_000 as u64)
 			// Standard Error: 38_000
-			.saturating_add((5_164_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_164_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_remove(c: u32, ) -> Weight {
-		(7_991_000 as Weight)
+		Weight::from_ref_time(7_991_000 as u64)
 			// Standard Error: 35_000
-			.saturating_add((5_193_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_193_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 }
 
@@ -155,85 +155,85 @@ impl WeightInfo for () {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationNodes (r:0 w:1)
 	fn create_hierarchy() -> Weight {
-		(37_014_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(37_014_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn add_delegation() -> Weight {
-		(44_986_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(44_986_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_root_child(r: u32, c: u32, ) -> Weight {
-		(19_082_000 as Weight)
+		Weight::from_ref_time(19_082_000 as u64)
 			// Standard Error: 51_000
-			.saturating_add((13_360_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(13_360_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 51_000
-			.saturating_add((169_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(169_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:6 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_leaf(r: u32, c: u32, ) -> Weight {
-		(32_789_000 as Weight)
+		Weight::from_ref_time(32_789_000 as u64)
 			// Standard Error: 41_000
-			.saturating_add((13_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(13_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 41_000
-			.saturating_add((5_095_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(5_095_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:1)
 	fn remove_delegation(r: u32, ) -> Weight {
-		(51_863_000 as Weight)
+		Weight::from_ref_time(51_863_000 as u64)
 			// Standard Error: 59_000
-			.saturating_add((23_235_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(23_235_000 as u64).saturating_mul(r as u64))
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:0 w:1)
 	fn reclaim_deposit(r: u32, ) -> Weight {
-		(44_669_000 as Weight)
+		Weight::from_ref_time(44_669_000 as u64)
 			// Standard Error: 56_000
-			.saturating_add((23_133_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(23_133_000 as u64).saturating_mul(r as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:0)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn can_attest() -> Weight {
-		(12_484_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+		Weight::from_ref_time(12_484_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_revoke(c: u32, ) -> Weight {
-		(8_127_000 as Weight)
+		Weight::from_ref_time(8_127_000 as u64)
 			// Standard Error: 38_000
-			.saturating_add((5_164_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_164_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_remove(c: u32, ) -> Weight {
-		(7_991_000 as Weight)
+		Weight::from_ref_time(7_991_000 as u64)
 			// Standard Error: 35_000
-			.saturating_add((5_193_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_193_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 }

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -787,7 +787,7 @@ impl<T: Config> Pallet<T> {
 		max_revocations: u32,
 	) -> Result<(u32, Weight), DispatchError> {
 		let mut revocations: u32 = 0;
-		let mut consumed_weight: Weight = 0;
+		let mut consumed_weight: Weight = Weight::zero();
 		if let Some(delegation_node) = <DelegationNodes<T>>::get(delegation) {
 			// Iterate children and revoke all nodes
 			for child in delegation_node.children.iter() {
@@ -823,7 +823,7 @@ impl<T: Config> Pallet<T> {
 		max_revocations: u32,
 	) -> Result<(u32, Weight), DispatchError> {
 		let mut revocations: u32 = 0;
-		let mut consumed_weight: Weight = 0;
+		let mut consumed_weight: Weight = Weight::zero();
 		// Retrieve delegation node from storage
 		let mut delegation_node = <DelegationNodes<T>>::get(*delegation).ok_or(Error::<T>::DelegationNotFound)?;
 		consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().reads(1));
@@ -870,7 +870,7 @@ impl<T: Config> Pallet<T> {
 	/// # </weight>
 	fn remove_children(delegation: &DelegationNodeIdOf<T>, max_removals: u32) -> Result<(u32, Weight), DispatchError> {
 		let mut removals: u32 = 0;
-		let mut consumed_weight: Weight = 0;
+		let mut consumed_weight: Weight = Weight::zero();
 
 		// Can't clear storage until we have reached a leaf
 		if let Some(mut delegation_node) = DelegationNodes::<T>::get(delegation) {
@@ -909,7 +909,7 @@ impl<T: Config> Pallet<T> {
 	/// # </weight>
 	fn remove(delegation: &DelegationNodeIdOf<T>, max_removals: u32) -> Result<(u32, Weight), DispatchError> {
 		let mut removals: u32 = 0;
-		let mut consumed_weight: Weight = 0;
+		let mut consumed_weight: Weight = Weight::zero();
 
 		// Retrieve delegation node from storage
 		// Storage removal has to be postponed until children have been removed

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -10,7 +10,7 @@ version = "1.7.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dev-dependencies]
 env_logger = "0.9.0"
@@ -18,9 +18,9 @@ serde = "1.0.142"
 
 ctype = {features = ["mock"], path = "../ctype"}
 
-frame-benchmarking = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 # Internal dependencies
@@ -33,18 +33,18 @@ log = "0.4.17"
 serde = {version = "1.0.136", optional = true, features = ["derive"]}
 
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # benchmarking
-frame-benchmarking = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
-sp-keystore = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
+sp-keystore = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
 
 [features]
 default = ["std"]

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -14,7 +14,7 @@ substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branc
 
 [dev-dependencies]
 env_logger = "0.9.0"
-serde = "1.0.142"
+serde = "1.0.144"
 
 ctype = {features = ["mock"], path = "../ctype"}
 

--- a/pallets/did/src/default_weights.rs
+++ b/pallets/did/src/default_weights.rs
@@ -86,387 +86,387 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn create_ed25519_keys(_n: u32, c: u32, ) -> Weight {
-		(436_583_000_u64)
+		Weight::from_ref_time(436_583_000 as u64)
 			// Standard Error: 1_760_000
-			.saturating_add((9_755_000_u64).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().writes(4_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(9_755_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn create_sr25519_keys(n: u32, c: u32, ) -> Weight {
-		(354_663_000_u64)
+		Weight::from_ref_time(354_663_000 as u64)
 			// Standard Error: 649_000
-			.saturating_add((3_972_000_u64).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_972_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 243_000
-			.saturating_add((19_126_000_u64).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().writes(4_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(19_126_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn create_ecdsa_keys(_n: u32, c: u32, ) -> Weight {
-		(706_144_000_u64)
+		Weight::from_ref_time(706_144_000 as u64)
 			// Standard Error: 434_000
-			.saturating_add((10_592_000_u64).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().writes(4_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(10_592_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn delete(c: u32, ) -> Weight {
-		(37_058_000_u64)
+		Weight::from_ref_time(37_058_000 as u64)
 			// Standard Error: 22_000
-			.saturating_add((2_646_000_u64).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(2_646_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn reclaim_deposit(c: u32, ) -> Weight {
-		(75_498_000_u64)
+		Weight::from_ref_time(75_498_000 as u64)
 			// Standard Error: 90_000
-			.saturating_add((1_372_000_u64).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_372_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn submit_did_call_ed25519_key() -> Weight {
-		(94_698_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(94_698_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn submit_did_call_sr25519_key() -> Weight {
-		(88_897_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(88_897_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn submit_did_call_ecdsa_key() -> Weight {
-		(250_190_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(250_190_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_authentication_key() -> Weight {
-		(86_282_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(86_282_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_authentication_key() -> Weight {
-		(124_704_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(124_704_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_authentication_key() -> Weight {
-		(121_388_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(121_388_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_delegation_key() -> Weight {
-		(113_934_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(113_934_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_delegation_key() -> Weight {
-		(99_958_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_958_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_delegation_key() -> Weight {
-		(121_038_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(121_038_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_delegation_key() -> Weight {
-		(106_690_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_690_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_delegation_key() -> Weight {
-		(110_408_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(110_408_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_delegation_key() -> Weight {
-		(103_364_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(103_364_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_attestation_key() -> Weight {
-		(114_004_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(114_004_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_attestation_key() -> Weight {
-		(102_743_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(102_743_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_attestation_key() -> Weight {
-		(99_226_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_226_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_attestation_key() -> Weight {
-		(106_430_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_430_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_attestation_key() -> Weight {
-		(101_260_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(101_260_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_attestation_key() -> Weight {
-		(102_934_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(102_934_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn add_ed25519_key_agreement_key() -> Weight {
-		(106_259_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_259_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn add_sr25519_key_agreement_key() -> Weight {
-		(109_486_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(109_486_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn add_ecdsa_key_agreement_key() -> Weight {
-		(100_199_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(100_199_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_key_agreement_key() -> Weight {
-		(99_136_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_136_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_key_agreement_key() -> Weight {
-		(114_495_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(114_495_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_key_agreement_key() -> Weight {
-		(74_631_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(74_631_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn add_service_endpoint() -> Weight {
-		(52_909_000_u64)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		Weight::from_ref_time(52_909_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	fn remove_service_endpoint() -> Weight {
-		(61_756_000_u64)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		Weight::from_ref_time(61_756_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	fn signature_verification_sr25519(l: u32, ) -> Weight {
-		(123_502_000_u64)
+		Weight::from_ref_time(123_502_000 as u64)
 			// Standard Error: 0
-			.saturating_add((5_000_u64).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(5_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	fn signature_verification_ed25519(l: u32, ) -> Weight {
-		(130_465_000_u64)
+		Weight::from_ref_time(130_465_000 as u64)
 			// Standard Error: 0
-			.saturating_add((3_000_u64).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	fn signature_verification_ecdsa(l: u32, ) -> Weight {
-		(286_956_000_u64)
+		Weight::from_ref_time(286_956_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000_u64).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn create_ed25519_keys(_n: u32, c: u32, ) -> Weight {
-		(436_583_000_u64)
+		Weight::from_ref_time(436_583_000 as u64)
 			// Standard Error: 1_760_000
-			.saturating_add((9_755_000_u64).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(9_755_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn create_sr25519_keys(n: u32, c: u32, ) -> Weight {
-		(354_663_000_u64)
+		Weight::from_ref_time(354_663_000 as u64)
 			// Standard Error: 649_000
-			.saturating_add((3_972_000_u64).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_972_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 243_000
-			.saturating_add((19_126_000_u64).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(19_126_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn create_ecdsa_keys(_n: u32, c: u32, ) -> Weight {
-		(706_144_000_u64)
+		Weight::from_ref_time(706_144_000 as u64)
 			// Standard Error: 434_000
-			.saturating_add((10_592_000_u64).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(10_592_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn delete(c: u32, ) -> Weight {
-		(37_058_000_u64)
+		Weight::from_ref_time(37_058_000 as u64)
 			// Standard Error: 22_000
-			.saturating_add((2_646_000_u64).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(2_646_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn reclaim_deposit(c: u32, ) -> Weight {
-		(75_498_000_u64)
+		Weight::from_ref_time(75_498_000 as u64)
 			// Standard Error: 90_000
-			.saturating_add((1_372_000_u64).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_372_000 as u64).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	fn submit_did_call_ed25519_key() -> Weight {
-		(94_698_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(94_698_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn submit_did_call_sr25519_key() -> Weight {
-		(88_897_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(88_897_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn submit_did_call_ecdsa_key() -> Weight {
-		(250_190_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(250_190_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_authentication_key() -> Weight {
-		(86_282_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(86_282_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_authentication_key() -> Weight {
-		(124_704_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(124_704_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_authentication_key() -> Weight {
-		(121_388_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(121_388_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_delegation_key() -> Weight {
-		(113_934_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(113_934_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_delegation_key() -> Weight {
-		(99_958_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_958_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_delegation_key() -> Weight {
-		(121_038_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(121_038_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_delegation_key() -> Weight {
-		(106_690_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_690_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_delegation_key() -> Weight {
-		(110_408_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(110_408_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_delegation_key() -> Weight {
-		(103_364_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(103_364_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ed25519_attestation_key() -> Weight {
-		(114_004_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(114_004_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_sr25519_attestation_key() -> Weight {
-		(102_743_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(102_743_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_ecdsa_attestation_key() -> Weight {
-		(99_226_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_226_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_attestation_key() -> Weight {
-		(106_430_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_430_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_attestation_key() -> Weight {
-		(101_260_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(101_260_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_attestation_key() -> Weight {
-		(102_934_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(102_934_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn add_ed25519_key_agreement_key() -> Weight {
-		(106_259_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(106_259_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn add_sr25519_key_agreement_key() -> Weight {
-		(109_486_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(109_486_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn add_ecdsa_key_agreement_key() -> Weight {
-		(100_199_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(100_199_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ed25519_key_agreement_key() -> Weight {
-		(99_136_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(99_136_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_sr25519_key_agreement_key() -> Weight {
-		(114_495_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(114_495_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn remove_ecdsa_key_agreement_key() -> Weight {
-		(74_631_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(74_631_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn add_service_endpoint() -> Weight {
-		(52_909_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+		Weight::from_ref_time(52_909_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	fn remove_service_endpoint() -> Weight {
-		(61_756_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+		Weight::from_ref_time(61_756_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	fn signature_verification_sr25519(l: u32, ) -> Weight {
-		(123_502_000_u64)
+		Weight::from_ref_time(123_502_000 as u64)
 			// Standard Error: 0
-			.saturating_add((5_000_u64).saturating_mul(l as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(5_000 as u64).saturating_mul(l as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 	}
 	fn signature_verification_ed25519(l: u32, ) -> Weight {
-		(130_465_000_u64)
+		Weight::from_ref_time(130_465_000 as u64)
 			// Standard Error: 0
-			.saturating_add((3_000_u64).saturating_mul(l as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(l as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 	}
 	fn signature_verification_ecdsa(l: u32, ) -> Weight {
-		(286_956_000_u64)
+		Weight::from_ref_time(286_956_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000_u64).saturating_mul(l as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(l as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 	}
 }

--- a/pallets/pallet-did-lookup/Cargo.toml
+++ b/pallets/pallet-did-lookup/Cargo.toml
@@ -12,11 +12,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 kilt-support = {features = ["mock"], path = "../../support"}
 
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
 rand = "0.8"
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"]}
@@ -30,15 +30,15 @@ sha3 = {version = "0.10", default-features = false}
 kilt-support = {default-features = false, path = "../../support"}
 
 # Substrate dependencies
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # benchmarking
-frame-benchmarking = {branch = "polkadot-v0.9.27", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # optional dependencies
 impl-serde = {version = "0.3.1", optional = true}

--- a/pallets/pallet-did-lookup/src/default_weights.rs
+++ b/pallets/pallet-did-lookup/src/default_weights.rs
@@ -63,57 +63,57 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_sr25519() -> Weight {
-		(116_556_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(116_556_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ed25519() -> Weight {
-		(114_104_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(114_104_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ecdsa() -> Weight {
-		(105_595_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(105_595_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_eth_account() -> Weight {
-		(110_091_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(110_091_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_sender() -> Weight {
-		(58_803_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(58_803_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_sender_association() -> Weight {
-		(37_730_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(37_730_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_account_association() -> Weight {
-		(40_466_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(40_466_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }
 
@@ -123,56 +123,56 @@ impl WeightInfo for () {
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_sr25519() -> Weight {
-		(116_556_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(116_556_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ed25519() -> Weight {
-		(114_104_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(114_104_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ecdsa() -> Weight {
-		(105_595_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(105_595_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_eth_account() -> Weight {
-		(110_091_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(110_091_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_sender() -> Weight {
-		(58_803_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(58_803_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_sender_association() -> Weight {
-		(37_730_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(37_730_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_account_association() -> Weight {
-		(40_466_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(40_466_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 }

--- a/pallets/pallet-dyn-filter/Cargo.toml
+++ b/pallets/pallet-dyn-filter/Cargo.toml
@@ -12,10 +12,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -23,15 +23,15 @@ log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 
 # Substrate dependencies
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # benchmarking
-frame-benchmarking = {branch = "polkadot-v0.9.27", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/pallet-dyn-filter/src/default_weights.rs
+++ b/pallets/pallet-dyn-filter/src/default_weights.rs
@@ -34,7 +34,7 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn set_filter() -> Weight {
-		1_000_000.saturating_add(T::DbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(1_000_000u64).saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 
 }
@@ -42,6 +42,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn set_filter() -> Weight {
-		1_000_000.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(1_000_000u64).saturating_add(RocksDbWeight::get().reads(1 as u64))
 	}
 }

--- a/pallets/pallet-inflation/Cargo.toml
+++ b/pallets/pallet-inflation/Cargo.toml
@@ -12,9 +12,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 serde = "1.0.142"
 
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -22,13 +22,13 @@ scale-info = {version = "2.1.1", default-features = false, features = ["derive"]
 serde = {version = "1.0.142", optional = true}
 
 # benchmarking
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true}
 
 # Substrate dependencies
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/pallet-inflation/Cargo.toml
+++ b/pallets/pallet-inflation/Cargo.toml
@@ -10,7 +10,7 @@ version = "1.7.2"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
-serde = "1.0.142"
+serde = "1.0.144"
 
 pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
 sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
@@ -19,7 +19,7 @@ sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true}
+serde = {version = "1.0.144", optional = true}
 
 # benchmarking
 frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true}

--- a/pallets/pallet-inflation/src/default_weights.rs
+++ b/pallets/pallet-inflation/src/default_weights.rs
@@ -56,23 +56,23 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_mint_to_treasury() -> Weight {
-		(30_534_000_u64)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		Weight::from_ref_time(30_534_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize_no_action() -> Weight {
-		(386_000_u64)
+		Weight::from_ref_time(386_000 as u64)
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn on_initialize_mint_to_treasury() -> Weight {
-		(30_534_000_u64)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		Weight::from_ref_time(30_534_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize_no_action() -> Weight {
-		(386_000_u64)
+		Weight::from_ref_time(386_000 as u64)
 	}
 }

--- a/pallets/pallet-web3-names/Cargo.toml
+++ b/pallets/pallet-web3-names/Cargo.toml
@@ -12,10 +12,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 kilt-support = {features = ["mock"], path = "../../support"}
 
-pallet-balances = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
-sp-keystore = {branch = "polkadot-v0.9.27", git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", git = "https://github.com/paritytech/substrate"}
+sp-keystore = {branch = "master", git = "https://github.com/paritytech/substrate"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -26,14 +26,14 @@ serde = {version = "1.0.136", optional = true}
 kilt-support = {default-features = false, path = "../../support"}
 
 # Substrate dependencies
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # benchmarking
-frame-benchmarking = {branch = "polkadot-v0.9.27", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/pallet-web3-names/src/default_weights.rs
+++ b/pallets/pallet-web3-names/src/default_weights.rs
@@ -61,48 +61,48 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Web3Names Banned (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn claim(n: u32, ) -> Weight {
-		(51_814_000 as Weight)
+		Weight::from_ref_time(51_814_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((42_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(42_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Names (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn release_by_owner() -> Weight {
-		(44_267_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(44_267_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn reclaim_deposit(n: u32, ) -> Weight {
-		(43_834_000 as Weight)
+		Weight::from_ref_time(43_834_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((19_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(19_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn ban(n: u32, ) -> Weight {
-		(47_315_000 as Weight)
+		Weight::from_ref_time(47_315_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((43_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(43_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	fn unban(n: u32, ) -> Weight {
-		(20_297_000 as Weight)
+		Weight::from_ref_time(20_297_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((32_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }
 
@@ -113,47 +113,47 @@ impl WeightInfo for () {
 	// Storage: Web3Names Banned (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn claim(n: u32, ) -> Weight {
-		(51_814_000 as Weight)
+		Weight::from_ref_time(51_814_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((42_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(42_000 as u64).saturating_mul(n as u64))
+			.saturating_add(RocksDbWeight::get().reads(4 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Names (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn release_by_owner() -> Weight {
-		(44_267_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(44_267_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn reclaim_deposit(n: u32, ) -> Weight {
-		(43_834_000 as Weight)
+		Weight::from_ref_time(43_834_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((19_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(19_000 as u64).saturating_mul(n as u64))
+			.saturating_add(RocksDbWeight::get().reads(2 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn ban(n: u32, ) -> Weight {
-		(47_315_000 as Weight)
+		Weight::from_ref_time(47_315_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((43_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(43_000 as u64).saturating_mul(n as u64))
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	fn unban(n: u32, ) -> Weight {
-		(20_297_000 as Weight)
+		Weight::from_ref_time(20_297_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((32_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(32_000 as u64).saturating_mul(n as u64))
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -6,11 +6,11 @@ name = "parachain-staking"
 version = "1.7.2"
 
 [dev-dependencies]
-pallet-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-pallet-timestamp = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
-sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+pallet-aura = {git = "https://github.com/paritytech/substrate", branch = "master"}
+pallet-timestamp = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", branch = "master"}
+sp-io = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 log = "0.4.17"
@@ -18,17 +18,17 @@ parity-scale-codec = {version = "3.1.5", default-features = false, features = ["
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 serde = {version = "1.0.142", optional = true}
 
-frame-support = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-frame-system = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-pallet-session = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-sp-staking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
-sp-std = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false}
+frame-support = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+pallet-authorship = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+pallet-balances = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+pallet-session = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+sp-runtime = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+sp-staking = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
+sp-std = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
 
 # benchmarking
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true}
 
 [features]
 default = ["std"]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -16,7 +16,7 @@ sp-io = {git = "https://github.com/paritytech/substrate", branch = "master"}
 log = "0.4.17"
 parity-scale-codec = {version = "3.1.5", default-features = false, features = ["derive"]}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true}
+serde = {version = "1.0.144", optional = true}
 
 frame-support = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}
 frame-system = {git = "https://github.com/paritytech/substrate", branch = "master", default-features = false}

--- a/pallets/parachain-staking/src/default_weights.rs
+++ b/pallets/parachain-staking/src/default_weights.rs
@@ -75,22 +75,22 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking Round (r:1 w:0)
 	fn on_initialize_no_action() -> Weight {
-		(3_525_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(3_525_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn on_initialize_round_update() -> Weight {
-		(14_459_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(14_459_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
 	// Storage: ParachainStaking InflationConfig (r:1 w:1)
 	fn on_initialize_new_year() -> Weight {
-		(26_228_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(26_228_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
@@ -99,38 +99,38 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_network_rewards() -> Weight {
-		(55_319_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(55_319_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: ParachainStaking ForceNewRound (r:0 w:1)
 	fn force_new_round() -> Weight {
-		(1_768_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(1_768_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking InflationConfig (r:0 w:1)
 	fn set_inflation() -> Weight {
-		(12_952_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(12_952_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:0)
 	fn set_max_selected_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((10_570_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(10_570_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 33_000
-			.saturating_add((9_858_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(9_858_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(n as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn set_blocks_per_round() -> Weight {
-		(15_586_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_586_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -143,15 +143,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn force_remove_candidate(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((3_615_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_615_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 32_000
-			.saturating_add((23_037_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(25 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(23_037_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(25 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:0)
@@ -164,13 +164,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn join_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((2_514_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_514_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 44_000
-			.saturating_add((4_377_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(4_377_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(10 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -178,26 +178,26 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn init_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 19_000
-			.saturating_add((2_873_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_873_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 34_000
-			.saturating_add((7_012_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(21 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(7_012_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(21 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((2_709_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_709_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 30_000
-			.saturating_add((5_483_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(5_483_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Round (r:1 w:0)
@@ -208,15 +208,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Digest (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn execute_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 20_000
-			.saturating_add((4_307_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(4_307_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 37_000
-			.saturating_add((24_082_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(24_082_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -227,15 +227,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_682_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_682_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 41_000
-			.saturating_add((7_135_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(7_135_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 246_000
-			.saturating_add((2_235_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+			.saturating_add(Weight::from_ref_time(2_235_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
@@ -243,13 +243,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_502_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_502_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 42_000
-			.saturating_add((7_182_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(7_182_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
@@ -262,13 +262,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn join_delegators(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 20_000
-			.saturating_add((3_803_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_803_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 54_000
-			.saturating_add((8_007_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(11 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(Weight::from_ref_time(8_007_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(11 as u64))
+			.saturating_add(T::DbWeight::get().writes(8 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -279,15 +279,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 21_000
-			.saturating_add((3_810_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_810_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 58_000
-			.saturating_add((7_940_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(7_940_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 371_000
-			.saturating_add((3_810_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(3_810_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -296,13 +296,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 19_000
-			.saturating_add((3_567_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_567_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 51_000
-			.saturating_add((7_292_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_292_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -311,13 +311,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_516_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_516_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 45_000
-			.saturating_add((7_157_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_157_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -326,28 +326,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn leave_delegators(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((3_503_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_503_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 49_000
-			.saturating_add((7_270_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_270_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_unstaked(u: u32, ) -> Weight {
-		(33_495_000 as Weight)
+		Weight::from_ref_time(33_495_000 as u64)
 			// Standard Error: 23_000
-			.saturating_add((366_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(366_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:0 w:1)
 	fn set_max_candidate_stake() -> Weight {
-		(11_984_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(11_984_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }
 
@@ -355,22 +355,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: ParachainStaking Round (r:1 w:0)
 	fn on_initialize_no_action() -> Weight {
-		(3_525_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(3_525_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn on_initialize_round_update() -> Weight {
-		(14_459_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(14_459_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
 	// Storage: ParachainStaking InflationConfig (r:1 w:1)
 	fn on_initialize_new_year() -> Weight {
-		(26_228_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(26_228_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
@@ -379,38 +379,38 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_network_rewards() -> Weight {
-		(55_319_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(55_319_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: ParachainStaking ForceNewRound (r:0 w:1)
 	fn force_new_round() -> Weight {
-		(1_768_000 as Weight)
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(1_768_000 as u64)
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking InflationConfig (r:0 w:1)
 	fn set_inflation() -> Weight {
-		(12_952_000 as Weight)
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(12_952_000 as u64)
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:0)
 	fn set_max_selected_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((10_570_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(10_570_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 33_000
-			.saturating_add((9_858_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(9_858_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(n as u64)))
+			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn set_blocks_per_round() -> Weight {
-		(15_586_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_586_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -423,15 +423,15 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn force_remove_candidate(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((3_615_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_615_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 32_000
-			.saturating_add((23_037_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(25 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(23_037_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(25 as u64))
+			.saturating_add(RocksDbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
+			.saturating_add(RocksDbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:0)
@@ -444,13 +444,13 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn join_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((2_514_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_514_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 44_000
-			.saturating_add((4_377_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(10 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(4_377_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(10 as u64))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -458,26 +458,26 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn init_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 19_000
-			.saturating_add((2_873_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_873_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 34_000
-			.saturating_add((7_012_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(21 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(7_012_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(21 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((2_709_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_709_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 30_000
-			.saturating_add((5_483_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(5_483_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Round (r:1 w:0)
@@ -488,15 +488,15 @@ impl WeightInfo for () {
 	// Storage: System Digest (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn execute_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 20_000
-			.saturating_add((4_307_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(4_307_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 37_000
-			.saturating_add((24_082_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(24_082_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(7 as u64))
+			.saturating_add(RocksDbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -507,15 +507,15 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_682_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_682_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 41_000
-			.saturating_add((7_135_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(7_135_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 246_000
-			.saturating_add((2_235_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+			.saturating_add(Weight::from_ref_time(2_235_000 as u64).saturating_mul(u as u64))
+			.saturating_add(RocksDbWeight::get().reads(8 as u64))
+			.saturating_add(RocksDbWeight::get().writes(6 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
@@ -523,13 +523,13 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_502_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_502_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 42_000
-			.saturating_add((7_182_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(7_182_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
@@ -542,13 +542,13 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn join_delegators(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 20_000
-			.saturating_add((3_803_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_803_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 54_000
-			.saturating_add((8_007_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(11 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
+			.saturating_add(Weight::from_ref_time(8_007_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(11 as u64))
+			.saturating_add(RocksDbWeight::get().writes(8 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -559,15 +559,15 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 21_000
-			.saturating_add((3_810_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_810_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 58_000
-			.saturating_add((7_940_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(7_940_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 371_000
-			.saturating_add((3_810_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(3_810_000 as u64).saturating_mul(u as u64))
+			.saturating_add(RocksDbWeight::get().reads(8 as u64))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -576,13 +576,13 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 19_000
-			.saturating_add((3_567_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_567_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 51_000
-			.saturating_add((7_292_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_292_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -591,13 +591,13 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 17_000
-			.saturating_add((3_516_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_516_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 45_000
-			.saturating_add((7_157_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_157_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -606,27 +606,27 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn leave_delegators(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 18_000
-			.saturating_add((3_503_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_503_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 49_000
-			.saturating_add((7_270_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(7_270_000 as u64).saturating_mul(m as u64))
+			.saturating_add(RocksDbWeight::get().reads(6 as u64))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_unstaked(u: u32, ) -> Weight {
-		(33_495_000 as Weight)
+		Weight::from_ref_time(33_495_000 as u64)
 			// Standard Error: 23_000
-			.saturating_add((366_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(366_000 as u64).saturating_mul(u as u64))
+			.saturating_add(RocksDbWeight::get().reads(3 as u64))
+			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:0 w:1)
 	fn set_max_candidate_stake() -> Weight {
-		(11_984_000 as Weight)
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(11_984_000 as u64)
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2822,8 +2822,8 @@ pub mod pallet {
 		/// - Writes: (D + 1) * Balance
 		/// # </weight>
 		fn note_author(author: T::AccountId) {
-			let mut reads = Weight::one();
-			let mut writes = Weight::zero();
+			let mut reads = 1u64;
+			let mut writes = 0u64;
 			// should always include state except if the collator has been forcedly removed
 			// via `force_remove_candidate` in the current or previous round
 			if let Some(state) = CandidatePool::<T>::get(author.clone()) {
@@ -2844,7 +2844,7 @@ pub mod pallet {
 						.collator
 						.compute_reward::<T>(state.stake, c_staking_rate, authors_per_round);
 				Self::do_reward(&author, amt_due_collator);
-				writes = writes.saturating_add(Weight::one());
+				writes = writes.saturating_add(1u64);
 
 				// Reward delegators
 				for Stake { owner, amount } in state.delegators {
@@ -2854,7 +2854,7 @@ pub mod pallet {
 								.delegator
 								.compute_reward::<T>(amount, d_staking_rate, authors_per_round);
 						Self::do_reward(&owner, due);
-						writes = writes.saturating_add(Weight::one());
+						writes = writes.saturating_add(1u64);
 					}
 				}
 				reads = reads.saturating_add(4);

--- a/pallets/relay-migration/Cargo.toml
+++ b/pallets/relay-migration/Cargo.toml
@@ -11,28 +11,28 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
-cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
+cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
 log = "0.4.17"
-pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-polkadot-core-primitives = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-polkadot-runtime-common = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+polkadot-core-primitives = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+polkadot-runtime-common = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 
 # KILT
 kilt-support = {default-features = false, path = "../../support"}
 
 # Substrate dependencies
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # benchmarking
-frame-benchmarking = {branch = "polkadot-v0.9.27", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", optional = true, default-features = false, git = "https://github.com/paritytech/substrate"}
 
 [features]
 default = ["std"]

--- a/pallets/relay-migration/src/lib.rs
+++ b/pallets/relay-migration/src/lib.rs
@@ -80,7 +80,7 @@ pub mod pallet {
 		/// Set an XCM call to the relay chain.
 		///
 		/// Has to be done pre migration.
-		#[pallet::weight(1_000_000 + T::DbWeight::get().reads_writes(10, 10))]
+		#[pallet::weight(1_000_000 + T::DbWeight::get().reads_writes(10, 10).ref_time())]
 		pub fn send_swap_call_bytes(
 			origin: OriginFor<T>,
 			relay_call: Vec<u8>,
@@ -103,7 +103,7 @@ pub mod pallet {
 		/// RelayNumberStrictlyIncreases.
 		///
 		/// Has to be done post migration.
-		#[pallet::weight(100_000 + T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight(100_000 + T::DbWeight::get().reads_writes(1, 1).ref_time())]
 		pub fn enable_strict_relay_number_check(origin: OriginFor<T>) -> DispatchResult {
 			T::ApproveOrigin::ensure_origin(origin)?;
 			RelayNumberStrictlyIncreases::<T>::put(true);
@@ -116,7 +116,7 @@ pub mod pallet {
 		/// Set the associated relay block number to be AnyRelayNumber.
 		///
 		/// Has to be done pre migration.
-		#[pallet::weight(100_000 + T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight(100_000 + T::DbWeight::get().reads_writes(1, 1).ref_time())]
 		pub fn disable_strict_relay_number_check(origin: OriginFor<T>) -> DispatchResult {
 			T::ApproveOrigin::ensure_origin(origin)?;
 			RelayNumberStrictlyIncreases::<T>::put(false);

--- a/rpc/did/Cargo.toml
+++ b/rpc/did/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.6.2"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5" }
-jsonrpsee = { version = "0.14.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 
 did-rpc-runtime-api = {version = "1.6.2", path = "./runtime-api"}
 

--- a/rpc/did/Cargo.toml
+++ b/rpc/did/Cargo.toml
@@ -11,10 +11,10 @@ jsonrpsee = { version = "0.14.0", features = ["server", "macros"] }
 
 did-rpc-runtime-api = {version = "1.6.2", path = "./runtime-api"}
 
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-blockchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-blockchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 [features]
 default = ["std"]

--- a/rpc/did/runtime-api/Cargo.toml
+++ b/rpc/did/runtime-api/Cargo.toml
@@ -10,9 +10,9 @@ codec = { package = "parity-scale-codec", version = "3.1.5", default-features = 
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 did = {path = "../../../pallets/did", default-features = false}
 pallet-did-lookup = {path = "../../../pallets/pallet-did-lookup", default-features = false}

--- a/runtimes/clone/Cargo.toml
+++ b/runtimes/clone/Cargo.toml
@@ -5,7 +5,7 @@ name = "clone-runtime"
 version = "1.7.2"
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -19,67 +19,67 @@ serde = {version = "1.0.137", optional = true, features = ["derive"]}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}
-frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # KILT pallets & primitives
 pallet-did-lookup = {path = "../../pallets/pallet-did-lookup", default-features = false}
 runtime-common = {path = "../../runtimes/common", default-features = false}
 
 # Substrate dependencies
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-sudo = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-sudo = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-solo-to-para = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-collator-selection = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
+cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-solo-to-para = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+pallet-collator-selection = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
 
 # Polkadot dependencies
-pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 
 # Benchmarking
-cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
-frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
+cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "master"}
+frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master"}
 
 # Runtime tests
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27", optional = true}
+frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master", optional = true}
 
 [features]
 default = ["std"]

--- a/runtimes/clone/src/lib.rs
+++ b/runtimes/clone/src/lib.rs
@@ -195,8 +195,8 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
-	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
+	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {

--- a/runtimes/clone/src/weights/frame_system.rs
+++ b/runtimes/clone/src/weights/frame_system.rs
@@ -49,39 +49,39 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 	fn remark(_b: u32, ) -> Weight {
-		(860_000 as Weight)
+		Weight::from_ref_time(860_000 as u64)
 	}
 	fn remark_with_event(b: u32, ) -> Weight {
-		(13_814_000 as Weight)
+		Weight::from_ref_time(13_814_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 	}
 	// Storage: System Digest (r:1 w:1)
 	// Storage: unknown [0x3a686561707061676573] (r:0 w:1)
 	fn set_heap_pages() -> Weight {
-		(4_811_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(4_811_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn set_storage(i: u32, ) -> Weight {
-		(1_312_000 as Weight)
+		Weight::from_ref_time(1_312_000 as u64)
 			// Standard Error: 0
-			.saturating_add((615_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(615_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_storage(i: u32, ) -> Weight {
-		(1_523_000 as Weight)
+		Weight::from_ref_time(1_523_000 as u64)
 			// Standard Error: 0
-			.saturating_add((448_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(448_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_prefix(p: u32, ) -> Weight {
-		(4_533_000 as Weight)
+		Weight::from_ref_time(4_533_000 as u64)
 			// Standard Error: 0
-			.saturating_add((841_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(841_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 }

--- a/runtimes/clone/src/weights/pallet_balances.rs
+++ b/runtimes/clone/src/weights/pallet_balances.rs
@@ -50,44 +50,44 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:2 w:2)
 	fn transfer() -> Weight {
-		(68_568_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(68_568_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_keep_alive() -> Weight {
-		(43_526_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(43_526_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_creating() -> Weight {
-		(27_315_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(27_315_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_killing() -> Weight {
-		(32_217_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_217_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:3 w:3)
 	fn force_transfer() -> Weight {
-		(68_361_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(68_361_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_all() -> Weight {
-		(52_521_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(52_521_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn force_unreserve() -> Weight {
-		(25_515_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(25_515_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/clone/src/weights/pallet_session.rs
+++ b/runtimes/clone/src/weights/pallet_session.rs
@@ -51,15 +51,15 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:1 w:1)
 	fn set_keys() -> Weight {
-		(21_418_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(21_418_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:0 w:1)
 	fn purge_keys() -> Weight {
-		(16_419_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(16_419_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/clone/src/weights/pallet_timestamp.rs
+++ b/runtimes/clone/src/weights/pallet_timestamp.rs
@@ -50,11 +50,11 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 	// Storage: Timestamp Now (r:1 w:1)
 	fn set() -> Weight {
-		(6_990_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_990_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_finalize() -> Weight {
-		(4_251_000 as Weight)
+		Weight::from_ref_time(4_251_000 as u64)
 	}
 }

--- a/runtimes/clone/src/weights/pallet_utility.rs
+++ b/runtimes/clone/src/weights/pallet_utility.rs
@@ -49,24 +49,24 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 	fn batch(c: u32, ) -> Weight {
-		(12_999_000 as Weight)
+		Weight::from_ref_time(12_999_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_094_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_094_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		(2_600_000 as Weight)
+		Weight::from_ref_time(2_600_000 as u64)
 	}
 	fn batch_all(c: u32, ) -> Weight {
-		(17_564_000 as Weight)
+		Weight::from_ref_time(17_564_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_447_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_447_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		(13_814_000 as Weight)
+		Weight::from_ref_time(13_814_000 as u64)
 	}
 	fn force_batch(c: u32, ) -> Weight {
-		(12_779_000 as Weight)
+		Weight::from_ref_time(12_779_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((4_112_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_112_000 as u64).saturating_mul(c as u64))
 	}
 }

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -11,7 +11,7 @@ sp-io = {git = "https://github.com/paritytech/substrate", branch = "master"}
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
 log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
-serde = {version = "1.0.142", optional = true, features = ["derive"]}
+serde = {version = "1.0.144", optional = true, features = ["derive"]}
 smallvec = "1.8.0"
 
 attestation = {default-features = false, path = "../../pallets/attestation"}

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -5,7 +5,7 @@ name = "runtime-common"
 version = "1.7.2"
 
 [dev-dependencies]
-sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+sp-io = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -17,22 +17,22 @@ smallvec = "1.8.0"
 attestation = {default-features = false, path = "../../pallets/attestation"}
 parachain-staking = {default-features = false, path = "../../pallets/parachain-staking"}
 
-frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 
 [features]
 default = ["std"]

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -67,7 +67,7 @@ pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// used by  Operational  extrinsics.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 0.5 seconds of compute with a 12 second average block time.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2);
 
 pub const INFLATION_CONFIG: (Perquintill, Perquintill, Perquintill, Perquintill) = (
 	// max collator staking rate

--- a/runtimes/common/src/fees.rs
+++ b/runtimes/common/src/fees.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	traits::{Currency, Get, Imbalance, OnUnbalanced},
 	weights::{
 		DispatchClass, WeightToFee as WeightToFeeT, WeightToFeeCoefficient, WeightToFeeCoefficients,
-		WeightToFeePolynomial,
+		WeightToFeePolynomial, Weight,
 	},
 };
 use pallet_balances::WeightInfo;
@@ -105,15 +105,15 @@ where
 
 		// TODO: transfer_keep_alive is 288 byte long?
 		let tx_len: u64 = 288;
-		let byte_fee: Balance = <R as pallet_transaction_payment::Config>::LengthToFee::weight_to_fee(&tx_len).into();
-		let base_weight: Balance = <R as frame_system::Config>::BlockWeights::get()
+		let byte_fee: Balance = <R as pallet_transaction_payment::Config>::LengthToFee::weight_to_fee(&Weight::from_ref_time(tx_len)).into();
+		let base_weight: Weight  =<R as frame_system::Config>::BlockWeights::get()
 			.get(DispatchClass::Normal)
-			.base_extrinsic
-			.into();
-		let tx_weight: Balance = <R as pallet_balances::Config>::WeightInfo::transfer_keep_alive().into();
-		let unbalanced_fee: Balance = base_weight + tx_weight;
+			.base_extrinsic;
+		let base_weight_fee: Balance =  <R as pallet_transaction_payment::Config>::LengthToFee::weight_to_fee(&base_weight).into();
+		let tx_weight_fee: Balance =  <R as pallet_transaction_payment::Config>::LengthToFee::weight_to_fee(&<R as pallet_balances::Config>::WeightInfo::transfer_keep_alive()).into();
+		let unbalanced_fee: Balance = base_weight_fee.saturating_add(tx_weight_fee);
 
-		let wanted_weight_fee: Balance = wanted_fee - byte_fee;
+		let wanted_weight_fee: Balance = wanted_fee.saturating_sub(byte_fee);
 
 		smallvec![WeightToFeeCoefficient {
 			degree: 1,
@@ -156,12 +156,12 @@ mod tests {
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub BlockWeights: limits::BlockWeights = limits::BlockWeights::builder()
-			.base_block(10)
+			.base_block(Weight::from_ref_time(10u64))
 			.for_class(DispatchClass::all(), |weight| {
-				weight.base_extrinsic = 100;
+				weight.base_extrinsic = Weight::from_ref_time(100u64);
 			})
 			.for_class(DispatchClass::non_mandatory(), |weight| {
-				weight.max_total = Some(1024);
+				weight.max_total = Some(Weight::from_ref_time(1024u64));
 			})
 			.build_or_panic();
 		pub BlockLength: limits::BlockLength = limits::BlockLength::max(2 * 1024);

--- a/runtimes/common/src/xcm_config.rs
+++ b/runtimes/common/src/xcm_config.rs
@@ -30,7 +30,7 @@ use crate::AccountId;
 
 parameter_types! {
 	// One XCM operation is 1_000_000_000 weight, almost certainly a conservative estimate.
-	pub UnitWeightCost: Weight = 1_000_000_000;
+	pub UnitWeightCost: u64 = 1_000_000_000 as u64;
 	pub const MaxInstructions: u32 = 100;
 }
 
@@ -55,8 +55,8 @@ where
 	fn should_execute<Call>(
 		origin: &MultiLocation,
 		message: &mut Xcm<Call>,
-		max_weight: Weight,
-		weight_credit: &mut Weight,
+		max_weight: u64,
+		weight_credit: &mut u64,
 	) -> Result<(), ()> {
 		Deny::should_execute(origin, message, max_weight, weight_credit)?;
 		Allow::should_execute(origin, message, max_weight, weight_credit)
@@ -85,8 +85,8 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 	fn should_execute<Call>(
 		origin: &MultiLocation,
 		message: &mut Xcm<Call>,
-		_max_weight: Weight,
-		_weight_credit: &mut Weight,
+		_max_weight: u64,
+		_weight_credit: &mut u64,
 	) -> Result<(), ()> {
 		if message.0.iter().any(|inst| {
 			matches!(

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -5,7 +5,7 @@ name = "peregrine-runtime"
 version = "1.7.2"
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -19,8 +19,8 @@ serde = {version = "1.0.142", optional = true, features = ["derive"]}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}
-frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # KILT pallets & primitives
 attestation = {path = "../../pallets/attestation", default-features = false}
@@ -37,68 +37,68 @@ parachain-staking = {path = "../../pallets/parachain-staking", default-features 
 runtime-common = {path = "../../runtimes/common", default-features = false}
 
 # Substrate dependencies
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-collective = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-democracy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-indices = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-preimage = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-proxy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-randomness-collective-flip = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-scheduler = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-sudo = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-tips = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-treasury = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-collective = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-democracy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-indices = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-preimage = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-proxy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-randomness-collective-flip = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-scheduler = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-sudo = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-tips = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-treasury = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
+cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
 
 # Polkadot dependencies
-pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 
 # Benchmarking
-cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
-frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
+cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "master"}
+frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master"}
 
 # Runtime tests
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27", optional = true}
+frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master", optional = true}
 
 [features]
 default = ["std"]

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -15,7 +15,7 @@ smallvec = "1.8.0"
 static_assertions = "1.1.0"
 
 hex-literal = {version = "0.3.4", optional = true}
-serde = {version = "1.0.142", optional = true, features = ["derive"]}
+serde = {version = "1.0.144", optional = true, features = ["derive"]}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -207,8 +207,8 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
-	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
+	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {

--- a/runtimes/peregrine/src/weights/attestation.rs
+++ b/runtimes/peregrine/src/weights/attestation.rs
@@ -52,28 +52,28 @@ impl<T: frame_system::Config> attestation::WeightInfo for WeightInfo<T> {
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add() -> Weight {
-		(39_155_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(39_155_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	fn revoke() -> Weight {
-		(22_118_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(22_118_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn remove() -> Weight {
-		(37_056_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(37_056_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reclaim_deposit() -> Weight {
-		(36_419_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(36_419_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/ctype.rs
+++ b/runtimes/peregrine/src/weights/ctype.rs
@@ -51,10 +51,10 @@ impl<T: frame_system::Config> ctype::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Ctype Ctypes (r:1 w:1)
 	fn add(l: u32, ) -> Weight {
-		(55_375_000 as Weight)
+		Weight::from_ref_time(55_375_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/delegation.rs
+++ b/runtimes/peregrine/src/weights/delegation.rs
@@ -53,85 +53,85 @@ impl<T: frame_system::Config> delegation::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationNodes (r:0 w:1)
 	fn create_hierarchy() -> Weight {
-		(42_445_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(42_445_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn add_delegation() -> Weight {
-		(50_201_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(50_201_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_root_child(r: u32, c: u32, ) -> Weight {
-		(20_845_000 as Weight)
+		Weight::from_ref_time(20_845_000 as u64)
 			// Standard Error: 26_000
-			.saturating_add((14_255_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(14_255_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 26_000
-			.saturating_add((39_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(39_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:6 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_leaf(r: u32, c: u32, ) -> Weight {
-		(35_096_000 as Weight)
+		Weight::from_ref_time(35_096_000 as u64)
 			// Standard Error: 28_000
-			.saturating_add((70_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(70_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 28_000
-			.saturating_add((5_074_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(5_074_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:1)
 	fn remove_delegation(r: u32, ) -> Weight {
-		(56_155_000 as Weight)
+		Weight::from_ref_time(56_155_000 as u64)
 			// Standard Error: 39_000
-			.saturating_add((24_122_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(24_122_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:0 w:1)
 	fn reclaim_deposit(r: u32, ) -> Weight {
-		(48_349_000 as Weight)
+		Weight::from_ref_time(48_349_000 as u64)
 			// Standard Error: 49_000
-			.saturating_add((24_335_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(24_335_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:0)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn can_attest() -> Weight {
-		(13_495_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+		Weight::from_ref_time(13_495_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_revoke(c: u32, ) -> Weight {
-		(8_438_000 as Weight)
+		Weight::from_ref_time(8_438_000 as u64)
 			// Standard Error: 18_000
-			.saturating_add((5_037_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_037_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_remove(c: u32, ) -> Weight {
-		(8_448_000 as Weight)
+		Weight::from_ref_time(8_448_000 as u64)
 			// Standard Error: 17_000
-			.saturating_add((5_022_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_022_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 }

--- a/runtimes/peregrine/src/weights/did.rs
+++ b/runtimes/peregrine/src/weights/did.rs
@@ -54,14 +54,14 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_ed25519_keys(n: u32, c: u32, ) -> Weight {
-		(136_970_000 as Weight)
+		Weight::from_ref_time(136_970_000 as u64)
 			// Standard Error: 43_000
-			.saturating_add((1_516_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_516_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 16_000
-			.saturating_add((5_935_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_935_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Storage: Did DidBlacklist (r:1 w:0)
@@ -69,14 +69,14 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_sr25519_keys(n: u32, c: u32, ) -> Weight {
-		(139_739_000 as Weight)
+		Weight::from_ref_time(139_739_000 as u64)
 			// Standard Error: 15_000
-			.saturating_add((1_503_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_503_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 5_000
-			.saturating_add((6_392_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(6_392_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Storage: Did DidBlacklist (r:1 w:0)
@@ -84,217 +84,217 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_ecdsa_keys(n: u32, c: u32, ) -> Weight {
-		(128_949_000 as Weight)
+		Weight::from_ref_time(128_949_000 as u64)
 			// Standard Error: 21_000
-			.saturating_add((1_495_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_495_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 8_000
-			.saturating_add((5_559_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_559_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did Did (r:1 w:1)
 	// Storage: Did DidBlacklist (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:1)
 	fn delete(c: u32, ) -> Weight {
-		(33_940_000 as Weight)
+		Weight::from_ref_time(33_940_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_128_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_128_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did Did (r:1 w:1)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did DidBlacklist (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:1)
 	fn reclaim_deposit(c: u32, ) -> Weight {
-		(37_019_000 as Weight)
+		Weight::from_ref_time(37_019_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_119_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_119_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_ed25519_key() -> Weight {
-		(79_603_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(79_603_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_sr25519_key() -> Weight {
-		(82_379_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(82_379_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_ecdsa_key() -> Weight {
-		(71_713_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(71_713_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_authentication_key() -> Weight {
-		(35_722_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_722_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_authentication_key() -> Weight {
-		(35_743_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_743_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_authentication_key() -> Weight {
-		(35_735_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_735_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_delegation_key() -> Weight {
-		(35_251_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_251_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_delegation_key() -> Weight {
-		(35_317_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_317_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_delegation_key() -> Weight {
-		(35_687_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_687_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_delegation_key() -> Weight {
-		(32_882_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_882_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_delegation_key() -> Weight {
-		(32_918_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_918_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_delegation_key() -> Weight {
-		(32_664_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_664_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_attestation_key() -> Weight {
-		(35_499_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_499_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_attestation_key() -> Weight {
-		(35_531_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_531_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_attestation_key() -> Weight {
-		(35_185_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_185_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_attestation_key() -> Weight {
-		(32_934_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_934_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_attestation_key() -> Weight {
-		(33_312_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_312_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_attestation_key() -> Weight {
-		(33_179_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_179_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_ed25519_key_agreement_key() -> Weight {
-		(35_159_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_159_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_sr25519_key_agreement_key() -> Weight {
-		(35_051_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_051_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_ecdsa_key_agreement_key() -> Weight {
-		(34_842_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_842_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_key_agreement_key() -> Weight {
-		(33_369_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_369_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_key_agreement_key() -> Weight {
-		(33_497_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_497_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_key_agreement_key() -> Weight {
-		(33_403_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_403_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did ServiceEndpoints (r:1 w:1)
 	fn add_service_endpoint() -> Weight {
-		(37_336_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(37_336_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Did ServiceEndpoints (r:1 w:1)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	fn remove_service_endpoint() -> Weight {
-		(31_417_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(31_417_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_sr25519(l: u32, ) -> Weight {
-		(66_480_000 as Weight)
+		Weight::from_ref_time(66_480_000 as u64)
 			// Standard Error: 0
-			.saturating_add((4_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_ed25519(l: u32, ) -> Weight {
-		(63_463_000 as Weight)
+		Weight::from_ref_time(63_463_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_ecdsa(l: u32, ) -> Weight {
-		(56_006_000 as Weight)
+		Weight::from_ref_time(56_006_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/frame_system.rs
+++ b/runtimes/peregrine/src/weights/frame_system.rs
@@ -49,39 +49,39 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 	fn remark(_b: u32, ) -> Weight {
-		(926_000 as Weight)
+		Weight::from_ref_time(926_000 as u64)
 	}
 	fn remark_with_event(b: u32, ) -> Weight {
-		(13_870_000 as Weight)
+		Weight::from_ref_time(13_870_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 	}
 	// Storage: System Digest (r:1 w:1)
 	// Storage: unknown [0x3a686561707061676573] (r:0 w:1)
 	fn set_heap_pages() -> Weight {
-		(4_795_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(4_795_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn set_storage(i: u32, ) -> Weight {
-		(1_464_000 as Weight)
+		Weight::from_ref_time(1_464_000 as u64)
 			// Standard Error: 0
-			.saturating_add((613_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(613_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_storage(i: u32, ) -> Weight {
-		(1_668_000 as Weight)
+		Weight::from_ref_time(1_668_000 as u64)
 			// Standard Error: 0
-			.saturating_add((449_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(449_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_prefix(p: u32, ) -> Weight {
-		(4_618_000 as Weight)
+		Weight::from_ref_time(4_618_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((841_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(841_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_balances.rs
+++ b/runtimes/peregrine/src/weights/pallet_balances.rs
@@ -50,44 +50,44 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:2 w:2)
 	fn transfer() -> Weight {
-		(70_833_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(70_833_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_keep_alive() -> Weight {
-		(43_906_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(43_906_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_creating() -> Weight {
-		(27_540_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(27_540_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_killing() -> Weight {
-		(32_308_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_308_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:3 w:3)
 	fn force_transfer() -> Weight {
-		(68_589_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(68_589_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_all() -> Weight {
-		(52_624_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(52_624_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn force_unreserve() -> Weight {
-		(25_623_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(25_623_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_collective.rs
+++ b/runtimes/peregrine/src/weights/pallet_collective.rs
@@ -53,36 +53,36 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council Voting (r:100 w:100)
 	// Storage: Council Prime (r:0 w:1)
 	fn set_members(m: u32, n: u32, p: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 20_000
-			.saturating_add((11_799_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(11_799_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 20_000
-			.saturating_add((167_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(167_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 20_000
-			.saturating_add((16_773_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(16_773_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(p as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 	// Storage: Council Members (r:1 w:0)
 	fn execute(b: u32, m: u32, ) -> Weight {
-		(19_437_000 as Weight)
+		Weight::from_ref_time(19_437_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((40_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(40_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:0)
 	fn propose_execute(b: u32, m: u32, ) -> Weight {
-		(23_299_000 as Weight)
+		Weight::from_ref_time(23_299_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((68_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(Weight::from_ref_time(68_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:1)
@@ -90,52 +90,52 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council ProposalCount (r:1 w:1)
 	// Storage: Council Voting (r:0 w:1)
 	fn propose_proposed(b: u32, m: u32, p: u32, ) -> Weight {
-		(34_869_000 as Weight)
+		Weight::from_ref_time(34_869_000 as u64)
 			// Standard Error: 0
-			.saturating_add((3_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((21_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(21_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((292_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(292_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council Voting (r:1 w:1)
 	fn vote(m: u32, ) -> Weight {
-		(39_159_000 as Weight)
+		Weight::from_ref_time(39_159_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((77_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(77_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn close_early_disapproved(m: u32, p: u32, ) -> Weight {
-		(35_399_000 as Weight)
+		Weight::from_ref_time(35_399_000 as u64)
 			// Standard Error: 0
-			.saturating_add((62_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(62_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((268_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(268_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:1)
 	// Storage: Council Proposals (r:1 w:1)
 	fn close_early_approved(b: u32, m: u32, p: u32, ) -> Weight {
-		(46_262_000 as Weight)
+		Weight::from_ref_time(46_262_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 1_000
-			.saturating_add((58_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(58_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 1_000
-			.saturating_add((286_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(286_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
@@ -143,13 +143,13 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn close_disapproved(m: u32, p: u32, ) -> Weight {
-		(39_459_000 as Weight)
+		Weight::from_ref_time(39_459_000 as u64)
 			// Standard Error: 0
-			.saturating_add((64_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(64_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((263_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(263_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
@@ -157,24 +157,24 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council ProposalOf (r:1 w:1)
 	// Storage: Council Proposals (r:1 w:1)
 	fn close_approved(b: u32, m: u32, p: u32, ) -> Weight {
-		(50_332_000 as Weight)
+		Weight::from_ref_time(50_332_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((53_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(53_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((289_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(289_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council Voting (r:0 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn disapprove_proposal(p: u32, ) -> Weight {
-		(21_104_000 as Weight)
+		Weight::from_ref_time(21_104_000 as u64)
 			// Standard Error: 0
-			.saturating_add((264_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(264_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_democracy.rs
+++ b/runtimes/peregrine/src/weights/pallet_democracy.rs
@@ -53,44 +53,44 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy Blacklist (r:1 w:0)
 	// Storage: Democracy DepositOf (r:0 w:1)
 	fn propose() -> Weight {
-		(64_086_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(64_086_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy DepositOf (r:1 w:1)
 	fn second(s: u32, ) -> Weight {
-		(38_769_000 as Weight)
+		Weight::from_ref_time(38_769_000 as u64)
 			// Standard Error: 0
-			.saturating_add((206_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(206_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vote_new(r: u32, ) -> Weight {
-		(49_982_000 as Weight)
+		Weight::from_ref_time(49_982_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((220_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(220_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vote_existing(r: u32, ) -> Weight {
-		(49_366_000 as Weight)
+		Weight::from_ref_time(49_366_000 as u64)
 			// Standard Error: 0
-			.saturating_add((224_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(224_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy Cancellations (r:1 w:1)
 	fn emergency_cancel() -> Weight {
-		(23_906_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(23_906_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy PublicProps (r:1 w:1)
 	// Storage: Democracy NextExternal (r:1 w:1)
@@ -99,82 +99,82 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy DepositOf (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn blacklist(p: u32, ) -> Weight {
-		(34_381_000 as Weight)
+		Weight::from_ref_time(34_381_000 as u64)
 			// Standard Error: 0
-			.saturating_add((748_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(748_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy Blacklist (r:1 w:0)
 	fn external_propose(v: u32, ) -> Weight {
-		(11_903_000 as Weight)
+		Weight::from_ref_time(11_903_000 as u64)
 			// Standard Error: 0
-			.saturating_add((31_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(v as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_majority() -> Weight {
-		(2_218_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_218_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_default() -> Weight {
-		(2_178_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_178_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:1)
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn fast_track() -> Weight {
-		(25_513_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(25_513_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy Blacklist (r:1 w:1)
 	fn veto_external(v: u32, ) -> Weight {
-		(25_342_000 as Weight)
+		Weight::from_ref_time(25_342_000 as u64)
 			// Standard Error: 0
-			.saturating_add((61_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(61_000 as u64).saturating_mul(v as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy PublicProps (r:1 w:1)
 	// Storage: Democracy DepositOf (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn cancel_proposal(p: u32, ) -> Weight {
-		(53_486_000 as Weight)
+		Weight::from_ref_time(53_486_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((364_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(364_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn cancel_referendum() -> Weight {
-		(15_712_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_712_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn cancel_queued(r: u32, ) -> Weight {
-		(26_060_000 as Weight)
+		Weight::from_ref_time(26_060_000 as u64)
 			// Standard Error: 0
-			.saturating_add((894_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(894_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy LowestUnbaked (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:0)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	fn on_initialize_base(r: u32, ) -> Weight {
-		(10_480_000 as Weight)
+		Weight::from_ref_time(10_480_000 as u64)
 			// Standard Error: 11_000
-			.saturating_add((4_516_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_516_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy LowestUnbaked (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:0)
@@ -183,102 +183,102 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy PublicProps (r:1 w:0)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	fn on_initialize_base_with_launch_period(r: u32, ) -> Weight {
-		(17_021_000 as Weight)
+		Weight::from_ref_time(17_021_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((4_496_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_496_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy VotingOf (r:3 w:3)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn delegate(r: u32, ) -> Weight {
-		(56_025_000 as Weight)
+		Weight::from_ref_time(56_025_000 as u64)
 			// Standard Error: 14_000
-			.saturating_add((6_054_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(6_054_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Democracy VotingOf (r:2 w:2)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	fn undelegate(r: u32, ) -> Weight {
-		(29_138_000 as Weight)
+		Weight::from_ref_time(29_138_000 as u64)
 			// Standard Error: 18_000
-			.saturating_add((5_963_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(5_963_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Democracy PublicProps (r:0 w:1)
 	fn clear_public_proposals() -> Weight {
-		(2_689_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_689_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	fn note_preimage(b: u32, ) -> Weight {
-		(21_539_000 as Weight)
+		Weight::from_ref_time(21_539_000 as u64)
 			// Standard Error: 0
-			.saturating_add((3_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	fn note_imminent_preimage(b: u32, ) -> Weight {
-		(24_509_000 as Weight)
+		Weight::from_ref_time(24_509_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	// Storage: System Account (r:1 w:0)
 	fn reap_preimage(b: u32, ) -> Weight {
-		(26_108_000 as Weight)
+		Weight::from_ref_time(26_108_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_remove(r: u32, ) -> Weight {
-		(32_975_000 as Weight)
+		Weight::from_ref_time(32_975_000 as u64)
 			// Standard Error: 0
-			.saturating_add((118_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(118_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_set(r: u32, ) -> Weight {
-		(31_147_000 as Weight)
+		Weight::from_ref_time(31_147_000 as u64)
 			// Standard Error: 0
-			.saturating_add((196_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(196_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	fn remove_vote(r: u32, ) -> Weight {
-		(16_115_000 as Weight)
+		Weight::from_ref_time(16_115_000 as u64)
 			// Standard Error: 0
-			.saturating_add((199_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(199_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	fn remove_other_vote(r: u32, ) -> Weight {
-		(15_889_000 as Weight)
+		Weight::from_ref_time(15_889_000 as u64)
 			// Standard Error: 0
-			.saturating_add((200_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(200_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_did_lookup.rs
+++ b/runtimes/peregrine/src/weights/pallet_did_lookup.rs
@@ -52,56 +52,56 @@ impl<T: frame_system::Config> pallet_did_lookup::WeightInfo for WeightInfo<T> {
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_sr25519() -> Weight {
-		(117_104_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(117_104_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ed25519() -> Weight {
-		(114_593_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(114_593_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ecdsa() -> Weight {
-		(106_042_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(106_042_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_eth_account() -> Weight {
-		(108_327_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(108_327_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_sender() -> Weight {
-		(58_083_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(58_083_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_sender_association() -> Weight {
-		(39_015_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(39_015_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_account_association() -> Weight {
-		(40_687_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(40_687_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_indices.rs
+++ b/runtimes/peregrine/src/weights/pallet_indices.rs
@@ -50,34 +50,34 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_indices::WeightInfo for WeightInfo<T> {
 	// Storage: Indices Accounts (r:1 w:1)
 	fn claim() -> Weight {
-		(33_833_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_833_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn transfer() -> Weight {
-		(42_192_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(42_192_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	fn free() -> Weight {
-		(35_607_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_607_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn force_transfer() -> Weight {
-		(35_748_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(35_748_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	fn freeze() -> Weight {
-		(40_156_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(40_156_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_inflation.rs
+++ b/runtimes/peregrine/src/weights/pallet_inflation.rs
@@ -50,11 +50,11 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_inflation::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_mint_to_treasury() -> Weight {
-		(30_672_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(30_672_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize_no_action() -> Weight {
-		(259_000 as Weight)
+		Weight::from_ref_time(259_000 as u64)
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_membership.rs
+++ b/runtimes/peregrine/src/weights/pallet_membership.rs
@@ -53,11 +53,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn add_member(m: u32, ) -> Weight {
-		(22_525_000 as Weight)
+		Weight::from_ref_time(22_525_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((217_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(217_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -65,11 +65,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn remove_member(m: u32, ) -> Weight {
-		(27_856_000 as Weight)
+		Weight::from_ref_time(27_856_000 as u64)
 			// Standard Error: 0
-			.saturating_add((56_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(56_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -77,11 +77,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn swap_member(m: u32, ) -> Weight {
-		(28_331_000 as Weight)
+		Weight::from_ref_time(28_331_000 as u64)
 			// Standard Error: 0
-			.saturating_add((71_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(71_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -89,11 +89,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn reset_member(m: u32, ) -> Weight {
-		(27_486_000 as Weight)
+		Weight::from_ref_time(27_486_000 as u64)
 			// Standard Error: 0
-			.saturating_add((197_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(197_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -101,28 +101,28 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn change_key(m: u32, ) -> Weight {
-		(28_469_000 as Weight)
+		Weight::from_ref_time(28_469_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((67_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(67_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:0)
 	// Storage: TechnicalMembership Prime (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn set_prime(m: u32, ) -> Weight {
-		(7_782_000 as Weight)
+		Weight::from_ref_time(7_782_000 as u64)
 			// Standard Error: 0
-			.saturating_add((33_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(33_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TechnicalMembership Prime (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn clear_prime(m: u32, ) -> Weight {
-		(2_766_000 as Weight)
+		Weight::from_ref_time(2_766_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_preimage.rs
+++ b/runtimes/peregrine/src/weights/pallet_preimage.rs
@@ -51,86 +51,86 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for WeightInfo<T> {
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn note_preimage(s: u32, ) -> Weight {
-		(38_993_000 as Weight)
+		Weight::from_ref_time(38_993_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:0)
 	fn note_requested_preimage(s: u32, ) -> Weight {
-		(23_491_000 as Weight)
+		Weight::from_ref_time(23_491_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:0)
 	fn note_no_deposit_preimage(s: u32, ) -> Weight {
-		(21_609_000 as Weight)
+		Weight::from_ref_time(21_609_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_preimage() -> Weight {
-		(47_553_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(47_553_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_no_deposit_preimage() -> Weight {
-		(28_680_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(28_680_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_preimage() -> Weight {
-		(44_418_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(44_418_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_no_deposit_preimage() -> Weight {
-		(26_607_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(26_607_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_unnoted_preimage() -> Weight {
-		(19_019_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(19_019_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_requested_preimage() -> Weight {
-		(6_720_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_720_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_preimage() -> Weight {
-		(27_827_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(27_827_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_unnoted_preimage() -> Weight {
-		(21_077_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(21_077_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn unrequest_multi_referenced_preimage() -> Weight {
-		(6_661_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_661_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_proxy.rs
+++ b/runtimes/peregrine/src/weights/pallet_proxy.rs
@@ -50,92 +50,92 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 	// Storage: Proxy Proxies (r:1 w:0)
 	fn proxy(p: u32, ) -> Weight {
-		(22_325_000 as Weight)
+		Weight::from_ref_time(22_325_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((72_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(72_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:0)
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn proxy_announced(a: u32, p: u32, ) -> Weight {
-		(48_023_000 as Weight)
+		Weight::from_ref_time(48_023_000 as u64)
 			// Standard Error: 10_000
-			.saturating_add((399_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add(Weight::from_ref_time(399_000 as u64).saturating_mul(a as u64))
 			// Standard Error: 12_000
-			.saturating_add((13_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(13_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn remove_announcement(a: u32, _p: u32, ) -> Weight {
-		(34_219_000 as Weight)
+		Weight::from_ref_time(34_219_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((376_000 as Weight).saturating_mul(a as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(376_000 as u64).saturating_mul(a as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reject_announcement(a: u32, _p: u32, ) -> Weight {
-		(34_148_000 as Weight)
+		Weight::from_ref_time(34_148_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((418_000 as Weight).saturating_mul(a as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(418_000 as u64).saturating_mul(a as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:0)
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn announce(a: u32, p: u32, ) -> Weight {
-		(44_814_000 as Weight)
+		Weight::from_ref_time(44_814_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((428_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add(Weight::from_ref_time(428_000 as u64).saturating_mul(a as u64))
 			// Standard Error: 8_000
-			.saturating_add((78_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(78_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn add_proxy(p: u32, ) -> Weight {
-		(38_309_000 as Weight)
+		Weight::from_ref_time(38_309_000 as u64)
 			// Standard Error: 12_000
-			.saturating_add((375_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(375_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn remove_proxy(p: u32, ) -> Weight {
-		(38_994_000 as Weight)
+		Weight::from_ref_time(38_994_000 as u64)
 			// Standard Error: 14_000
-			.saturating_add((309_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(309_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn remove_proxies(p: u32, ) -> Weight {
-		(32_875_000 as Weight)
+		Weight::from_ref_time(32_875_000 as u64)
 			// Standard Error: 9_000
-			.saturating_add((145_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(145_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: unknown [0x3a65787472696e7369635f696e646578] (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn anonymous(p: u32, ) -> Weight {
-		(44_627_000 as Weight)
+		Weight::from_ref_time(44_627_000 as u64)
 			// Standard Error: 15_000
-			.saturating_add((128_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(128_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(34_989_000 as Weight)
+		Weight::from_ref_time(34_989_000 as u64)
 			// Standard Error: 10_000
-			.saturating_add((87_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(87_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_scheduler.rs
+++ b/runtimes/peregrine/src/weights/pallet_scheduler.rs
@@ -53,145 +53,145 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for WeightInfo<T> {
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_periodic_named_resolved(s: u32, ) -> Weight {
-		(16_908_000 as Weight)
+		Weight::from_ref_time(16_908_000 as u64)
 			// Standard Error: 69_000
-			.saturating_add((31_130_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((4 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(31_130_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((4 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named_resolved(s: u32, ) -> Weight {
-		(15_706_000 as Weight)
+		Weight::from_ref_time(15_706_000 as u64)
 			// Standard Error: 55_000
-			.saturating_add((23_499_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(23_499_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn on_initialize_periodic_resolved(s: u32, ) -> Weight {
-		(16_051_000 as Weight)
+		Weight::from_ref_time(16_051_000 as u64)
 			// Standard Error: 19_000
-			.saturating_add((25_704_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(25_704_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn on_initialize_resolved(s: u32, ) -> Weight {
-		(15_912_000 as Weight)
+		Weight::from_ref_time(15_912_000 as u64)
 			// Standard Error: 75_000
-			.saturating_add((21_495_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(21_495_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named_aborted(s: u32, ) -> Weight {
-		(11_281_000 as Weight)
+		Weight::from_ref_time(11_281_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((9_530_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(9_530_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	fn on_initialize_aborted(s: u32, ) -> Weight {
-		(10_158_000 as Weight)
+		Weight::from_ref_time(10_158_000 as u64)
 			// Standard Error: 11_000
-			.saturating_add((4_979_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(4_979_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_periodic_named(s: u32, ) -> Weight {
-		(16_550_000 as Weight)
+		Weight::from_ref_time(16_550_000 as u64)
 			// Standard Error: 86_000
-			.saturating_add((14_921_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(14_921_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	fn on_initialize_periodic(s: u32, ) -> Weight {
-		(15_523_000 as Weight)
+		Weight::from_ref_time(15_523_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((10_247_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(10_247_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named(s: u32, ) -> Weight {
-		(16_497_000 as Weight)
+		Weight::from_ref_time(16_497_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((7_676_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(7_676_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn on_initialize(s: u32, ) -> Weight {
-		(15_892_000 as Weight)
+		Weight::from_ref_time(15_892_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((5_972_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(5_972_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn schedule(s: u32, ) -> Weight {
-		(21_165_000 as Weight)
+		Weight::from_ref_time(21_165_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((156_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(156_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn cancel(s: u32, ) -> Weight {
-		(21_753_000 as Weight)
+		Weight::from_ref_time(21_753_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((878_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(878_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn schedule_named(s: u32, ) -> Weight {
-		(26_011_000 as Weight)
+		Weight::from_ref_time(26_011_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((176_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(176_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn cancel_named(s: u32, ) -> Weight {
-		(23_273_000 as Weight)
+		Weight::from_ref_time(23_273_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((917_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(917_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_session.rs
+++ b/runtimes/peregrine/src/weights/pallet_session.rs
@@ -51,15 +51,15 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:1 w:1)
 	fn set_keys() -> Weight {
-		(21_936_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(21_936_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:0 w:1)
 	fn purge_keys() -> Weight {
-		(17_051_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(17_051_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_timestamp.rs
+++ b/runtimes/peregrine/src/weights/pallet_timestamp.rs
@@ -50,11 +50,11 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 	// Storage: Timestamp Now (r:1 w:1)
 	fn set() -> Weight {
-		(7_004_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(7_004_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_finalize() -> Weight {
-		(4_450_000 as Weight)
+		Weight::from_ref_time(4_450_000 as u64)
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_tips.rs
+++ b/runtimes/peregrine/src/weights/pallet_tips.rs
@@ -51,58 +51,58 @@ impl<T: frame_system::Config> pallet_tips::WeightInfo for WeightInfo<T> {
 	// Storage: Tips Reasons (r:1 w:1)
 	// Storage: Tips Tips (r:1 w:1)
 	fn report_awesome(r: u32, ) -> Weight {
-		(40_507_000 as Weight)
+		Weight::from_ref_time(40_507_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn retract_tip() -> Weight {
-		(38_870_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(38_870_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: Tips Reasons (r:1 w:1)
 	// Storage: Tips Tips (r:0 w:1)
 	fn tip_new(r: u32, t: u32, ) -> Weight {
-		(25_635_000 as Weight)
+		Weight::from_ref_time(25_635_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 0
-			.saturating_add((51_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(51_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: Tips Tips (r:1 w:1)
 	fn tip(t: u32, ) -> Weight {
-		(14_855_000 as Weight)
+		Weight::from_ref_time(14_855_000 as u64)
 			// Standard Error: 0
-			.saturating_add((221_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(221_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: System Account (r:2 w:2)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn close_tip(t: u32, ) -> Weight {
-		(64_407_000 as Weight)
+		Weight::from_ref_time(64_407_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((157_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(157_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn slash_tip(t: u32, ) -> Weight {
-		(22_062_000 as Weight)
+		Weight::from_ref_time(22_062_000 as u64)
 			// Standard Error: 0
-			.saturating_add((13_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(13_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_treasury.rs
+++ b/runtimes/peregrine/src/weights/pallet_treasury.rs
@@ -51,45 +51,45 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for WeightInfo<T> {
 	// Storage: Treasury ProposalCount (r:1 w:1)
 	// Storage: Treasury Proposals (r:0 w:1)
 	fn propose_spend() -> Weight {
-		(35_798_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(35_798_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn reject_proposal() -> Weight {
-		(54_861_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(54_861_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:0)
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn approve_proposal(p: u32, ) -> Weight {
-		(9_689_000 as Weight)
+		Weight::from_ref_time(9_689_000 as u64)
 			// Standard Error: 0
-			.saturating_add((167_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(167_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn remove_approval() -> Weight {
-		(6_554_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_554_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:0)
 	// Storage: Treasury Approvals (r:1 w:1)
 	// Storage: Treasury Proposals (r:100 w:100)
 	fn on_initialize_proposals(p: u32, ) -> Weight {
-		(37_352_000 as Weight)
+		Weight::from_ref_time(37_352_000 as u64)
 			// Standard Error: 26_000
-			.saturating_add((48_967_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(48_967_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(p as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(p as u64)))
 	}
 	fn spend() -> Weight {
-		(151_000 as Weight)
+		Weight::from_ref_time(151_000 as u64)
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_utility.rs
+++ b/runtimes/peregrine/src/weights/pallet_utility.rs
@@ -49,24 +49,24 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 	fn batch(c: u32, ) -> Weight {
-		(12_671_000 as Weight)
+		Weight::from_ref_time(12_671_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((3_956_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(3_956_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		(2_453_000 as Weight)
+		Weight::from_ref_time(2_453_000 as u64)
 	}
 	fn batch_all(c: u32, ) -> Weight {
-		(17_185_000 as Weight)
+		Weight::from_ref_time(17_185_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_222_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_222_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		(13_684_000 as Weight)
+		Weight::from_ref_time(13_684_000 as u64)
 	}
 	fn force_batch(c: u32, ) -> Weight {
-		(12_678_000 as Weight)
+		Weight::from_ref_time(12_678_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((3_938_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(3_938_000 as u64).saturating_mul(c as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_vesting.rs
+++ b/runtimes/peregrine/src/weights/pallet_vesting.rs
@@ -51,91 +51,91 @@ impl<T: frame_system::Config> pallet_vesting::WeightInfo for WeightInfo<T> {
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vest_locked(l: u32, s: u32, ) -> Weight {
-		(44_681_000 as Weight)
+		Weight::from_ref_time(44_681_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((84_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(84_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 3_000
-			.saturating_add((145_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(145_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vest_unlocked(l: u32, s: u32, ) -> Weight {
-		(45_867_000 as Weight)
+		Weight::from_ref_time(45_867_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((51_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(51_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 2_000
-			.saturating_add((102_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(102_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn vest_other_locked(l: u32, s: u32, ) -> Weight {
-		(43_825_000 as Weight)
+		Weight::from_ref_time(43_825_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((86_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(86_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 2_000
-			.saturating_add((131_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(131_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn vest_other_unlocked(l: u32, s: u32, ) -> Weight {
-		(43_633_000 as Weight)
+		Weight::from_ref_time(43_633_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((78_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(78_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 2_000
-			.saturating_add((114_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(114_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vested_transfer(l: u32, _s: u32, ) -> Weight {
-		(78_819_000 as Weight)
+		Weight::from_ref_time(78_819_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((98_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(98_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	// Storage: Balances Locks (r:1 w:1)
 	fn force_vested_transfer(l: u32, _s: u32, ) -> Weight {
-		(76_055_000 as Weight)
+		Weight::from_ref_time(76_055_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((83_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(83_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn not_unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
-		(43_915_000 as Weight)
+		Weight::from_ref_time(43_915_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((106_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(106_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 3_000
-			.saturating_add((167_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(167_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
-		(44_315_000 as Weight)
+		Weight::from_ref_time(44_315_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((95_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(95_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 3_000
-			.saturating_add((153_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(153_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/pallet_web3_names.rs
+++ b/runtimes/peregrine/src/weights/pallet_web3_names.rs
@@ -53,47 +53,47 @@ impl<T: frame_system::Config> pallet_web3_names::WeightInfo for WeightInfo<T> {
 	// Storage: Web3Names Banned (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn claim(n: u32, ) -> Weight {
-		(46_312_000 as Weight)
+		Weight::from_ref_time(46_312_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((25_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(25_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Names (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn release_by_owner() -> Weight {
-		(41_790_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(41_790_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn reclaim_deposit(n: u32, ) -> Weight {
-		(39_385_000 as Weight)
+		Weight::from_ref_time(39_385_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((36_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(36_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn ban(n: u32, ) -> Weight {
-		(42_203_000 as Weight)
+		Weight::from_ref_time(42_203_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((72_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(72_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	fn unban(n: u32, ) -> Weight {
-		(19_773_000 as Weight)
+		Weight::from_ref_time(19_773_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((45_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(45_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/peregrine/src/weights/parachain_staking.rs
+++ b/runtimes/peregrine/src/weights/parachain_staking.rs
@@ -50,22 +50,22 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking Round (r:1 w:0)
 	fn on_initialize_no_action() -> Weight {
-		(3_723_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(3_723_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn on_initialize_round_update() -> Weight {
-		(18_017_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(18_017_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
 	// Storage: ParachainStaking InflationConfig (r:1 w:1)
 	fn on_initialize_new_year() -> Weight {
-		(31_315_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(31_315_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
@@ -74,38 +74,38 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_network_rewards() -> Weight {
-		(62_389_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(62_389_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: ParachainStaking ForceNewRound (r:0 w:1)
 	fn force_new_round() -> Weight {
-		(2_001_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_001_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking InflationConfig (r:0 w:1)
 	fn set_inflation() -> Weight {
-		(15_420_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_420_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:59 w:0)
 	fn set_max_selected_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 14_000
-			.saturating_add((7_981_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(7_981_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 25_000
-			.saturating_add((6_588_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(6_588_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(n as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn set_blocks_per_round() -> Weight {
-		(17_980_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(17_980_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -118,15 +118,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn force_remove_candidate(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 31_000
-			.saturating_add((3_278_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(3_278_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 52_000
-			.saturating_add((21_750_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(25 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(21_750_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(25 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:0)
@@ -139,13 +139,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn join_candidates(n: u32, m: u32, ) -> Weight {
-		(17_637_000 as Weight)
+		Weight::from_ref_time(17_637_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((1_338_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_338_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 10_000
-			.saturating_add((2_867_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(2_867_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(10 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -153,26 +153,26 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn init_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(43_107_000 as Weight)
+		Weight::from_ref_time(43_107_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_585_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_585_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 11_000
-			.saturating_add((3_718_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(21 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(3_718_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(21 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 8_000
-			.saturating_add((1_354_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_354_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 13_000
-			.saturating_add((2_731_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(2_731_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Round (r:1 w:0)
@@ -183,15 +183,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: System Digest (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn execute_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 25_000
-			.saturating_add((2_586_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_586_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 41_000
-			.saturating_add((20_179_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(20_179_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -202,15 +202,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 5_000
-			.saturating_add((1_577_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_577_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 11_000
-			.saturating_add((3_284_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(3_284_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 46_000
-			.saturating_add((976_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+			.saturating_add(Weight::from_ref_time(976_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
@@ -218,13 +218,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 5_000
-			.saturating_add((1_469_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_469_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 12_000
-			.saturating_add((2_996_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(2_996_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
@@ -237,13 +237,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn join_delegators(n: u32, m: u32, ) -> Weight {
-		(31_078_000 as Weight)
+		Weight::from_ref_time(31_078_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_699_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_699_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 10_000
-			.saturating_add((2_770_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(11 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(Weight::from_ref_time(2_770_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(11 as u64))
+			.saturating_add(T::DbWeight::get().writes(8 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -254,15 +254,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(13_240_000 as Weight)
+		Weight::from_ref_time(13_240_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((1_666_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_666_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 16_000
-			.saturating_add((2_759_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(2_759_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 68_000
-			.saturating_add((766_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(766_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -271,13 +271,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_569_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_569_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 10_000
-			.saturating_add((2_722_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_722_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -286,13 +286,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
-		(2_496_000 as Weight)
+		Weight::from_ref_time(2_496_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((1_619_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_619_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 12_000
-			.saturating_add((2_730_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_730_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -301,27 +301,27 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn leave_delegators(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 7_000
-			.saturating_add((1_632_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_632_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 15_000
-			.saturating_add((2_908_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_908_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_unstaked(u: u32, ) -> Weight {
-		(34_358_000 as Weight)
+		Weight::from_ref_time(34_358_000 as u64)
 			// Standard Error: 10_000
-			.saturating_add((551_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(551_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:0 w:1)
 	fn set_max_candidate_stake() -> Weight {
-		(14_071_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(14_071_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -5,7 +5,7 @@ name = "spiritnet-runtime"
 version = "1.7.2"
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"]}
@@ -19,8 +19,8 @@ serde = {version = "1.0.142", optional = true, features = ["derive"]}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}
-frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # KILT pallets & primitives
 attestation = {path = "../../pallets/attestation", default-features = false}
@@ -37,67 +37,67 @@ parachain-staking = {path = "../../pallets/parachain-staking", default-features 
 runtime-common = {path = "../../runtimes/common", default-features = false}
 
 # Substrate dependencies
-sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+sp-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-arithmetic = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-block-builder = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-consensus-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-inherents = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-offchain = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-std = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-transaction-pool = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+sp-version = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
-frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-collective = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-democracy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-indices = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-preimage = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-proxy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-randomness-collective-flip = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-scheduler = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-tips = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-treasury = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
-pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27"}
+frame-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-executive = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-aura = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-balances = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-collective = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-democracy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-indices = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-membership = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-preimage = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-proxy = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-randomness-collective-flip = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-scheduler = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-session = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-timestamp = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-tips = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-transaction-payment = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-treasury = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-utility = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
+pallet-vesting = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master"}
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
-parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27"}
+cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-core = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-timestamp = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+cumulus-primitives-utility = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
+parachain-info = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "master"}
 
 # Polkadot dependencies
-pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
-xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27"}
+pallet-xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+polkadot-parachain = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-builder = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
+xcm-executor = {git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master"}
 
 # Benchmarking
-cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
-frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
+cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, optional = true, branch = "master"}
+frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master"}
 
 # Runtime tests
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27", optional = true}
+frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master", optional = true}
 
 [features]
 default = ["std"]

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -15,7 +15,7 @@ smallvec = "1.8.0"
 static_assertions = "1.1.0"
 
 hex-literal = {version = "0.3.4", optional = true}
-serde = {version = "1.0.142", optional = true, features = ["derive"]}
+serde = {version = "1.0.144", optional = true, features = ["derive"]}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -202,8 +202,8 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
-	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT / 4;
+	pub const ReservedXcmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = constants::MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {

--- a/runtimes/spiritnet/src/weights/attestation.rs
+++ b/runtimes/spiritnet/src/weights/attestation.rs
@@ -52,28 +52,28 @@ impl<T: frame_system::Config> attestation::WeightInfo for WeightInfo<T> {
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add() -> Weight {
-		(38_475_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(38_475_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	fn revoke() -> Weight {
-		(22_274_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(22_274_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn remove() -> Weight {
-		(37_192_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(37_192_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Attestation Attestations (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reclaim_deposit() -> Weight {
-		(37_573_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(37_573_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/ctype.rs
+++ b/runtimes/spiritnet/src/weights/ctype.rs
@@ -51,10 +51,10 @@ impl<T: frame_system::Config> ctype::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:2 w:2)
 	// Storage: Ctype Ctypes (r:1 w:1)
 	fn add(l: u32, ) -> Weight {
-		(55_554_000 as Weight)
+		Weight::from_ref_time(55_554_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/delegation.rs
+++ b/runtimes/spiritnet/src/weights/delegation.rs
@@ -53,81 +53,81 @@ impl<T: frame_system::Config> delegation::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationNodes (r:0 w:1)
 	fn create_hierarchy() -> Weight {
-		(41_504_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(41_504_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn add_delegation() -> Weight {
-		(48_679_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(48_679_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_root_child(r: u32, _c: u32, ) -> Weight {
-		(20_626_000 as Weight)
+		Weight::from_ref_time(20_626_000 as u64)
 			// Standard Error: 30_000
-			.saturating_add((14_142_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(14_142_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:6 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn revoke_delegation_leaf(_r: u32, c: u32, ) -> Weight {
-		(34_444_000 as Weight)
+		Weight::from_ref_time(34_444_000 as u64)
 			// Standard Error: 24_000
-			.saturating_add((4_926_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_926_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:1 w:1)
 	fn remove_delegation(r: u32, ) -> Weight {
-		(55_382_000 as Weight)
+		Weight::from_ref_time(55_382_000 as u64)
 			// Standard Error: 46_000
-			.saturating_add((24_306_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(24_306_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Delegation DelegationHierarchies (r:0 w:1)
 	fn reclaim_deposit(r: u32, ) -> Weight {
-		(47_460_000 as Weight)
+		Weight::from_ref_time(47_460_000 as u64)
 			// Standard Error: 56_000
-			.saturating_add((24_567_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(24_567_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:1 w:0)
 	// Storage: Delegation DelegationHierarchies (r:1 w:0)
 	fn can_attest() -> Weight {
-		(12_951_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+		Weight::from_ref_time(12_951_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_revoke(c: u32, ) -> Weight {
-		(8_132_000 as Weight)
+		Weight::from_ref_time(8_132_000 as u64)
 			// Standard Error: 22_000
-			.saturating_add((4_897_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(4_897_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Delegation DelegationNodes (r:2 w:0)
 	fn can_remove(c: u32, ) -> Weight {
-		(8_055_000 as Weight)
+		Weight::from_ref_time(8_055_000 as u64)
 			// Standard Error: 19_000
-			.saturating_add((4_947_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(4_947_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(c as u64)))
 	}
 }

--- a/runtimes/spiritnet/src/weights/did.rs
+++ b/runtimes/spiritnet/src/weights/did.rs
@@ -54,14 +54,14 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_ed25519_keys(n: u32, c: u32, ) -> Weight {
-		(139_062_000 as Weight)
+		Weight::from_ref_time(139_062_000 as u64)
 			// Standard Error: 22_000
-			.saturating_add((1_602_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_602_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 8_000
-			.saturating_add((6_002_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(6_002_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Storage: Did DidBlacklist (r:1 w:0)
@@ -69,14 +69,14 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_sr25519_keys(n: u32, c: u32, ) -> Weight {
-		(142_600_000 as Weight)
+		Weight::from_ref_time(142_600_000 as u64)
 			// Standard Error: 27_000
-			.saturating_add((1_587_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_587_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 10_000
-			.saturating_add((6_483_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(6_483_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Storage: Did DidBlacklist (r:1 w:0)
@@ -84,217 +84,217 @@ impl<T: frame_system::Config> did::WeightInfo for WeightInfo<T> {
 	// Storage: Did DidEndpointsCount (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:25)
 	fn create_ecdsa_keys(n: u32, c: u32, ) -> Weight {
-		(132_375_000 as Weight)
+		Weight::from_ref_time(132_375_000 as u64)
 			// Standard Error: 37_000
-			.saturating_add((1_497_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_497_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 14_000
-			.saturating_add((5_600_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(5_600_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did Did (r:1 w:1)
 	// Storage: Did DidBlacklist (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:1)
 	fn delete(c: u32, ) -> Weight {
-		(35_098_000 as Weight)
+		Weight::from_ref_time(35_098_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_080_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_080_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did Did (r:1 w:1)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did DidBlacklist (r:0 w:1)
 	// Storage: Did ServiceEndpoints (r:0 w:1)
 	fn reclaim_deposit(c: u32, ) -> Weight {
-		(37_604_000 as Weight)
+		Weight::from_ref_time(37_604_000 as u64)
 			// Standard Error: 5_000
-			.saturating_add((1_114_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(Weight::from_ref_time(1_114_000 as u64).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(c as u64)))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_ed25519_key() -> Weight {
-		(81_034_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(81_034_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_sr25519_key() -> Weight {
-		(83_045_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(83_045_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn submit_did_call_ecdsa_key() -> Weight {
-		(72_485_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(72_485_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_authentication_key() -> Weight {
-		(37_241_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(37_241_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_authentication_key() -> Weight {
-		(37_473_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(37_473_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_authentication_key() -> Weight {
-		(37_498_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(37_498_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_delegation_key() -> Weight {
-		(36_794_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_794_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_delegation_key() -> Weight {
-		(36_806_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_806_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_delegation_key() -> Weight {
-		(36_349_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_349_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_delegation_key() -> Weight {
-		(34_065_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_065_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_delegation_key() -> Weight {
-		(34_433_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_433_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_delegation_key() -> Weight {
-		(33_775_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_775_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ed25519_attestation_key() -> Weight {
-		(36_696_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_696_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_sr25519_attestation_key() -> Weight {
-		(36_951_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_951_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn set_ecdsa_attestation_key() -> Weight {
-		(36_352_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_352_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_attestation_key() -> Weight {
-		(34_194_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_194_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_attestation_key() -> Weight {
-		(34_191_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_191_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_attestation_key() -> Weight {
-		(34_179_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_179_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_ed25519_key_agreement_key() -> Weight {
-		(35_896_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_896_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_sr25519_key_agreement_key() -> Weight {
-		(36_379_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_379_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn add_ecdsa_key_agreement_key() -> Weight {
-		(36_056_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(36_056_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ed25519_key_agreement_key() -> Weight {
-		(34_384_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_384_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_sr25519_key_agreement_key() -> Weight {
-		(34_868_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_868_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:1)
 	fn remove_ecdsa_key_agreement_key() -> Weight {
-		(34_643_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(34_643_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	// Storage: Did ServiceEndpoints (r:1 w:1)
 	fn add_service_endpoint() -> Weight {
-		(37_784_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(37_784_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Did ServiceEndpoints (r:1 w:1)
 	// Storage: Did DidEndpointsCount (r:1 w:1)
 	fn remove_service_endpoint() -> Weight {
-		(31_680_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(31_680_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_sr25519(l: u32, ) -> Weight {
-		(66_507_000 as Weight)
+		Weight::from_ref_time(66_507_000 as u64)
 			// Standard Error: 0
-			.saturating_add((4_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_ed25519(l: u32, ) -> Weight {
-		(64_220_000 as Weight)
+		Weight::from_ref_time(64_220_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Did Did (r:1 w:0)
 	fn signature_verification_ecdsa(l: u32, ) -> Weight {
-		(55_901_000 as Weight)
+		Weight::from_ref_time(55_901_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/frame_system.rs
+++ b/runtimes/spiritnet/src/weights/frame_system.rs
@@ -49,39 +49,39 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 	fn remark(_b: u32, ) -> Weight {
-		(860_000 as Weight)
+		Weight::from_ref_time(860_000 as u64)
 	}
 	fn remark_with_event(b: u32, ) -> Weight {
-		(13_814_000 as Weight)
+		Weight::from_ref_time(13_814_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 	}
 	// Storage: System Digest (r:1 w:1)
 	// Storage: unknown [0x3a686561707061676573] (r:0 w:1)
 	fn set_heap_pages() -> Weight {
-		(4_811_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(4_811_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn set_storage(i: u32, ) -> Weight {
-		(1_312_000 as Weight)
+		Weight::from_ref_time(1_312_000 as u64)
 			// Standard Error: 0
-			.saturating_add((615_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(615_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_storage(i: u32, ) -> Weight {
-		(1_523_000 as Weight)
+		Weight::from_ref_time(1_523_000 as u64)
 			// Standard Error: 0
-			.saturating_add((448_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(Weight::from_ref_time(448_000 as u64).saturating_mul(i as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(i as u64)))
 	}
 	// Storage: Skipped Metadata (r:0 w:0)
 	fn kill_prefix(p: u32, ) -> Weight {
-		(4_533_000 as Weight)
+		Weight::from_ref_time(4_533_000 as u64)
 			// Standard Error: 0
-			.saturating_add((841_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(841_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_balances.rs
+++ b/runtimes/spiritnet/src/weights/pallet_balances.rs
@@ -50,44 +50,44 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:2 w:2)
 	fn transfer() -> Weight {
-		(68_568_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(68_568_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_keep_alive() -> Weight {
-		(43_526_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(43_526_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_creating() -> Weight {
-		(27_315_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(27_315_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn set_balance_killing() -> Weight {
-		(32_217_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(32_217_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:3 w:3)
 	fn force_transfer() -> Weight {
-		(68_361_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(68_361_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn transfer_all() -> Weight {
-		(52_521_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(52_521_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	fn force_unreserve() -> Weight {
-		(25_515_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(25_515_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_collective.rs
+++ b/runtimes/spiritnet/src/weights/pallet_collective.rs
@@ -53,36 +53,36 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council Voting (r:100 w:100)
 	// Storage: Council Prime (r:0 w:1)
 	fn set_members(m: u32, n: u32, p: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 9_000
-			.saturating_add((12_196_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(12_196_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 9_000
-			.saturating_add((144_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(144_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 9_000
-			.saturating_add((16_975_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(16_975_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(p as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 	// Storage: Council Members (r:1 w:0)
 	fn execute(b: u32, m: u32, ) -> Weight {
-		(20_038_000 as Weight)
+		Weight::from_ref_time(20_038_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((29_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(29_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:0)
 	fn propose_execute(b: u32, m: u32, ) -> Weight {
-		(24_048_000 as Weight)
+		Weight::from_ref_time(24_048_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((57_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(Weight::from_ref_time(57_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:1)
@@ -90,52 +90,52 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council ProposalCount (r:1 w:1)
 	// Storage: Council Voting (r:0 w:1)
 	fn propose_proposed(b: u32, m: u32, p: u32, ) -> Weight {
-		(33_247_000 as Weight)
+		Weight::from_ref_time(33_247_000 as u64)
 			// Standard Error: 0
-			.saturating_add((4_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(4_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 0
-			.saturating_add((26_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(26_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((299_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(299_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council Voting (r:1 w:1)
 	fn vote(m: u32, ) -> Weight {
-		(39_774_000 as Weight)
+		Weight::from_ref_time(39_774_000 as u64)
 			// Standard Error: 0
-			.saturating_add((73_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(73_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn close_early_disapproved(m: u32, p: u32, ) -> Weight {
-		(35_659_000 as Weight)
+		Weight::from_ref_time(35_659_000 as u64)
 			// Standard Error: 0
-			.saturating_add((54_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(54_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((272_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(272_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
 	// Storage: Council ProposalOf (r:1 w:1)
 	// Storage: Council Proposals (r:1 w:1)
 	fn close_early_approved(b: u32, m: u32, p: u32, ) -> Weight {
-		(46_908_000 as Weight)
+		Weight::from_ref_time(46_908_000 as u64)
 			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(1_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 1_000
-			.saturating_add((53_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(53_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 1_000
-			.saturating_add((287_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(287_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
@@ -143,13 +143,13 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn close_disapproved(m: u32, p: u32, ) -> Weight {
-		(39_434_000 as Weight)
+		Weight::from_ref_time(39_434_000 as u64)
 			// Standard Error: 0
-			.saturating_add((60_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(60_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 0
-			.saturating_add((271_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(271_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Voting (r:1 w:1)
 	// Storage: Council Members (r:1 w:0)
@@ -157,24 +157,24 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 	// Storage: Council ProposalOf (r:1 w:1)
 	// Storage: Council Proposals (r:1 w:1)
 	fn close_approved(b: u32, m: u32, p: u32, ) -> Weight {
-		(51_226_000 as Weight)
+		Weight::from_ref_time(51_226_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
 			// Standard Error: 1_000
-			.saturating_add((47_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(47_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 1_000
-			.saturating_add((285_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(285_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Council Proposals (r:1 w:1)
 	// Storage: Council Voting (r:0 w:1)
 	// Storage: Council ProposalOf (r:0 w:1)
 	fn disapprove_proposal(p: u32, ) -> Weight {
-		(21_329_000 as Weight)
+		Weight::from_ref_time(21_329_000 as u64)
 			// Standard Error: 0
-			.saturating_add((266_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(266_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_democracy.rs
+++ b/runtimes/spiritnet/src/weights/pallet_democracy.rs
@@ -53,44 +53,44 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy Blacklist (r:1 w:0)
 	// Storage: Democracy DepositOf (r:0 w:1)
 	fn propose() -> Weight {
-		(65_143_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(65_143_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy DepositOf (r:1 w:1)
 	fn second(s: u32, ) -> Weight {
-		(38_681_000 as Weight)
+		Weight::from_ref_time(38_681_000 as u64)
 			// Standard Error: 0
-			.saturating_add((200_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(200_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vote_new(r: u32, ) -> Weight {
-		(48_387_000 as Weight)
+		Weight::from_ref_time(48_387_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((235_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(235_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vote_existing(r: u32, ) -> Weight {
-		(49_051_000 as Weight)
+		Weight::from_ref_time(49_051_000 as u64)
 			// Standard Error: 0
-			.saturating_add((227_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(227_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy Cancellations (r:1 w:1)
 	fn emergency_cancel() -> Weight {
-		(24_542_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(24_542_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy PublicProps (r:1 w:1)
 	// Storage: Democracy NextExternal (r:1 w:1)
@@ -99,82 +99,82 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy DepositOf (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn blacklist(p: u32, ) -> Weight {
-		(34_083_000 as Weight)
+		Weight::from_ref_time(34_083_000 as u64)
 			// Standard Error: 0
-			.saturating_add((742_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(742_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy Blacklist (r:1 w:0)
 	fn external_propose(v: u32, ) -> Weight {
-		(11_903_000 as Weight)
+		Weight::from_ref_time(11_903_000 as u64)
 			// Standard Error: 0
-			.saturating_add((29_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(29_000 as u64).saturating_mul(v as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_majority() -> Weight {
-		(2_243_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_243_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:0 w:1)
 	fn external_propose_default() -> Weight {
-		(2_180_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_180_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:1)
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn fast_track() -> Weight {
-		(25_465_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(25_465_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy NextExternal (r:1 w:1)
 	// Storage: Democracy Blacklist (r:1 w:1)
 	fn veto_external(v: u32, ) -> Weight {
-		(25_812_000 as Weight)
+		Weight::from_ref_time(25_812_000 as u64)
 			// Standard Error: 0
-			.saturating_add((59_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(59_000 as u64).saturating_mul(v as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy PublicProps (r:1 w:1)
 	// Storage: Democracy DepositOf (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn cancel_proposal(p: u32, ) -> Weight {
-		(53_701_000 as Weight)
+		Weight::from_ref_time(53_701_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((354_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(354_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:0 w:1)
 	fn cancel_referendum() -> Weight {
-		(15_909_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_909_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn cancel_queued(r: u32, ) -> Weight {
-		(26_079_000 as Weight)
+		Weight::from_ref_time(26_079_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((936_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(936_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy LowestUnbaked (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:0)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	fn on_initialize_base(r: u32, ) -> Weight {
-		(10_580_000 as Weight)
+		Weight::from_ref_time(10_580_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_502_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_502_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy LowestUnbaked (r:1 w:1)
 	// Storage: Democracy ReferendumCount (r:1 w:0)
@@ -183,102 +183,102 @@ impl<T: frame_system::Config> pallet_democracy::WeightInfo for WeightInfo<T> {
 	// Storage: Democracy PublicProps (r:1 w:0)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:0)
 	fn on_initialize_base_with_launch_period(r: u32, ) -> Weight {
-		(17_380_000 as Weight)
+		Weight::from_ref_time(17_380_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_501_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(4_501_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy VotingOf (r:3 w:3)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn delegate(r: u32, ) -> Weight {
-		(55_115_000 as Weight)
+		Weight::from_ref_time(55_115_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((6_037_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(6_037_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Democracy VotingOf (r:2 w:2)
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	fn undelegate(r: u32, ) -> Weight {
-		(29_855_000 as Weight)
+		Weight::from_ref_time(29_855_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((5_940_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(Weight::from_ref_time(5_940_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(r as u64)))
 	}
 	// Storage: Democracy PublicProps (r:0 w:1)
 	fn clear_public_proposals() -> Weight {
-		(2_889_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_889_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	fn note_preimage(b: u32, ) -> Weight {
-		(21_577_000 as Weight)
+		Weight::from_ref_time(21_577_000 as u64)
 			// Standard Error: 0
-			.saturating_add((3_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(3_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	fn note_imminent_preimage(b: u32, ) -> Weight {
-		(24_786_000 as Weight)
+		Weight::from_ref_time(24_786_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy Preimages (r:1 w:1)
 	// Storage: System Account (r:1 w:0)
 	fn reap_preimage(b: u32, ) -> Weight {
-		(26_755_000 as Weight)
+		Weight::from_ref_time(26_755_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(b as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_remove(r: u32, ) -> Weight {
-		(33_290_000 as Weight)
+		Weight::from_ref_time(33_290_000 as u64)
 			// Standard Error: 0
-			.saturating_add((111_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(111_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy VotingOf (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_set(r: u32, ) -> Weight {
-		(30_871_000 as Weight)
+		Weight::from_ref_time(30_871_000 as u64)
 			// Standard Error: 0
-			.saturating_add((199_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(199_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	fn remove_vote(r: u32, ) -> Weight {
-		(15_910_000 as Weight)
+		Weight::from_ref_time(15_910_000 as u64)
 			// Standard Error: 0
-			.saturating_add((199_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(199_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Democracy ReferendumInfoOf (r:1 w:1)
 	// Storage: Democracy VotingOf (r:1 w:1)
 	fn remove_other_vote(r: u32, ) -> Weight {
-		(15_776_000 as Weight)
+		Weight::from_ref_time(15_776_000 as u64)
 			// Standard Error: 0
-			.saturating_add((204_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(204_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_did_lookup.rs
+++ b/runtimes/spiritnet/src/weights/pallet_did_lookup.rs
@@ -52,56 +52,56 @@ impl<T: frame_system::Config> pallet_did_lookup::WeightInfo for WeightInfo<T> {
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_sr25519() -> Weight {
-		(116_943_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(116_943_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ed25519() -> Weight {
-		(113_639_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(113_639_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_account_multisig_ecdsa() -> Weight {
-		(105_172_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(105_172_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_eth_account() -> Weight {
-		(107_737_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(107_737_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:2)
 	fn associate_sender() -> Weight {
-		(57_996_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(57_996_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_sender_association() -> Weight {
-		(39_395_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(39_395_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: DidLookup ConnectedDids (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DidLookup ConnectedAccounts (r:0 w:1)
 	fn remove_account_association() -> Weight {
-		(40_723_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(40_723_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_indices.rs
+++ b/runtimes/spiritnet/src/weights/pallet_indices.rs
@@ -50,34 +50,34 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_indices::WeightInfo for WeightInfo<T> {
 	// Storage: Indices Accounts (r:1 w:1)
 	fn claim() -> Weight {
-		(33_463_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(33_463_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn transfer() -> Weight {
-		(42_729_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(42_729_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	fn free() -> Weight {
-		(35_762_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(35_762_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn force_transfer() -> Weight {
-		(35_636_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(35_636_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Indices Accounts (r:1 w:1)
 	fn freeze() -> Weight {
-		(40_105_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(40_105_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_inflation.rs
+++ b/runtimes/spiritnet/src/weights/pallet_inflation.rs
@@ -50,11 +50,11 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_inflation::WeightInfo for WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_mint_to_treasury() -> Weight {
-		(30_864_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(30_864_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_initialize_no_action() -> Weight {
-		(263_000 as Weight)
+		Weight::from_ref_time(263_000 as u64)
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_membership.rs
+++ b/runtimes/spiritnet/src/weights/pallet_membership.rs
@@ -53,11 +53,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn add_member(m: u32, ) -> Weight {
-		(22_804_000 as Weight)
+		Weight::from_ref_time(22_804_000 as u64)
 			// Standard Error: 11_000
-			.saturating_add((223_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(223_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -65,11 +65,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn remove_member(m: u32, ) -> Weight {
-		(27_011_000 as Weight)
+		Weight::from_ref_time(27_011_000 as u64)
 			// Standard Error: 0
-			.saturating_add((46_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(46_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -77,11 +77,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn swap_member(m: u32, ) -> Weight {
-		(27_119_000 as Weight)
+		Weight::from_ref_time(27_119_000 as u64)
 			// Standard Error: 0
-			.saturating_add((53_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(53_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -89,11 +89,11 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn reset_member(m: u32, ) -> Weight {
-		(26_139_000 as Weight)
+		Weight::from_ref_time(26_139_000 as u64)
 			// Standard Error: 0
-			.saturating_add((204_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(204_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:1)
 	// Storage: TechnicalCommittee Proposals (r:1 w:0)
@@ -101,28 +101,28 @@ impl<T: frame_system::Config> pallet_membership::WeightInfo for WeightInfo<T> {
 	// Storage: TechnicalCommittee Members (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn change_key(m: u32, ) -> Weight {
-		(28_045_000 as Weight)
+		Weight::from_ref_time(28_045_000 as u64)
 			// Standard Error: 0
-			.saturating_add((62_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(62_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: TechnicalMembership Members (r:1 w:0)
 	// Storage: TechnicalMembership Prime (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn set_prime(m: u32, ) -> Weight {
-		(7_675_000 as Weight)
+		Weight::from_ref_time(7_675_000 as u64)
 			// Standard Error: 0
-			.saturating_add((31_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(31_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TechnicalMembership Prime (r:0 w:1)
 	// Storage: TechnicalCommittee Prime (r:0 w:1)
 	fn clear_prime(m: u32, ) -> Weight {
-		(3_004_000 as Weight)
+		Weight::from_ref_time(3_004_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_preimage.rs
+++ b/runtimes/spiritnet/src/weights/pallet_preimage.rs
@@ -51,86 +51,86 @@ impl<T: frame_system::Config> pallet_preimage::WeightInfo for WeightInfo<T> {
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn note_preimage(s: u32, ) -> Weight {
-		(39_701_000 as Weight)
+		Weight::from_ref_time(39_701_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:0)
 	fn note_requested_preimage(s: u32, ) -> Weight {
-		(23_922_000 as Weight)
+		Weight::from_ref_time(23_922_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:0)
 	fn note_no_deposit_preimage(s: u32, ) -> Weight {
-		(21_458_000 as Weight)
+		Weight::from_ref_time(21_458_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_preimage() -> Weight {
-		(48_908_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(48_908_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unnote_no_deposit_preimage() -> Weight {
-		(28_896_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(28_896_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_preimage() -> Weight {
-		(45_762_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(45_762_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_no_deposit_preimage() -> Weight {
-		(27_024_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(27_024_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_unnoted_preimage() -> Weight {
-		(19_427_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(19_427_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn request_requested_preimage() -> Weight {
-		(7_106_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(7_106_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_preimage() -> Weight {
-		(29_270_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(29_270_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:0 w:1)
 	fn unrequest_unnoted_preimage() -> Weight {
-		(21_064_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(21_064_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn unrequest_multi_referenced_preimage() -> Weight {
-		(6_825_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_825_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_proxy.rs
+++ b/runtimes/spiritnet/src/weights/pallet_proxy.rs
@@ -50,92 +50,92 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 	// Storage: Proxy Proxies (r:1 w:0)
 	fn proxy(p: u32, ) -> Weight {
-		(21_011_000 as Weight)
+		Weight::from_ref_time(21_011_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((185_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(Weight::from_ref_time(185_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:0)
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn proxy_announced(a: u32, p: u32, ) -> Weight {
-		(44_314_000 as Weight)
+		Weight::from_ref_time(44_314_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((536_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add(Weight::from_ref_time(536_000 as u64).saturating_mul(a as u64))
 			// Standard Error: 7_000
-			.saturating_add((126_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(126_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn remove_announcement(a: u32, _p: u32, ) -> Weight {
-		(32_029_000 as Weight)
+		Weight::from_ref_time(32_029_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((462_000 as Weight).saturating_mul(a as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(462_000 as u64).saturating_mul(a as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn reject_announcement(a: u32, _p: u32, ) -> Weight {
-		(32_803_000 as Weight)
+		Weight::from_ref_time(32_803_000 as u64)
 			// Standard Error: 12_000
-			.saturating_add((399_000 as Weight).saturating_mul(a as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(399_000 as u64).saturating_mul(a as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:0)
 	// Storage: Proxy Announcements (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn announce(a: u32, p: u32, ) -> Weight {
-		(43_487_000 as Weight)
+		Weight::from_ref_time(43_487_000 as u64)
 			// Standard Error: 8_000
-			.saturating_add((405_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add(Weight::from_ref_time(405_000 as u64).saturating_mul(a as u64))
 			// Standard Error: 9_000
-			.saturating_add((24_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(24_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn add_proxy(p: u32, ) -> Weight {
-		(36_963_000 as Weight)
+		Weight::from_ref_time(36_963_000 as u64)
 			// Standard Error: 10_000
-			.saturating_add((196_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(196_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn remove_proxy(p: u32, ) -> Weight {
-		(36_855_000 as Weight)
+		Weight::from_ref_time(36_855_000 as u64)
 			// Standard Error: 17_000
-			.saturating_add((226_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(226_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn remove_proxies(p: u32, ) -> Weight {
-		(31_428_000 as Weight)
+		Weight::from_ref_time(31_428_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((174_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(174_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: unknown [0x3a65787472696e7369635f696e646578] (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn anonymous(p: u32, ) -> Weight {
-		(41_835_000 as Weight)
+		Weight::from_ref_time(41_835_000 as u64)
 			// Standard Error: 24_000
-			.saturating_add((135_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(135_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(33_364_000 as Weight)
+		Weight::from_ref_time(33_364_000 as u64)
 			// Standard Error: 8_000
-			.saturating_add((60_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(60_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_scheduler.rs
+++ b/runtimes/spiritnet/src/weights/pallet_scheduler.rs
@@ -53,145 +53,145 @@ impl<T: frame_system::Config> pallet_scheduler::WeightInfo for WeightInfo<T> {
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_periodic_named_resolved(s: u32, ) -> Weight {
-		(16_582_000 as Weight)
+		Weight::from_ref_time(16_582_000 as u64)
 			// Standard Error: 9_000
-			.saturating_add((30_119_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((4 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(30_119_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((4 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named_resolved(s: u32, ) -> Weight {
-		(15_117_000 as Weight)
+		Weight::from_ref_time(15_117_000 as u64)
 			// Standard Error: 14_000
-			.saturating_add((23_014_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(23_014_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn on_initialize_periodic_resolved(s: u32, ) -> Weight {
-		(14_930_000 as Weight)
+		Weight::from_ref_time(14_930_000 as u64)
 			// Standard Error: 94_000
-			.saturating_add((26_006_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(26_006_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Preimage PreimageFor (r:1 w:1)
 	// Storage: Preimage StatusFor (r:1 w:1)
 	fn on_initialize_resolved(s: u32, ) -> Weight {
-		(15_944_000 as Weight)
+		Weight::from_ref_time(15_944_000 as u64)
 			// Standard Error: 25_000
-			.saturating_add((21_044_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(21_044_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named_aborted(s: u32, ) -> Weight {
-		(11_119_000 as Weight)
+		Weight::from_ref_time(11_119_000 as u64)
 			// Standard Error: 11_000
-			.saturating_add((9_144_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(9_144_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Preimage PreimageFor (r:1 w:0)
 	fn on_initialize_aborted(s: u32, ) -> Weight {
-		(10_038_000 as Weight)
+		Weight::from_ref_time(10_038_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((5_022_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(5_022_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_periodic_named(s: u32, ) -> Weight {
-		(15_669_000 as Weight)
+		Weight::from_ref_time(15_669_000 as u64)
 			// Standard Error: 18_000
-			.saturating_add((14_595_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(14_595_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:2 w:2)
 	fn on_initialize_periodic(s: u32, ) -> Weight {
-		(14_997_000 as Weight)
+		Weight::from_ref_time(14_997_000 as u64)
 			// Standard Error: 14_000
-			.saturating_add((10_203_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(10_203_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(s as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn on_initialize_named(s: u32, ) -> Weight {
-		(15_694_000 as Weight)
+		Weight::from_ref_time(15_694_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((7_671_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(Weight::from_ref_time(7_671_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(s as u64)))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn on_initialize(s: u32, ) -> Weight {
-		(15_005_000 as Weight)
+		Weight::from_ref_time(15_005_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((5_998_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(5_998_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn schedule(s: u32, ) -> Weight {
-		(20_276_000 as Weight)
+		Weight::from_ref_time(20_276_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((159_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(159_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Scheduler Agenda (r:1 w:1)
 	// Storage: Scheduler Lookup (r:0 w:1)
 	fn cancel(s: u32, ) -> Weight {
-		(20_897_000 as Weight)
+		Weight::from_ref_time(20_897_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((937_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(937_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn schedule_named(s: u32, ) -> Weight {
-		(25_199_000 as Weight)
+		Weight::from_ref_time(25_199_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((181_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(181_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Scheduler Lookup (r:1 w:1)
 	// Storage: Scheduler Agenda (r:1 w:1)
 	fn cancel_named(s: u32, ) -> Weight {
-		(22_673_000 as Weight)
+		Weight::from_ref_time(22_673_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((998_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(998_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_session.rs
+++ b/runtimes/spiritnet/src/weights/pallet_session.rs
@@ -51,15 +51,15 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:1 w:1)
 	fn set_keys() -> Weight {
-		(21_418_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(21_418_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Session NextKeys (r:1 w:1)
 	// Storage: Session KeyOwner (r:0 w:1)
 	fn purge_keys() -> Weight {
-		(16_419_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(16_419_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_timestamp.rs
+++ b/runtimes/spiritnet/src/weights/pallet_timestamp.rs
@@ -50,11 +50,11 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 	// Storage: Timestamp Now (r:1 w:1)
 	fn set() -> Weight {
-		(6_990_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_990_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn on_finalize() -> Weight {
-		(4_251_000 as Weight)
+		Weight::from_ref_time(4_251_000 as u64)
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_tips.rs
+++ b/runtimes/spiritnet/src/weights/pallet_tips.rs
@@ -51,58 +51,58 @@ impl<T: frame_system::Config> pallet_tips::WeightInfo for WeightInfo<T> {
 	// Storage: Tips Reasons (r:1 w:1)
 	// Storage: Tips Tips (r:1 w:1)
 	fn report_awesome(r: u32, ) -> Weight {
-		(40_570_000 as Weight)
+		Weight::from_ref_time(40_570_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(r as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(r as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn retract_tip() -> Weight {
-		(39_413_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(39_413_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: Tips Reasons (r:1 w:1)
 	// Storage: Tips Tips (r:0 w:1)
 	fn tip_new(r: u32, t: u32, ) -> Weight {
-		(25_679_000 as Weight)
+		Weight::from_ref_time(25_679_000 as u64)
 			// Standard Error: 0
-			.saturating_add((2_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(Weight::from_ref_time(2_000 as u64).saturating_mul(r as u64))
 			// Standard Error: 0
-			.saturating_add((43_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(43_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: Tips Tips (r:1 w:1)
 	fn tip(t: u32, ) -> Weight {
-		(15_006_000 as Weight)
+		Weight::from_ref_time(15_006_000 as u64)
 			// Standard Error: 0
-			.saturating_add((234_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(234_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: TipsMembership Members (r:1 w:0)
 	// Storage: System Account (r:2 w:2)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn close_tip(t: u32, ) -> Weight {
-		(64_454_000 as Weight)
+		Weight::from_ref_time(64_454_000 as u64)
 			// Standard Error: 0
-			.saturating_add((184_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(184_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Tips Tips (r:1 w:1)
 	// Storage: Tips Reasons (r:0 w:1)
 	fn slash_tip(t: u32, ) -> Weight {
-		(21_757_000 as Weight)
+		Weight::from_ref_time(21_757_000 as u64)
 			// Standard Error: 0
-			.saturating_add((19_000 as Weight).saturating_mul(t as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(19_000 as u64).saturating_mul(t as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_treasury.rs
+++ b/runtimes/spiritnet/src/weights/pallet_treasury.rs
@@ -51,45 +51,45 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for WeightInfo<T> {
 	// Storage: Treasury ProposalCount (r:1 w:1)
 	// Storage: Treasury Proposals (r:0 w:1)
 	fn propose_spend() -> Weight {
-		(33_993_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		Weight::from_ref_time(33_993_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn reject_proposal() -> Weight {
-		(51_599_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(51_599_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Treasury Proposals (r:1 w:0)
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn approve_proposal(p: u32, ) -> Weight {
-		(9_601_000 as Weight)
+		Weight::from_ref_time(9_601_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((169_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(169_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Treasury Approvals (r:1 w:1)
 	fn remove_approval() -> Weight {
-		(6_252_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(6_252_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:1 w:0)
 	// Storage: Treasury Approvals (r:1 w:1)
 	// Storage: Treasury Proposals (r:100 w:100)
 	fn on_initialize_proposals(p: u32, ) -> Weight {
-		(35_269_000 as Weight)
+		Weight::from_ref_time(35_269_000 as u64)
 			// Standard Error: 42_000
-			.saturating_add((46_504_000 as Weight).saturating_mul(p as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(p as Weight)))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(p as Weight)))
+			.saturating_add(Weight::from_ref_time(46_504_000 as u64).saturating_mul(p as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().reads((3 as u64).saturating_mul(p as u64)))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((3 as u64).saturating_mul(p as u64)))
 	}
 	fn spend() -> Weight {
-		(151_000 as Weight)
+		Weight::from_ref_time(151_000 as u64)
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_utility.rs
+++ b/runtimes/spiritnet/src/weights/pallet_utility.rs
@@ -49,24 +49,24 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 	fn batch(c: u32, ) -> Weight {
-		(12_999_000 as Weight)
+		Weight::from_ref_time(12_999_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_094_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_094_000 as u64).saturating_mul(c as u64))
 	}
 	fn as_derivative() -> Weight {
-		(2_600_000 as Weight)
+		Weight::from_ref_time(2_600_000 as u64)
 	}
 	fn batch_all(c: u32, ) -> Weight {
-		(17_564_000 as Weight)
+		Weight::from_ref_time(17_564_000 as u64)
 			// Standard Error: 3_000
-			.saturating_add((4_447_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_447_000 as u64).saturating_mul(c as u64))
 	}
 	fn dispatch_as() -> Weight {
-		(13_814_000 as Weight)
+		Weight::from_ref_time(13_814_000 as u64)
 	}
 	fn force_batch(c: u32, ) -> Weight {
-		(12_779_000 as Weight)
+		Weight::from_ref_time(12_779_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((4_112_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(Weight::from_ref_time(4_112_000 as u64).saturating_mul(c as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_vesting.rs
+++ b/runtimes/spiritnet/src/weights/pallet_vesting.rs
@@ -51,89 +51,89 @@ impl<T: frame_system::Config> pallet_vesting::WeightInfo for WeightInfo<T> {
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vest_locked(l: u32, s: u32, ) -> Weight {
-		(42_785_000 as Weight)
+		Weight::from_ref_time(42_785_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((107_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(107_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 3_000
-			.saturating_add((171_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(171_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vest_unlocked(l: u32, s: u32, ) -> Weight {
-		(44_923_000 as Weight)
+		Weight::from_ref_time(44_923_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((58_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(58_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 3_000
-			.saturating_add((105_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(105_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn vest_other_locked(l: u32, s: u32, ) -> Weight {
-		(41_986_000 as Weight)
+		Weight::from_ref_time(41_986_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((113_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(113_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 4_000
-			.saturating_add((157_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(157_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn vest_other_unlocked(_l: u32, s: u32, ) -> Weight {
-		(49_088_000 as Weight)
+		Weight::from_ref_time(49_088_000 as u64)
 			// Standard Error: 30_000
-			.saturating_add((85_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(85_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn vested_transfer(l: u32, _s: u32, ) -> Weight {
-		(74_393_000 as Weight)
+		Weight::from_ref_time(74_393_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((107_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(107_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	// Storage: Balances Locks (r:1 w:1)
 	fn force_vested_transfer(l: u32, _s: u32, ) -> Weight {
-		(72_731_000 as Weight)
+		Weight::from_ref_time(72_731_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((132_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(132_000 as u64).saturating_mul(l as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn not_unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
-		(43_881_000 as Weight)
+		Weight::from_ref_time(43_881_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((124_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(124_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 7_000
-			.saturating_add((225_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(225_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Vesting Vesting (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
-		(48_538_000 as Weight)
+		Weight::from_ref_time(48_538_000 as u64)
 			// Standard Error: 23_000
-			.saturating_add((20_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(Weight::from_ref_time(20_000 as u64).saturating_mul(l as u64))
 			// Standard Error: 44_000
-			.saturating_add((229_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(229_000 as u64).saturating_mul(s as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/pallet_web3_names.rs
+++ b/runtimes/spiritnet/src/weights/pallet_web3_names.rs
@@ -53,47 +53,47 @@ impl<T: frame_system::Config> pallet_web3_names::WeightInfo for WeightInfo<T> {
 	// Storage: Web3Names Banned (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn claim(n: u32, ) -> Weight {
-		(46_594_000 as Weight)
+		Weight::from_ref_time(46_594_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((10_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(10_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(4 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Names (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn release_by_owner() -> Weight {
-		(41_228_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(41_228_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn reclaim_deposit(n: u32, ) -> Weight {
-		(39_996_000 as Weight)
+		Weight::from_ref_time(39_996_000 as u64)
 			// Standard Error: 2_000
-			.saturating_add((8_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(8_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(2 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	// Storage: Web3Names Owner (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Web3Names Names (r:0 w:1)
 	fn ban(n: u32, ) -> Weight {
-		(42_763_000 as Weight)
+		Weight::from_ref_time(42_763_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((58_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(58_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: Web3Names Banned (r:1 w:1)
 	fn unban(n: u32, ) -> Weight {
-		(19_648_000 as Weight)
+		Weight::from_ref_time(19_648_000 as u64)
 			// Standard Error: 1_000
-			.saturating_add((37_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(Weight::from_ref_time(37_000 as u64).saturating_mul(n as u64))
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/spiritnet/src/weights/parachain_staking.rs
+++ b/runtimes/spiritnet/src/weights/parachain_staking.rs
@@ -50,22 +50,22 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking Round (r:1 w:0)
 	fn on_initialize_no_action() -> Weight {
-		(3_693_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+		Weight::from_ref_time(3_693_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn on_initialize_round_update() -> Weight {
-		(16_988_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(16_988_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
 	// Storage: ParachainStaking InflationConfig (r:1 w:1)
 	fn on_initialize_new_year() -> Weight {
-		(30_201_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		Weight::from_ref_time(30_201_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	// Storage: ParachainStaking LastRewardReduction (r:1 w:1)
@@ -74,38 +74,38 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn on_initialize_network_rewards() -> Weight {
-		(59_372_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		Weight::from_ref_time(59_372_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: ParachainStaking ForceNewRound (r:0 w:1)
 	fn force_new_round() -> Weight {
-		(2_040_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(2_040_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking InflationConfig (r:0 w:1)
 	fn set_inflation() -> Weight {
-		(15_234_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(15_234_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:59 w:0)
 	fn set_max_selected_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 26_000
-			.saturating_add((7_832_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(7_832_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 44_000
-			.saturating_add((6_420_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(Weight::from_ref_time(6_420_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(n as u64)))
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: ParachainStaking Round (r:1 w:1)
 	fn set_blocks_per_round() -> Weight {
-		(17_824_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(17_824_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -118,15 +118,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn force_remove_candidate(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 34_000
-			.saturating_add((2_953_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_953_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 57_000
-			.saturating_add((21_593_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(25 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(21_593_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(25 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:0)
@@ -139,13 +139,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn join_candidates(n: u32, m: u32, ) -> Weight {
-		(18_166_000 as Weight)
+		Weight::from_ref_time(18_166_000 as u64)
 			// Standard Error: 4_000
-			.saturating_add((1_324_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_324_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 9_000
-			.saturating_add((2_825_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(2_825_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(10 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:17 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
@@ -153,26 +153,26 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn init_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(48_782_000 as Weight)
+		Weight::from_ref_time(48_782_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_455_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_455_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 10_000
-			.saturating_add((3_702_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(21 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(3_702_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(21 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 7_000
-			.saturating_add((1_217_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_217_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 12_000
-			.saturating_add((2_701_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(2_701_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Round (r:1 w:0)
@@ -183,15 +183,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: System Digest (r:1 w:1)
 	// Storage: ParachainStaking CounterForCandidatePool (r:1 w:1)
 	fn execute_leave_candidates(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 23_000
-			.saturating_add((2_616_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(2_616_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 38_000
-			.saturating_add((20_346_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
+			.saturating_add(Weight::from_ref_time(20_346_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(m as u64)))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
+			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(m as u64)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -202,15 +202,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_622_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_622_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 12_000
-			.saturating_add((3_378_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(3_378_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 49_000
-			.saturating_add((1_386_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+			.saturating_add(Weight::from_ref_time(1_386_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(6 as u64))
 	}
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
@@ -218,13 +218,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
-		(0 as Weight)
+		Weight::from_ref_time(0 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_458_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_458_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 13_000
-			.saturating_add((3_010_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(Weight::from_ref_time(3_010_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	// Storage: System Account (r:1 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
@@ -237,13 +237,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn join_delegators(n: u32, m: u32, ) -> Weight {
-		(29_422_000 as Weight)
+		Weight::from_ref_time(29_422_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_661_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_661_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 14_000
-			.saturating_add((2_847_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(11 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(Weight::from_ref_time(2_847_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(11 as u64))
+			.saturating_add(T::DbWeight::get().writes(8 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -254,15 +254,15 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
-		(10_618_000 as Weight)
+		Weight::from_ref_time(10_618_000 as u64)
 			// Standard Error: 6_000
-			.saturating_add((1_683_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_683_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 14_000
-			.saturating_add((2_894_000 as Weight).saturating_mul(m as Weight))
+			.saturating_add(Weight::from_ref_time(2_894_000 as u64).saturating_mul(m as u64))
 			// Standard Error: 60_000
-			.saturating_add((642_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+			.saturating_add(Weight::from_ref_time(642_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -271,13 +271,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
-		(2_224_000 as Weight)
+		Weight::from_ref_time(2_224_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((1_593_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_593_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 16_000
-			.saturating_add((2_703_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_703_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -286,13 +286,13 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
-		(10_893_000 as Weight)
+		Weight::from_ref_time(10_893_000 as u64)
 			// Standard Error: 26_000
-			.saturating_add((1_704_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_704_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 59_000
-			.saturating_add((2_449_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_449_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	// Storage: ParachainStaking CandidatePool (r:1 w:1)
@@ -301,27 +301,27 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
 	fn leave_delegators(n: u32, m: u32, ) -> Weight {
-		(703_000 as Weight)
+		Weight::from_ref_time(703_000 as u64)
 			// Standard Error: 7_000
-			.saturating_add((1_686_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(Weight::from_ref_time(1_686_000 as u64).saturating_mul(n as u64))
 			// Standard Error: 17_000
-			.saturating_add((2_839_000 as Weight).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+			.saturating_add(Weight::from_ref_time(2_839_000 as u64).saturating_mul(m as u64))
+			.saturating_add(T::DbWeight::get().reads(6 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: ParachainStaking Unstaking (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn unlock_unstaked(u: u32, ) -> Weight {
-		(33_561_000 as Weight)
+		Weight::from_ref_time(33_561_000 as u64)
 			// Standard Error: 10_000
-			.saturating_add((581_000 as Weight).saturating_mul(u as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(Weight::from_ref_time(581_000 as u64).saturating_mul(u as u64))
+			.saturating_add(T::DbWeight::get().reads(3 as u64))
+			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:0 w:1)
 	fn set_max_candidate_stake() -> Weight {
-		(13_922_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		Weight::from_ref_time(13_922_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 }

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -5,7 +5,7 @@ name = "mashnet-node-runtime"
 version = "1.7.2"
 
 [build-dependencies]
-substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27"}
+substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "master"}
 
 [dependencies]
 bitflags = {default-features = false, version = "1.3.2"}
@@ -29,45 +29,45 @@ runtime-common = {path = "../../runtimes/common", default-features = false}
 
 # RPC
 did-rpc-runtime-api = {path = "../../rpc/did/runtime-api", default-features = false}
-frame-system-rpc-runtime-api = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-transaction-payment-rpc-runtime-api = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system-rpc-runtime-api = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-transaction-payment-rpc-runtime-api = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # Benchmarking
-frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.27"}
+frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master"}
 
 # Substrate
-frame-benchmarking = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-executive = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-aura = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-authorship = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-balances = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-grandpa = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-indices = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-proxy = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-randomness-collective-flip = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-session = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-sudo = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-timestamp = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-transaction-payment = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-pallet-utility = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-api = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-arithmetic = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-block-builder = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-consensus-aura = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-inherents = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-io = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-offchain = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-session = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-transaction-pool = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-version = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-benchmarking = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-executive = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-aura = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-authorship = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-balances = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-grandpa = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-indices = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-proxy = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-randomness-collective-flip = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-session = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-sudo = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-timestamp = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-transaction-payment = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+pallet-utility = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-api = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-arithmetic = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-block-builder = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-consensus-aura = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-inherents = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-io = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-offchain = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-session = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-transaction-pool = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-version = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
 
 # Runtime tests
-frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27", optional = true}
+frame-try-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "master", optional = true}
 
 [features]
 default = ["std"]

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.17"
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 
 hex-literal = {version = "0.3.4", optional = true}
-serde = {version = "1.0.142", optional = true, features = ["derive"]}
+serde = {version = "1.0.144", optional = true, features = ["derive"]}
 
 # kilt functionality
 attestation = {default-features = false, path = "../../pallets/attestation"}

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -11,14 +11,14 @@ codec = {package = "parity-scale-codec", version = "3.1.5", default-features = f
 scale-info = {version = "2.1.1", default-features = false, features = ["derive"]}
 serde = {version = "1.0.136", optional = true, features = ["derive"]}
 
-cumulus-primitives-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/cumulus"}
-frame-support = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-frame-system = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-polkadot-core-primitives = {branch = "release-v0.9.27", default-features = false, git = "https://github.com/paritytech/polkadot"}
-sp-core = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-runtime = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-sp-std = {branch = "polkadot-v0.9.27", default-features = false, git = "https://github.com/paritytech/substrate"}
-xcm = {branch = "release-v0.9.27", default-features = false, git = "https://github.com/paritytech/polkadot"}
+cumulus-primitives-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/cumulus"}
+frame-support = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+frame-system = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+polkadot-core-primitives = {branch = "master", default-features = false, git = "https://github.com/paritytech/polkadot"}
+sp-core = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-runtime = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+sp-std = {branch = "master", default-features = false, git = "https://github.com/paritytech/substrate"}
+xcm = {branch = "master", default-features = false, git = "https://github.com/paritytech/polkadot"}
 
 [dev-dependencies]
 serde_json = "1.0.83"

--- a/support/src/relay.rs
+++ b/support/src/relay.rs
@@ -25,12 +25,11 @@
 #![allow(clippy::unused_unit)]
 
 use codec::{Decode, Encode, FullCodec};
-use frame_support::{traits::Get, weights::Weight};
+use frame_support::{traits::Get};
 use frame_system::Config;
 use scale_info::TypeInfo;
 use sp_std::{boxed::Box, marker::PhantomData, prelude::*};
 use xcm::latest::prelude::*;
-
 pub use cumulus_primitives_core::ParaId;
 
 use crate::traits::RelayCallBuilder;
@@ -83,7 +82,7 @@ where
 		RelayChainCall::Registrar(RegistrarCall::Swap(id, other))
 	}
 
-	fn finalize_call_into_xcm_message(call: Vec<u8>, extra_fee: Self::Balance, weight: Weight) -> Xcm<()> {
+	fn finalize_call_into_xcm_message(call: Vec<u8>, extra_fee: Self::Balance, weight: u64) -> Xcm<()> {
 		let asset = MultiAsset {
 			id: Concrete(MultiLocation::here()),
 			fun: Fungibility::Fungible(extra_fee),

--- a/support/src/traits.rs
+++ b/support/src/traits.rs
@@ -18,7 +18,6 @@
 
 use codec::{EncodeLike, FullCodec};
 use cumulus_primitives_core::ParaId;
-use frame_support::weights::Weight;
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 use xcm::latest::Xcm;
@@ -110,5 +109,5 @@ pub trait RelayCallBuilder {
 	///   `weight` and `debt`.
 	/// * weight: The weight limit used for XCM.
 	/// * debt: The weight limit used to process the call.
-	fn finalize_call_into_xcm_message(call: Vec<u8>, extra_fee: Self::Balance, weight: Weight) -> Xcm<()>;
+	fn finalize_call_into_xcm_message(call: Vec<u8>, extra_fee: Self::Balance, weight: u64) -> Xcm<()>;
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2173

Working branch against Substrate/Polkadot/Cumulus master upstream with goal:

* Converts 1d weight (u64) to two 2d struct
```
pub struct Weight {
	/// The computational time used to execute some logic based on reference hardware.
	ref_time: u64,
	/// The size of the proof needed to execute some logic.
	proof_size: u64,
}
```

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
