### PR TITLE
fix: allow reclaiming ethereum linked account

### DIFF
--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -286,10 +286,9 @@ pub mod pallet {
 		/// - Writes: ConnectedDids
 		/// # </weight>
 		#[pallet::weight(<T as Config>::WeightInfo::remove_sender_association())]
-		pub fn reclaim_deposit(origin: OriginFor<T>, account: AccountIdOf<T>) -> DispatchResult {
+		pub fn reclaim_deposit(origin: OriginFor<T>, account: LinkableAccountId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			let account: LinkableAccountId = account.into();
 			let record = ConnectedDids::<T>::get(&account).ok_or(Error::<T>::AssociationNotFound)?;
 			ensure!(record.deposit.owner == who, Error::<T>::NotAuthorized);
 			Self::remove_association(account)

--- a/pallets/pallet-did-lookup/src/tests.rs
+++ b/pallets/pallet-did-lookup/src/tests.rs
@@ -362,7 +362,10 @@ fn test_reclaim_deposit() {
 		.with_connections(vec![(ACCOUNT_01, DID_01, ACCOUNT_00)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(DidLookup::reclaim_deposit(Origin::signed(ACCOUNT_01), ACCOUNT_00));
+			assert_ok!(DidLookup::reclaim_deposit(
+				Origin::signed(ACCOUNT_01),
+				ACCOUNT_00.into()
+			));
 			assert_eq!(Balances::reserved_balance(ACCOUNT_01), 0);
 		});
 }
@@ -375,7 +378,7 @@ fn test_reclaim_deposit_not_authorized() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				DidLookup::reclaim_deposit(Origin::signed(ACCOUNT_00), ACCOUNT_00),
+				DidLookup::reclaim_deposit(Origin::signed(ACCOUNT_00), ACCOUNT_00.into()),
 				Error::<Test>::NotAuthorized
 			);
 			assert_eq!(


### PR DESCRIPTION
## fixes NO TICKET


## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
