### PR TITLE
ci: upgrade and add jq

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ test-features:
 
 build:
   image:
-    name: kiltprotocol/kilt-ci:2.2.38
+    name: kiltprotocol/kilt-ci:2.7.31
     entrypoint: [""]
   stage: build
   only:

--- a/.maintain/ci.Dockerfile
+++ b/.maintain/ci.Dockerfile
@@ -1,3 +1,5 @@
-FROM amazon/aws-cli:2.2.38
+FROM amazon/aws-cli:2.7.31
+RUN yum install -y curl \
+  && yum install -y jq
 
 RUN amazon-linux-extras install docker

--- a/.maintain/ci.Dockerfile
+++ b/.maintain/ci.Dockerfile
@@ -1,5 +1,4 @@
 FROM amazon/aws-cli:2.7.31
-RUN yum install -y curl \
-  && yum install -y jq
 
-RUN amazon-linux-extras install docker
+RUN amazon-linux-extras install docker \
+    && yum install -y jq


### PR DESCRIPTION
## fixes KILTProtocol/ticket#2144
Upgrades the kilt ci to latest stable version , adds jq and push to  [kiltprotocol repository](https://hub.docker.com/r/kiltprotocol/kilt-ci/tags)
## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
