### PR TITLE
fix: serde encoding for LinkableAccountId

### DIFF
--- a/pallets/pallet-did-lookup/src/linkable_account.rs
+++ b/pallets/pallet-did-lookup/src/linkable_account.rs
@@ -23,6 +23,7 @@ use sp_runtime::AccountId32;
 use crate::account::AccountId20;
 
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo)]
 pub enum LinkableAccountId {
 	AccountId20(AccountId20),


### PR DESCRIPTION
After spending a considerable amount of time for making the DID RPC using the new linkable accounts work, I stumbled across the following conversation: https://github.com/polkadot-js/api/issues/3367.

TL;DR: the polkadot api library expects any serde stuff to follow a `camelCase` capitalization. This PR fixes that for the `LinkableAccountId` type. I tested with the latest type definitions, and it now seems to be working fine.