### PR TITLE
chore: bump development spec_version to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "attestation"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "ctype",
  "frame-benchmarking",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "clone-runtime"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "ctype"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "delegation"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "attestation",
  "bitflags",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "did"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "ctype",
  "env_logger",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "did-rpc-runtime-api"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "did",
  "kilt-support",
@@ -3613,7 +3613,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kilt-asset-dids"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "base58",
  "frame-support",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-parachain"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "clap",
  "clone-runtime",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-support"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "attestation",
  "bitflags",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "node-common"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "kilt-support",
  "public-credentials",
@@ -5532,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-lookup"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-inflation"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-web3-names"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6248,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6456,7 +6456,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "peregrine-runtime"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "attestation",
  "ctype",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "public-credentials"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "base58",
  "ctype",
@@ -8016,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "public-credentials-rpc"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8028,7 +8028,7 @@ dependencies = [
 
 [[package]]
 name = "public-credentials-runtime-api"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "attestation",
  "frame-support",
@@ -10827,7 +10827,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spiritnet-runtime"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "attestation",
  "ctype",

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -4,7 +4,7 @@ description = "Asset DIDs and related structs, suitable for no_std environments.
 edition = "2021"
 name = "kilt-asset-dids"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.2"
+version = "1.8.0"
 
 [dependencies]
 # External dependencies

--- a/nodes/common/Cargo.toml
+++ b/nodes/common/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 description = "Set of common utility types, functions, and traits that all node executables can tap into."
 name = "node-common"
-version = "1.7.2"
+version = "1.8.0"
 
 [dependencies]
 # Client dependencies

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -4,7 +4,7 @@ build = "build.rs"
 description = "KILT parachain"
 edition = "2021"
 name = "kilt-parachain"
-version = "1.7.4"
+version = "1.8.0"
 
 [[bin]]
 name = "kilt-parachain"

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["KILT <info@kilt.io>"]
 build = "build.rs"
 edition = "2021"
 name = "mashnet-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [[bin]]
 name = "mashnet-node"

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding and revoking attestations."
 edition = "2021"
 name = "attestation"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding CTypes."
 edition = "2021"
 name = "ctype"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables creating and revoking root nodes of delegation hierarchie
 edition = "2021"
 name = "delegation"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding and removing decentralized identifiers (DIDs)."
 edition = "2021"
 name = "did"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-did-lookup/Cargo.toml
+++ b/pallets/pallet-did-lookup/Cargo.toml
@@ -4,7 +4,7 @@ description = "Lookup the DID for a blockchain account."
 edition = "2021"
 name = "pallet-did-lookup"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-inflation/Cargo.toml
+++ b/pallets/pallet-inflation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Substrate pallet issueing a pre-configured amount of tokens to th
 edition = "2021"
 name = "pallet-inflation"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-web3-names/Cargo.toml
+++ b/pallets/pallet-web3-names/Cargo.toml
@@ -4,7 +4,7 @@ description = "Unique Web3 nicknames for KILT DIDs."
 edition = "2021"
 name = "pallet-web3-names"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["KILT <info@kilt.io>"]
 description = "Parachain parachain-staking pallet for collator delegation and selection as well as reward distribution"
 edition = "2021"
 name = "parachain-staking"
-version = "1.7.4"
+version = "1.8.0"
 
 [dev-dependencies]
 pallet-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/pallets/public-credentials/Cargo.toml
+++ b/pallets/public-credentials/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding and revoking public credentials."
 edition = "2021"
 name = "public-credentials"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.2"
+version = "1.8.0"
 
 [dev-dependencies]
 ctype = {features = ["mock"], path = "../ctype"}

--- a/rpc/did/runtime-api/Cargo.toml
+++ b/rpc/did/runtime-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "did-rpc-runtime-api"
-version = "1.7.4"
+version = "1.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rpc/public-credentials/Cargo.toml
+++ b/rpc/public-credentials/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "public-credentials-rpc"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -18,7 +18,7 @@ sp-blockchain = {git = "https://github.com/paritytech/substrate", default-featur
 sp-runtime = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.29"}
 
 # Internal runtime dependencies
-public-credentials-runtime-api = {version = "1.7.2", path = "./runtime-api"}
+public-credentials-runtime-api = {version = "1.8.0", path = "./runtime-api"}
 
 [features]
 default = ["std"]

--- a/rpc/public-credentials/runtime-api/Cargo.toml
+++ b/rpc/public-credentials/runtime-api/Cargo.toml
@@ -4,7 +4,7 @@ description = "Runtime APIs for dealing with public credentials."
 edition = "2021"
 name = "public-credentials-runtime-api"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.2"
+version = "1.8.0"
 
 [dependencies]
 # External dependencies

--- a/runtimes/clone/Cargo.toml
+++ b/runtimes/clone/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "clone-runtime"
-version = "1.7.4"
+version = "1.8.0"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/runtimes/clone/src/lib.rs
+++ b/runtimes/clone/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("KILT"),
 	impl_name: create_runtime_str!("KILT"),
 	authoring_version: 0,
-	spec_version: 10740,
+	spec_version: 10800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "runtime-common"
-version = "1.7.4"
+version = "1.8.0"
 
 [dev-dependencies]
 sp-io = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "peregrine-runtime"
-version = "1.7.4"
+version = "1.8.0"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -88,7 +88,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10740,
+	spec_version: 10800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "spiritnet-runtime"
-version = "1.7.4"
+version = "1.8.0"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -88,7 +88,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kilt-spiritnet"),
 	impl_name: create_runtime_str!("kilt-spiritnet"),
 	authoring_version: 1,
-	spec_version: 10740,
+	spec_version: 10800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "mashnet-node-runtime"
-version = "1.7.4"
+version = "1.8.0"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29"}

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10740,
+	spec_version: 10800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -4,7 +4,7 @@ description = "Shared traits and structs used across the KILT pallets"
 edition = "2021"
 name = "kilt-support"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.7.4"
+version = "1.8.0"
 
 [dependencies]
 # External dependencies


### PR DESCRIPTION
Right now, it is very very **very** hard for the SDK to try to make sense of how to encode and decode stuff to and from the blockchain. This is due to the fact that we have same runtime, same `spec_version`, same `transaction_version`, and same `everything_else` both in our `master` branch and in our `develop` branch.
This normally would not be an issue, but right now we have a big breaking change between the two, where `master` only deals with `AccountId32` stuff, while `develop` deals with `LinkableAccountId`.

Types in the SDK can be cleverly defined as starting from a given spec_version number, hence I am proposing the following:

_always make sure that the `spec_version` number on `develop` is higher than the `spec_version` number on `master` and any released binaries._

This also follows the release flow of the SDK, since anything that has not been released in a version **x**, will be released not earlier than the next version **y**. It also assumes that patch releases will be pushed directly to `master`, and then merged back into `develop`. There might be other solutions, and I don't have strong preference as long as it makes it easier for the SDK to decorate and augment types. So here I am suggesting to **always** merge back from `master` into `develop` and to bump the `spec_version` on `develop` to the next minor version. In this case, I am proposing to bump from 1.7.4 to 1.8.0. It now becomes easier for the SDK to say that versions until 1.7.4 do not contain said breaking change. In case we would switch to a release branch model, I am proposing `master` to always have a `spec_version` highest than the latest released version, following the same logic.

Right now we are in an exceptional situation where we have this breaking change hanging in the codebase that is requiring the SDK to implement few hacks here and there to make it work, since we have to rely on type definitions for our RPC stuff. But if we make sure that `develop` is always ahead of `master` (as it should logically be), then this is easier to handle in the SDK, especially now that the [type definitions have been merged inside the SDK codebase](https://github.com/KILTprotocol/sdk-js/pull/658), making it very easy to spot if there is any breaking changes.