### PR TITLE
ci: Rotate DOCKER_AUTH_CONFIG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,9 +59,7 @@ build:
   script:
     - echo -n $CI_REGISTRY_TOKEN | docker login -u "$CI_REGISTRY_USER" --password-stdin $CI_REGISTRY
     - aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_REGISTRY
-    - export ENCODED_PASSWORD= `echo -n "AWS:$(aws ecr get-login-password --region $AWS_DEFAULT_REGION)" | base64`
-    - export PAYLOAD=`jq -n --arg userpass $ENCODED_PASSWORD '{"auths": {"'$AWS_REGISTRY'": {"auth": $userpass}}}'`
-    - curl --request PUT --header "PRIVATE-TOKEN:$TOKEN" "https://gitlab.com/api/v4/projects/26909212/variables/DOCKER_AUTH_CONFIG" --form "value=$PAYLOAD"
+    - ./.maintain/docker-auth-config.sh
 
     - ./.maintain/build-image.sh build
     - "if [[ ! -z ${CI_COMMIT_BRANCH} ]]; then ./.maintain/push-image.sh build ${CI_COMMIT_SHORT_SHA}; fi"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,9 @@ build:
   script:
     - echo -n $CI_REGISTRY_TOKEN | docker login -u "$CI_REGISTRY_USER" --password-stdin $CI_REGISTRY
     - aws ecr get-login-password | docker login --username AWS --password-stdin $AWS_REGISTRY
+    - export ENCODED_PASSWORD= `echo -n "AWS:$(aws ecr get-login-password --region $AWS_DEFAULT_REGION)" | base64`
+    - export PAYLOAD=`jq -n --arg userpass $ENCODED_PASSWORD '{"auths": {"'$AWS_REGISTRY'": {"auth": $userpass}}}'`
+    - curl --request PUT --header "PRIVATE-TOKEN:$TOKEN" "https://gitlab.com/api/v4/projects/26909212/variables/DOCKER_AUTH_CONFIG" --form "value=$PAYLOAD"
 
     - ./.maintain/build-image.sh build
     - "if [[ ! -z ${CI_COMMIT_BRANCH} ]]; then ./.maintain/push-image.sh build ${CI_COMMIT_SHORT_SHA}; fi"

--- a/.maintain/docker-auth-config.sh
+++ b/.maintain/docker-auth-config.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export ENCODED_PASSWORD= `echo -n "AWS:$(aws ecr get-login-password --region $AWS_DEFAULT_REGION)" | base64`
-export PAYLOAD=`jq -n --arg userpass $ENCODED_PASSWORD '{"auths": {"'$AWS_REGISTRY'": {"auth": $userpass}}}'`
+export PAYLOAD=`jq -n --arg userpass "$(echo -n "AWS:$(aws ecr get-login-password --region $AWS_DEFAULT_REGION)" | base64)" '{"auths": {"'$AWS_REGISTRY'": {"auth": $userpass}}}'`
 
 curl --request PUT --header "PRIVATE-TOKEN:$TOKEN" "https://gitlab.com/api/v4/projects/26909212/variables/DOCKER_AUTH_CONFIG" --form "value=$PAYLOAD"

--- a/.maintain/docker-auth-config.sh
+++ b/.maintain/docker-auth-config.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export ENCODED_PASSWORD= `echo -n "AWS:$(aws ecr get-login-password --region $AWS_DEFAULT_REGION)" | base64`
+export PAYLOAD=`jq -n --arg userpass $ENCODED_PASSWORD '{"auths": {"'$AWS_REGISTRY'": {"auth": $userpass}}}'`
+
+curl --request PUT --header "PRIVATE-TOKEN:$TOKEN" "https://gitlab.com/api/v4/projects/26909212/variables/DOCKER_AUTH_CONFIG" --form "value=$PAYLOAD"


### PR DESCRIPTION
## fixes NO TICKET
Gitlab authenticates with the private registry using `DOCKER_AUTH_CONFIG` that expires every 12 hours hence needs to be rotated ahead of wasm building stage.


## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
