### PR TITLE
chore: update toolchain versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ clippy:
   timeout: 1 hours
   script:
     - rustup show
-    - cargo +nightly clippy --all-features --all-targets --locked -- -D warnings
+    - cargo clippy --all-features --all-targets --locked -- -D warnings
 
 fmt:
   # Corresponds to paritytech/ci-linux:production at the time of this PR
@@ -19,7 +19,7 @@ fmt:
   stage: test
   timeout: 1 hours
   script:
-    - cargo +nightly fmt -- --check
+    - cargo fmt -- --check
 
 test:
   # Corresponds to paritytech/ci-linux:production at the time of this PR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ clippy:
   stage: test
   timeout: 1 hours
   script:
-    - rustup show
     - cargo clippy --all-features --all-targets --locked -- -D warnings
 
 fmt:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ clippy:
   stage: test
   timeout: 1 hours
   script:
-    - rustup update
+    - rustup show
     - cargo +nightly clippy --all-features --all-targets --locked -- -D warnings
 
 fmt:
@@ -19,7 +19,6 @@ fmt:
   stage: test
   timeout: 1 hours
   script:
-    - rustup update
     - cargo +nightly fmt -- --check
 
 test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ clippy:
   stage: test
   timeout: 1 hours
   script:
-    - rustup component add clippy --toolchain nightly
+    - rustup update
     - cargo +nightly clippy --all-features --all-targets --locked -- -D warnings
 
 fmt:
@@ -19,7 +19,7 @@ fmt:
   stage: test
   timeout: 1 hours
   script:
-    - rustup component add rustfmt --toolchain nightly
+    - rustup update
     - cargo +nightly fmt -- --check
 
 test:

--- a/.maintain/srtool.Dockerfile
+++ b/.maintain/srtool.Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/ubuntu:22.04
 LABEL maintainer "chevdor@gmail.com"
 LABEL description="This image contains tools for Substrate blockchains runtimes."
 
-ARG RUSTC_VERSION="1.62.0"
+ARG RUSTC_VERSION="1.64.0"
 ENV RUSTC_VERSION=$RUSTC_VERSION
 ENV DOCKER_IMAGE="paritytech/srtool"
 ENV PROFILE=release

--- a/crates/assets/Cargo.toml
+++ b/crates/assets/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -406,7 +406,7 @@ pub fn run() -> Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				let hwbench = if !cli.no_hardware_benchmarks {
 					config.database.path().map(|database_path| {
-						let _ = std::fs::create_dir_all(&database_path);
+						let _ = std::fs::create_dir_all(database_path);
 						sc_sysinfo::gather_hwbench(Some(database_path))
 					})
 				} else {

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/nodes/standalone/src/benchmarking.rs
+++ b/nodes/standalone/src/benchmarking.rs
@@ -130,7 +130,7 @@ pub fn create_benchmark_extrinsic(
 	let period = runtime::BlockHashCount::get()
 		.checked_next_power_of_two()
 		.map(|c| c / 2)
-		.unwrap_or(2) as u64;
+		.unwrap_or(2);
 	let extra: runtime::SignedExtra = (
 		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
 		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -41,7 +41,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester.clone());
@@ -66,7 +66,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester.clone());
@@ -92,7 +92,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester.clone());
@@ -109,7 +109,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester);
@@ -127,7 +127,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&deposit_owner_old, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 		<T as Config>::Currency::make_free_balance_be(&deposit_owner_new, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
@@ -154,7 +154,7 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		<T as Config>::Currency::make_free_balance_be(&deposit_owner, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(deposit_owner.clone(), attester.clone());

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -246,11 +246,11 @@ pub mod pallet {
 			let deposit_amount = <T as Config>::Deposit::get();
 
 			ensure!(
-				ctype::Ctypes::<T>::contains_key(&ctype_hash),
+				ctype::Ctypes::<T>::contains_key(ctype_hash),
 				ctype::Error::<T>::CTypeNotFound
 			);
 			ensure!(
-				!Attestations::<T>::contains_key(&claim_hash),
+				!Attestations::<T>::contains_key(claim_hash),
 				Error::<T>::AlreadyAttested
 			);
 
@@ -268,7 +268,7 @@ pub mod pallet {
 			log::debug!("insert Attestation");
 
 			Attestations::<T>::insert(
-				&claim_hash,
+				claim_hash,
 				AttestationDetails {
 					ctype_hash,
 					attester: who.clone(),
@@ -315,7 +315,7 @@ pub mod pallet {
 			let source = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 			let who = source.subject();
 
-			let attestation = Attestations::<T>::get(&claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
+			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
 
 			ensure!(!attestation.revoked, Error::<T>::AlreadyRevoked);
 
@@ -333,7 +333,7 @@ pub mod pallet {
 
 			log::debug!("revoking Attestation");
 			Attestations::<T>::insert(
-				&claim_hash,
+				claim_hash,
 				AttestationDetails {
 					revoked: true,
 					..attestation
@@ -374,7 +374,7 @@ pub mod pallet {
 			let source = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 			let who = source.subject();
 
-			let attestation = Attestations::<T>::get(&claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
+			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
 
 			if attestation.attester != who {
 				let attestation_auth_id = attestation.authorization_id.as_ref().ok_or(Error::<T>::Unauthorized)?;
@@ -408,7 +408,7 @@ pub mod pallet {
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::reclaim_deposit())]
 		pub fn reclaim_deposit(origin: OriginFor<T>, claim_hash: ClaimHashOf<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			let attestation = Attestations::<T>::get(&claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
+			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
 
 			ensure!(attestation.deposit.owner == who, Error::<T>::Unauthorized);
 
@@ -435,7 +435,7 @@ pub mod pallet {
 			let subject = source.subject();
 			let sender = source.sender();
 
-			let attestation = Attestations::<T>::get(&claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
+			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
 			ensure!(attestation.attester == subject, Error::<T>::Unauthorized);
 
 			AttestationStorageDepositCollector::<T>::change_deposit_owner(&claim_hash, sender)?;
@@ -450,7 +450,7 @@ pub mod pallet {
 		pub fn update_deposit(origin: OriginFor<T>, claim_hash: ClaimHashOf<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			let attestation = Attestations::<T>::get(&claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
+			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::AttestationNotFound)?;
 			ensure!(attestation.deposit.owner == sender, Error::<T>::Unauthorized);
 
 			AttestationStorageDepositCollector::<T>::update_deposit(&claim_hash)?;
@@ -462,7 +462,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		fn remove_attestation(attestation: AttestationDetails<T>, claim_hash: ClaimHashOf<T>) {
 			kilt_support::free_deposit::<AccountIdOf<T>, CurrencyOf<T>>(&attestation.deposit);
-			Attestations::<T>::remove(&claim_hash);
+			Attestations::<T>::remove(claim_hash);
 			if let Some(authorization_id) = &attestation.authorization_id {
 				ExternalAttestations::<T>::remove(authorization_id, claim_hash);
 			}

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -159,7 +159,7 @@ pub fn insert_attestation<T: Config>(claim_hash: ClaimHashOf<T>, details: Attest
 	)
 	.expect("Should have balance");
 
-	crate::Attestations::<T>::insert(&claim_hash, details.clone());
+	crate::Attestations::<T>::insert(claim_hash, details.clone());
 	if let Some(delegation_id) = details.authorization_id.as_ref() {
 		crate::ExternalAttestations::<T>::insert(delegation_id, claim_hash, true)
 	}

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/ctype/src/benchmarking.rs
+++ b/pallets/ctype/src/benchmarking.rs
@@ -57,7 +57,7 @@ benchmarks! {
 
 	}: _<T::Origin>(origin, ctype)
 	verify {
-		let stored_ctype_creator: T::CtypeCreatorId = Ctypes::<T>::get(&ctype_hash).expect("CType hash should be present on chain.");
+		let stored_ctype_creator: T::CtypeCreatorId = Ctypes::<T>::get(ctype_hash).expect("CType hash should be present on chain.");
 
 		// Verify the CType has the right owner
 		assert_eq!(stored_ctype_creator, did);

--- a/pallets/ctype/src/lib.rs
+++ b/pallets/ctype/src/lib.rs
@@ -160,7 +160,7 @@ pub mod pallet {
 
 			let hash = <T as frame_system::Config>::Hashing::hash(&ctype[..]);
 
-			ensure!(!Ctypes::<T>::contains_key(&hash), Error::<T>::CTypeAlreadyExists);
+			ensure!(!Ctypes::<T>::contains_key(hash), Error::<T>::CTypeAlreadyExists);
 
 			// *** No Fail except during withdraw beyond this point  ***
 
@@ -176,7 +176,7 @@ pub mod pallet {
 
 			T::FeeCollector::on_unbalanced(imbalance);
 			log::debug!("Creating CType with hash {:?} and creator {:?}", hash, creator);
-			Ctypes::<T>::insert(&hash, creator.clone());
+			Ctypes::<T>::insert(hash, creator.clone());
 
 			Self::deposit_event(Event::CTypeCreated(creator, hash));
 

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/delegation/src/benchmarking.rs
+++ b/pallets/delegation/src/benchmarking.rs
@@ -148,7 +148,7 @@ where
 		)?;
 
 		// only return first leaf
-		first_leaf = first_leaf.or(Some((delegation_acc_public, delegation_acc_id, delegation_id)));
+		first_leaf = first_leaf.or_else(|| Some((delegation_acc_public, delegation_acc_id, delegation_id)));
 	}
 
 	let (leaf_acc_public, leaf_acc_id, leaf_id) =

--- a/pallets/delegation/src/benchmarking.rs
+++ b/pallets/delegation/src/benchmarking.rs
@@ -74,7 +74,7 @@ where
 		<T as Config>::Currency::minimum_balance() + <T as Config>::Deposit::get() + <T as Config>::Deposit::get(),
 	);
 
-	ctype::Ctypes::<T>::insert(&ctype_hash, T::CtypeCreatorId::from(root_acc.clone()));
+	ctype::Ctypes::<T>::insert(ctype_hash, T::CtypeCreatorId::from(root_acc.clone()));
 
 	Pallet::<T>::create_hierarchy(
 		<T as Config>::EnsureOrigin::generate_origin(sender, root_acc.clone()),
@@ -234,7 +234,7 @@ benchmarks! {
 		let creator: T::DelegationEntityId = account("creator", 0, SEED);
 		let ctype = <T::Hash as Default>::default();
 		let delegation = generate_delegation_id::<T>(0);
-		ctype::Ctypes::<T>::insert(&ctype, <T as ctype::Config>::CtypeCreatorId::from(creator.clone()));
+		ctype::Ctypes::<T>::insert(ctype, <T as ctype::Config>::CtypeCreatorId::from(creator.clone()));
 		<T as Config>::Currency::make_free_balance_be(
 			&sender,
 			<T as Config>::Currency::minimum_balance() + <T as Config>::Deposit::get(),

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -324,12 +324,12 @@ pub mod pallet {
 			let creator = source.subject();
 
 			ensure!(
-				!<DelegationHierarchies<T>>::contains_key(&root_node_id),
+				!<DelegationHierarchies<T>>::contains_key(root_node_id),
 				Error::<T>::HierarchyAlreadyExists
 			);
 
 			ensure!(
-				<ctype::Ctypes<T>>::contains_key(&ctype_hash),
+				<ctype::Ctypes<T>>::contains_key(ctype_hash),
 				<ctype::Error<T>>::CTypeNotFound
 			);
 
@@ -397,11 +397,11 @@ pub mod pallet {
 			let delegator = source.subject();
 
 			ensure!(
-				!<DelegationNodes<T>>::contains_key(&delegation_id),
+				!<DelegationNodes<T>>::contains_key(delegation_id),
 				Error::<T>::DelegationAlreadyExists
 			);
 
-			let parent_node = <DelegationNodes<T>>::get(&parent_id).ok_or(Error::<T>::ParentDelegationNotFound)?;
+			let parent_node = <DelegationNodes<T>>::get(parent_id).ok_or(Error::<T>::ParentDelegationNotFound)?;
 			let hierarchy_root_id = parent_node.hierarchy_root_id;
 
 			// Calculate the hash root
@@ -501,7 +501,7 @@ pub mod pallet {
 			let invoker = <T as Config>::EnsureOrigin::ensure_origin(origin)?.subject();
 
 			ensure!(
-				<DelegationNodes<T>>::contains_key(&delegation_id),
+				<DelegationNodes<T>>::contains_key(delegation_id),
 				Error::<T>::DelegationNotFound
 			);
 
@@ -525,7 +525,7 @@ pub mod pallet {
 			let (revocation_checks, _) = Self::revoke(&delegation_id, &invoker, max_revocations.saturating_add(1))?;
 
 			// If the revoked node is a root node, emit also a HierarchyRevoked event.
-			if DelegationHierarchies::<T>::contains_key(&delegation_id) {
+			if DelegationHierarchies::<T>::contains_key(delegation_id) {
 				Self::deposit_event(Event::HierarchyRevoked(invoker, delegation_id));
 			}
 
@@ -574,7 +574,7 @@ pub mod pallet {
 			let source = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 			let invoker = source.subject();
 
-			let delegation = DelegationNodes::<T>::get(&delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
+			let delegation = DelegationNodes::<T>::get(delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
 
 			// Node can only be removed by owner of the node, not the parent or another
 			// ancestor
@@ -589,7 +589,7 @@ pub mod pallet {
 			let (removal_checks, _) = Self::remove(&delegation_id, max_removals.saturating_add(1))?;
 
 			// If the removed node is a root node, emit also a HierarchyRemoved event.
-			if DelegationHierarchies::<T>::take(&delegation_id).is_some() {
+			if DelegationHierarchies::<T>::take(delegation_id).is_some() {
 				Self::deposit_event(Event::HierarchyRemoved(invoker, delegation_id));
 			}
 
@@ -628,7 +628,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			let delegation = DelegationNodes::<T>::get(&delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
+			let delegation = DelegationNodes::<T>::get(delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
 
 			// Deposit can only be removed by the owner of the deposit, not the
 			// parent or another ancestor.
@@ -646,7 +646,7 @@ pub mod pallet {
 			// Delete the delegation hierarchy details, if the provided ID was for a root
 			// node. No event generated as we don't have information about the owner DID
 			// here.
-			DelegationHierarchies::<T>::remove(&delegation_id);
+			DelegationHierarchies::<T>::remove(delegation_id);
 
 			Ok(Some(<T as Config>::WeightInfo::remove_delegation(removal_checks)).into())
 		}
@@ -662,7 +662,7 @@ pub mod pallet {
 		pub fn change_deposit_owner(origin: OriginFor<T>, delegation_id: DelegationNodeIdOf<T>) -> DispatchResult {
 			let source = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 
-			let delegation = DelegationNodes::<T>::get(&delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
+			let delegation = DelegationNodes::<T>::get(delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
 
 			// Deposit can only be swapped by the owner of the delegation node, not the
 			// parent or another ancestor.
@@ -678,7 +678,7 @@ pub mod pallet {
 		pub fn update_deposit(origin: OriginFor<T>, delegation_id: DelegationNodeIdOf<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			let delegation = DelegationNodes::<T>::get(&delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
+			let delegation = DelegationNodes::<T>::get(delegation_id).ok_or(Error::<T>::DelegationNotFound)?;
 
 			// Deposit can only be swapped by the owner of the delegation node, not the
 			// parent or another ancestor.

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -115,9 +115,9 @@ fn generate_base_did_call_operation<T: Config>(
 
 fn save_service_endpoints<T: Config>(did_subject: &DidIdentifierOf<T>, endpoints: &[DidEndpoint<T>]) {
 	for endpoint in endpoints.iter() {
-		ServiceEndpoints::<T>::insert(&did_subject, &endpoint.id, endpoint.clone());
+		ServiceEndpoints::<T>::insert(did_subject, &endpoint.id, endpoint.clone());
 	}
-	DidEndpointsCount::<T>::insert(&did_subject, endpoints.len().saturated_into::<u32>());
+	DidEndpointsCount::<T>::insert(did_subject, endpoints.len().saturated_into::<u32>());
 }
 
 benchmarks! {

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -1244,7 +1244,7 @@ pub mod pallet {
 		fn deposit(
 			key: &DidIdentifierOf<T>,
 		) -> Result<Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>, DispatchError> {
-			let did_entry = Did::<T>::get(&key).ok_or(Error::<T>::DidNotPresent)?;
+			let did_entry = Did::<T>::get(key).ok_or(Error::<T>::DidNotPresent)?;
 			Ok(did_entry.deposit)
 		}
 
@@ -1256,8 +1256,8 @@ pub mod pallet {
 			key: &DidIdentifierOf<T>,
 			deposit: Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>,
 		) -> Result<(), DispatchError> {
-			let did_entry = Did::<T>::get(&key).ok_or(Error::<T>::DidNotPresent)?;
-			Did::<T>::insert(&key, DidDetails { deposit, ..did_entry });
+			let did_entry = Did::<T>::get(key).ok_or(Error::<T>::DidNotPresent)?;
+			Did::<T>::insert(key, DidDetails { deposit, ..did_entry });
 
 			Ok(())
 		}

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -481,13 +481,13 @@ impl ExtBuilder {
 					.expect("Deposit owner should have enough balance");
 			}
 			for did in self.deleted_dids.iter() {
-				DidBlacklist::<Test>::insert(&did, ());
+				DidBlacklist::<Test>::insert(did, ());
 			}
 			for (did, endpoints) in self.service_endpoints.iter() {
 				for endpoint in endpoints.iter() {
-					ServiceEndpoints::<Test>::insert(&did, &endpoint.id, endpoint)
+					ServiceEndpoints::<Test>::insert(did, &endpoint.id, endpoint)
 				}
-				DidEndpointsCount::<Test>::insert(&did, endpoints.len().saturated_into::<u32>());
+				DidEndpointsCount::<Test>::insert(did, endpoints.len().saturated_into::<u32>());
 			}
 		});
 

--- a/pallets/pallet-did-lookup/Cargo.toml
+++ b/pallets/pallet-did-lookup/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/pallet-did-lookup/src/account.rs
+++ b/pallets/pallet-did-lookup/src/account.rs
@@ -111,7 +111,7 @@ impl From<libsecp256k1::PublicKey> for EthereumSigner {
 	fn from(x: libsecp256k1::PublicKey) -> Self {
 		let mut m = [0u8; 64];
 		m.copy_from_slice(&x.serialize()[1..65]);
-		let account = H160::from(H256::from_slice(Keccak256::digest(&m).as_slice()));
+		let account = H160::from(H256::from_slice(Keccak256::digest(m).as_slice()));
 		EthereumSigner(account.into())
 	}
 }
@@ -141,7 +141,7 @@ impl sp_runtime::traits::Verify for EthereumSignature {
 			Ok(pubkey) => {
 				// TODO This conversion could use a comment. Why H256 first, then H160?
 				// TODO actually, there is probably just a better way to go from Keccak digest.
-				AccountId20(H160::from(H256::from_slice(Keccak256::digest(&pubkey).as_slice())).0) == *signer
+				AccountId20(H160::from(H256::from_slice(Keccak256::digest(pubkey).as_slice())).0) == *signer
 			}
 			Err(_) => {
 				log::trace!("Error verifying signature");

--- a/pallets/pallet-did-lookup/src/benchmarking.rs
+++ b/pallets/pallet-did-lookup/src/benchmarking.rs
@@ -176,7 +176,7 @@ benchmarks! {
 		let sig = sp_io::crypto::ecdsa_sign_prehashed(
 			KeyTypeId(*b"aura"),
 			&eth_public_key,
-			&Keccak256::digest(&wrapped_payload).try_into().unwrap(),
+			&Keccak256::digest(wrapped_payload).try_into().unwrap(),
 		).ok_or("Error while building signature.")?;
 
 		make_free_for_did::<T>(&caller);

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -380,7 +380,7 @@ pub mod pallet {
 		fn deposit(
 			key: &LinkableAccountId,
 		) -> Result<Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>, DispatchError> {
-			let record = ConnectedDids::<T>::get(&key).ok_or(Error::<T>::AssociationNotFound)?;
+			let record = ConnectedDids::<T>::get(key).ok_or(Error::<T>::AssociationNotFound)?;
 			Ok(record.deposit)
 		}
 
@@ -392,8 +392,8 @@ pub mod pallet {
 			key: &LinkableAccountId,
 			deposit: Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>,
 		) -> Result<(), DispatchError> {
-			let record = ConnectedDids::<T>::get(&key).ok_or(Error::<T>::AssociationNotFound)?;
-			ConnectedDids::<T>::insert(&key, ConnectionRecord { deposit, ..record });
+			let record = ConnectedDids::<T>::get(key).ok_or(Error::<T>::AssociationNotFound)?;
+			ConnectedDids::<T>::insert(key, ConnectionRecord { deposit, ..record });
 
 			Ok(())
 		}

--- a/pallets/pallet-did-lookup/src/tests.rs
+++ b/pallets/pallet-did-lookup/src/tests.rs
@@ -109,7 +109,7 @@ fn test_add_association_account() {
 			)
 			.is_ok());
 			assert_eq!(
-				ConnectedDids::<Test>::get(&LinkableAccountId::from(account_hash_alice.clone())),
+				ConnectedDids::<Test>::get(LinkableAccountId::from(account_hash_alice.clone())),
 				Some(ConnectionRecord {
 					did: DID_00,
 					deposit: Deposit {
@@ -119,7 +119,7 @@ fn test_add_association_account() {
 				})
 			);
 			assert!(
-				ConnectedAccounts::<Test>::get(DID_00, &LinkableAccountId::from(account_hash_alice.clone())).is_some()
+				ConnectedAccounts::<Test>::get(DID_00, LinkableAccountId::from(account_hash_alice.clone())).is_some()
 			);
 			assert_eq!(
 				Balances::reserved_balance(ACCOUNT_00),
@@ -137,7 +137,7 @@ fn test_add_association_account() {
 			}
 			assert!(res.is_ok());
 			assert_eq!(
-				ConnectedDids::<Test>::get(&LinkableAccountId::from(account_hash_alice.clone())),
+				ConnectedDids::<Test>::get(LinkableAccountId::from(account_hash_alice.clone())),
 				Some(ConnectionRecord {
 					did: DID_01,
 					deposit: Deposit {
@@ -147,10 +147,10 @@ fn test_add_association_account() {
 				})
 			);
 			assert!(
-				ConnectedAccounts::<Test>::get(DID_00, &LinkableAccountId::from(account_hash_alice.clone())).is_none()
+				ConnectedAccounts::<Test>::get(DID_00, LinkableAccountId::from(account_hash_alice.clone())).is_none()
 			);
 			assert!(
-				ConnectedAccounts::<Test>::get(DID_01, &LinkableAccountId::from(account_hash_alice.clone())).is_some()
+				ConnectedAccounts::<Test>::get(DID_01, LinkableAccountId::from(account_hash_alice.clone())).is_some()
 			);
 			assert_eq!(
 				Balances::reserved_balance(ACCOUNT_00),
@@ -165,7 +165,7 @@ fn test_add_association_account() {
 			)
 			.is_ok());
 			assert_eq!(
-				ConnectedDids::<Test>::get(&LinkableAccountId::from(account_hash_alice.clone())),
+				ConnectedDids::<Test>::get(LinkableAccountId::from(account_hash_alice.clone())),
 				Some(ConnectionRecord {
 					did: DID_01,
 					deposit: Deposit {
@@ -175,9 +175,9 @@ fn test_add_association_account() {
 				})
 			);
 			assert!(
-				ConnectedAccounts::<Test>::get(DID_00, &LinkableAccountId::from(account_hash_alice.clone())).is_none()
+				ConnectedAccounts::<Test>::get(DID_00, LinkableAccountId::from(account_hash_alice.clone())).is_none()
 			);
-			assert!(ConnectedAccounts::<Test>::get(DID_01, &LinkableAccountId::from(account_hash_alice)).is_some());
+			assert!(ConnectedAccounts::<Test>::get(DID_01, LinkableAccountId::from(account_hash_alice)).is_some());
 			assert_eq!(Balances::reserved_balance(ACCOUNT_00), 0);
 			assert_eq!(
 				Balances::reserved_balance(ACCOUNT_01),
@@ -204,7 +204,7 @@ fn test_add_eth_association() {
 				crate::signature::WrapType::Ethereum,
 			);
 
-			let sig = eth_pair.sign_prehashed(&Keccak256::digest(&wrapped_payload).try_into().unwrap());
+			let sig = eth_pair.sign_prehashed(&Keccak256::digest(wrapped_payload).try_into().unwrap());
 
 			// new association. No overwrite
 			let res = DidLookup::associate_account(
@@ -214,7 +214,7 @@ fn test_add_eth_association() {
 			);
 			assert!(res.is_ok());
 			assert_eq!(
-				ConnectedDids::<Test>::get(&LinkableAccountId::from(eth_account)),
+				ConnectedDids::<Test>::get(LinkableAccountId::from(eth_account)),
 				Some(ConnectionRecord {
 					did: DID_00,
 					deposit: Deposit {
@@ -223,7 +223,7 @@ fn test_add_eth_association() {
 					}
 				})
 			);
-			assert!(ConnectedAccounts::<Test>::get(DID_00, &LinkableAccountId::from(eth_account)).is_some());
+			assert!(ConnectedAccounts::<Test>::get(DID_00, LinkableAccountId::from(eth_account)).is_some());
 			assert_eq!(
 				Balances::reserved_balance(ACCOUNT_00),
 				<Test as crate::Config>::Deposit::get()
@@ -297,8 +297,8 @@ fn test_remove_association_sender() {
 		.execute_with(|| {
 			// remove association
 			assert!(DidLookup::remove_sender_association(Origin::signed(ACCOUNT_00)).is_ok());
-			assert_eq!(ConnectedDids::<Test>::get(&LinkableAccountId::from(ACCOUNT_00)), None);
-			assert!(ConnectedAccounts::<Test>::get(DID_01, &LinkableAccountId::from(ACCOUNT_00)).is_none());
+			assert_eq!(ConnectedDids::<Test>::get(LinkableAccountId::from(ACCOUNT_00)), None);
+			assert!(ConnectedAccounts::<Test>::get(DID_01, LinkableAccountId::from(ACCOUNT_00)).is_none());
 			assert_eq!(Balances::reserved_balance(ACCOUNT_00), 0);
 		});
 }
@@ -334,8 +334,8 @@ fn test_remove_association_account() {
 				LinkableAccountId::from(ACCOUNT_00.clone())
 			)
 			.is_ok());
-			assert_eq!(ConnectedDids::<Test>::get(&LinkableAccountId::from(ACCOUNT_00)), None);
-			assert!(ConnectedAccounts::<Test>::get(DID_01, &LinkableAccountId::from(ACCOUNT_00)).is_none());
+			assert_eq!(ConnectedDids::<Test>::get(LinkableAccountId::from(ACCOUNT_00)), None);
+			assert!(ConnectedAccounts::<Test>::get(DID_01, LinkableAccountId::from(ACCOUNT_00)).is_none());
 			assert_eq!(Balances::reserved_balance(ACCOUNT_01), 0);
 		});
 }
@@ -349,7 +349,7 @@ fn test_remove_association_account_not_found() {
 		])
 		.build()
 		.execute_with(|| {
-			assert_eq!(ConnectedDids::<Test>::get(&LinkableAccountId::from(ACCOUNT_00)), None);
+			assert_eq!(ConnectedDids::<Test>::get(LinkableAccountId::from(ACCOUNT_00)), None);
 
 			assert_noop!(
 				DidLookup::remove_account_association(

--- a/pallets/pallet-inflation/Cargo.toml
+++ b/pallets/pallet-inflation/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/pallet-web3-names/Cargo.toml
+++ b/pallets/pallet-web3-names/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -383,7 +383,7 @@ pub mod pallet {
 		) -> Result<Web3NameOf<T>, DispatchError> {
 			let name = Web3NameOf::<T>::try_from(name_input.into_inner()).map_err(DispatchError::from)?;
 
-			ensure!(!Names::<T>::contains_key(&owner), Error::<T>::OwnerAlreadyExists);
+			ensure!(!Names::<T>::contains_key(owner), Error::<T>::OwnerAlreadyExists);
 			ensure!(!Owner::<T>::contains_key(&name), Error::<T>::Web3NameAlreadyClaimed);
 			ensure!(!Banned::<T>::contains_key(&name), Error::<T>::Web3NameBanned);
 
@@ -423,7 +423,7 @@ pub mod pallet {
 		/// Specifically:
 		/// - The owner has a previously claimed name
 		fn check_releasing_preconditions(owner: &Web3NameOwnerOf<T>) -> Result<Web3NameOf<T>, DispatchError> {
-			let name = Names::<T>::get(&owner).ok_or(Error::<T>::OwnerNotFound)?;
+			let name = Names::<T>::get(owner).ok_or(Error::<T>::OwnerNotFound)?;
 
 			Ok(name)
 		}
@@ -480,7 +480,7 @@ pub mod pallet {
 		/// `check_banning_preconditions` as it does not verify all the
 		/// preconditions again.
 		pub(crate) fn ban_name(name: &Web3NameOf<T>) {
-			Banned::<T>::insert(&name, ());
+			Banned::<T>::insert(name, ());
 		}
 
 		/// Verify that the unbanning preconditions are verified.
@@ -510,7 +510,7 @@ pub mod pallet {
 		fn deposit(
 			key: &T::Web3Name,
 		) -> Result<Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>, DispatchError> {
-			let w3n_entry = Owner::<T>::get(&key).ok_or(Error::<T>::Web3NameNotFound)?;
+			let w3n_entry = Owner::<T>::get(key).ok_or(Error::<T>::Web3NameNotFound)?;
 
 			Ok(w3n_entry.deposit)
 		}
@@ -523,8 +523,8 @@ pub mod pallet {
 			key: &T::Web3Name,
 			deposit: Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>,
 		) -> Result<(), DispatchError> {
-			let w3n_entry = Owner::<T>::get(&key).ok_or(Error::<T>::Web3NameNotFound)?;
-			Owner::<T>::insert(&key, Web3OwnershipOf::<T> { deposit, ..w3n_entry });
+			let w3n_entry = Owner::<T>::get(key).ok_or(Error::<T>::Web3NameNotFound)?;
+			Owner::<T>::insert(key, Web3OwnershipOf::<T> { deposit, ..w3n_entry });
 
 			Ok(())
 		}

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -177,7 +177,7 @@ benchmarks! {
 		let candidates = setup_collator_candidates::<T>(n, None);
 		for (i, c) in candidates.iter().enumerate() {
 			fill_delegators::<T>(m, c.clone(), i.saturated_into::<u32>());
-			Rewards::<T>::insert(&c, T::CurrencyBalance::one());
+			Rewards::<T>::insert(c, T::CurrencyBalance::one());
 		}
 
 		let inflation = InflationInfo::new(
@@ -296,7 +296,7 @@ benchmarks! {
 		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
-		let u = T::MaxUnstakeRequests::get() as u32 - 1;
+		let u = T::MaxUnstakeRequests::get() - 1;
 		let candidates = setup_collator_candidates::<T>(n, None);
 		for (i, c) in candidates.iter().enumerate() {
 			fill_delegators::<T>(m, c.clone(), i.saturated_into::<u32>());
@@ -519,7 +519,7 @@ benchmarks! {
 	}
 
 	unlock_unstaked {
-		let u in 1 .. (T::MaxUnstakeRequests::get() as u32 - 1);
+		let u in 1 .. (T::MaxUnstakeRequests::get() - 1);
 
 		let candidate = account("collator", 0u32, COLLATOR_ACCOUNT_SEED);
 		let free_balance = T::CurrencyBalance::from(u128::MAX);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1980,7 +1980,7 @@ pub mod pallet {
 			// Snapshot exposure for round for weighting reward distribution
 			for account in collators.iter() {
 				let state =
-					CandidatePool::<T>::get(&account).expect("all members of TopCandidates must be candidates q.e.d");
+					CandidatePool::<T>::get(account).expect("all members of TopCandidates must be candidates q.e.d");
 				num_of_delegators = num_of_delegators.max(state.delegators.len().saturated_into::<u32>());
 
 				// sum up total stake and amount of collators, delegators
@@ -2270,8 +2270,8 @@ pub mod pallet {
 				.map(pallet_session::Pallet::<T>::disable_index);
 
 			// Kill storage
-			BlocksAuthored::<T>::remove(&collator);
-			BlocksRewarded::<T>::remove(&collator);
+			BlocksAuthored::<T>::remove(collator);
+			BlocksRewarded::<T>::remove(collator);
 			CandidatePool::<T>::remove(&collator);
 			Ok(())
 		}

--- a/pallets/public-credentials/Cargo.toml
+++ b/pallets/public-credentials/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/pallets/public-credentials/src/benchmarking.rs
+++ b/pallets/public-credentials/src/benchmarking.rs
@@ -70,7 +70,7 @@ benchmarks! {
 		));
 		let credential_id = generate_credential_id::<T>(&creation_op, &attester);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		reserve_balance::<T>(&sender);
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender, attester);
 	}: _<T::Origin>(origin, creation_op)
@@ -97,7 +97,7 @@ benchmarks! {
 
 		reserve_balance::<T>(&sender);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester);
+		ctype::Ctypes::<T>::insert(ctype_hash, attester);
 		Pallet::<T>::add(origin.clone(), creation_op).expect("Pallet::add should not fail");
 		let credential_id_clone = credential_id.clone();
 	}: _<T::Origin>(origin, credential_id_clone, None)
@@ -123,7 +123,7 @@ benchmarks! {
 
 		reserve_balance::<T>(&sender);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester);
+		ctype::Ctypes::<T>::insert(ctype_hash, attester);
 		Pallet::<T>::add(origin.clone(), creation_op).expect("Pallet::add should not fail");
 		Pallet::<T>::revoke(origin.clone(), credential_id.clone(), None).expect("Pallet::revoke should not fail");
 		let credential_id_clone = credential_id.clone();
@@ -149,7 +149,7 @@ benchmarks! {
 
 		reserve_balance::<T>(&sender);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester);
+		ctype::Ctypes::<T>::insert(ctype_hash, attester);
 		Pallet::<T>::add(origin.clone(), creation_op).expect("Pallet::add should not fail");
 		let credential_id_clone = credential_id.clone();
 	}: _<T::Origin>(origin, credential_id_clone, None)
@@ -175,7 +175,7 @@ benchmarks! {
 
 		reserve_balance::<T>(&sender);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester);
+		ctype::Ctypes::<T>::insert(ctype_hash, attester);
 		Pallet::<T>::add(origin, creation_op).expect("Pallet::add should not fail");
 		let origin = RawOrigin::Signed(sender);
 		let credential_id_clone = credential_id.clone();
@@ -204,7 +204,7 @@ benchmarks! {
 		reserve_balance::<T>(&deposit_owner_old);
 		reserve_balance::<T>(&deposit_owner_new);
 
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 		Pallet::<T>::add(origin, creation_op).expect("Pallet::add should not fail");
 		let credential_id_clone = credential_id.clone();
 		let origin = <T as Config>::EnsureOrigin::generate_origin(deposit_owner_new.clone(), attester);
@@ -227,7 +227,7 @@ benchmarks! {
 		let origin = <T as Config>::EnsureOrigin::generate_origin(deposit_owner.clone(), attester.clone());
 
 		reserve_balance::<T>(&deposit_owner);
-		ctype::Ctypes::<T>::insert(&ctype_hash, attester.clone());
+		ctype::Ctypes::<T>::insert(ctype_hash, attester.clone());
 
 		let credential_entry = generate_base_credential_entry::<T>(
 			deposit_owner.clone(),

--- a/pallets/public-credentials/src/lib.rs
+++ b/pallets/public-credentials/src/lib.rs
@@ -259,7 +259,7 @@ pub mod pallet {
 			} = *credential.clone();
 
 			ensure!(
-				ctype::Ctypes::<T>::contains_key(&ctype_hash),
+				ctype::Ctypes::<T>::contains_key(ctype_hash),
 				ctype::Error::<T>::CTypeNotFound
 			);
 
@@ -542,10 +542,10 @@ pub mod pallet {
 		) -> Result<(T::SubjectId, CredentialEntryOf<T>), Error<T>> {
 			// Verify that the credential exists
 			let credential_subject =
-				CredentialSubjects::<T>::get(&credential_id).ok_or(Error::<T>::CredentialNotFound)?;
+				CredentialSubjects::<T>::get(credential_id).ok_or(Error::<T>::CredentialNotFound)?;
 
 			// Should never happen if the line above succeeds
-			Credentials::<T>::get(&credential_subject, &credential_id)
+			Credentials::<T>::get(&credential_subject, credential_id)
 				.map(|entry| (credential_subject, entry))
 				.ok_or(Error::<T>::InternalError)
 		}
@@ -560,7 +560,7 @@ pub mod pallet {
 			// Fails if the credential does not exist OR the caller is different than the
 			// original attester. If successful, saves the additional weight used for access
 			// control and returns it at the end of the function.
-			Credentials::<T>::try_mutate(&credential_subject, &credential_id, |credential_entry| {
+			Credentials::<T>::try_mutate(credential_subject, credential_id, |credential_entry| {
 				if let Some(credential) = credential_entry {
 					// Additional weight is 0 if the caller is the attester, otherwise it's the
 					// value returned by the access control check, if it does not fail.
@@ -605,8 +605,8 @@ pub mod pallet {
 			deposit: Deposit<AccountIdOf<T>, <Self::Currency as Currency<AccountIdOf<T>>>::Balance>,
 		) -> Result<(), DispatchError> {
 			let credential_subject =
-				CredentialSubjects::<T>::get(&credential_id).ok_or(Error::<T>::CredentialNotFound)?;
-			Credentials::<T>::try_mutate(&credential_subject, &credential_id, |credential_entry| {
+				CredentialSubjects::<T>::get(credential_id).ok_or(Error::<T>::CredentialNotFound)?;
+			Credentials::<T>::try_mutate(&credential_subject, credential_id, |credential_entry| {
 				if let Some(credential) = credential_entry {
 					credential.deposit = deposit;
 					Ok(())

--- a/pallets/public-credentials/src/tests.rs
+++ b/pallets/public-credentials/src/tests.rs
@@ -58,7 +58,7 @@ fn add_successful_without_authorization() {
 				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
 				Box::new(new_credential_1.clone())
 			));
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id_1)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id_1)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -67,7 +67,7 @@ fn add_successful_without_authorization() {
 			assert_eq!(stored_public_credential_details.block_number, 0);
 			assert_eq!(stored_public_credential_details.ctype_hash, ctype_hash_1);
 			assert_eq!(stored_public_credential_details.authorization_id, None);
-			assert_eq!(CredentialSubjects::<Test>::get(&credential_id_1), Some(subject_id));
+			assert_eq!(CredentialSubjects::<Test>::get(credential_id_1), Some(subject_id));
 
 			// Check deposit reservation logic
 			assert_eq!(Balances::reserved_balance(ACCOUNT_00), deposit);
@@ -92,7 +92,7 @@ fn add_successful_without_authorization() {
 				Box::new(new_credential_2.clone())
 			));
 
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id_2)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id_2)
 				.expect("Public credential #2 details should be present on chain.");
 
 			// Test this pallet logic
@@ -101,7 +101,7 @@ fn add_successful_without_authorization() {
 			assert_eq!(stored_public_credential_details.block_number, 1);
 			assert_eq!(stored_public_credential_details.ctype_hash, ctype_hash_2);
 			assert_eq!(stored_public_credential_details.authorization_id, None);
-			assert_eq!(CredentialSubjects::<Test>::get(&credential_id_2), Some(subject_id));
+			assert_eq!(CredentialSubjects::<Test>::get(credential_id_2), Some(subject_id));
 
 			// Deposit is 2x now
 			assert_eq!(Balances::reserved_balance(ACCOUNT_00), 2 * deposit);
@@ -131,7 +131,7 @@ fn add_successful_with_authorization() {
 				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
 				Box::new(new_credential.clone())
 			));
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -140,7 +140,7 @@ fn add_successful_with_authorization() {
 			assert_eq!(stored_public_credential_details.block_number, 0);
 			assert_eq!(stored_public_credential_details.ctype_hash, ctype_hash);
 			assert_eq!(stored_public_credential_details.authorization_id, Some(attester));
-			assert_eq!(CredentialSubjects::<Test>::get(&credential_id), Some(subject_id));
+			assert_eq!(CredentialSubjects::<Test>::get(credential_id), Some(subject_id));
 		});
 }
 
@@ -275,7 +275,7 @@ fn revoke_successful() {
 				None,
 			));
 
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -288,7 +288,7 @@ fn revoke_successful() {
 				None,
 			));
 
-			let stored_public_credential_details_2 = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details_2 = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			assert_eq!(stored_public_credential_details, stored_public_credential_details_2);
@@ -316,7 +316,7 @@ fn revoke_same_attester_wrong_ac() {
 				Some(MockAccessControl(wrong_submitter))
 			));
 
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -415,7 +415,7 @@ fn unrevoke_successful() {
 				None,
 			));
 
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -428,7 +428,7 @@ fn unrevoke_successful() {
 				None,
 			));
 
-			let stored_public_credential_details_2 = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details_2 = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			assert_eq!(stored_public_credential_details, stored_public_credential_details_2);
@@ -457,7 +457,7 @@ fn unrevoke_same_attester_wrong_ac() {
 				Some(MockAccessControl(wrong_submitter))
 			));
 
-			let stored_public_credential_details = Credentials::<Test>::get(&subject_id, &credential_id)
+			let stored_public_credential_details = Credentials::<Test>::get(subject_id, credential_id)
 				.expect("Public credential details should be present on chain.");
 
 			// Test this pallet logic
@@ -558,8 +558,8 @@ fn remove_successful() {
 			));
 
 			// Test this pallet logic
-			assert!(Credentials::<Test>::get(&subject_id, &credential_id).is_none());
-			assert!(CredentialSubjects::<Test>::get(&credential_id).is_none());
+			assert!(Credentials::<Test>::get(subject_id, credential_id).is_none());
+			assert!(CredentialSubjects::<Test>::get(credential_id).is_none());
 
 			// Check deposit release logic
 			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
@@ -594,8 +594,8 @@ fn remove_same_attester_wrong_ac() {
 			));
 
 			// Test this pallet logic
-			assert!(Credentials::<Test>::get(&subject_id, &credential_id).is_none());
-			assert!(CredentialSubjects::<Test>::get(&credential_id).is_none());
+			assert!(Credentials::<Test>::get(subject_id, credential_id).is_none());
+			assert!(CredentialSubjects::<Test>::get(credential_id).is_none());
 		});
 }
 
@@ -689,8 +689,8 @@ fn reclaim_deposit_successful() {
 			));
 
 			// Test this pallet logic
-			assert!(Credentials::<Test>::get(&subject_id, &credential_id).is_none());
-			assert!(CredentialSubjects::<Test>::get(&credential_id).is_none());
+			assert!(Credentials::<Test>::get(subject_id, credential_id).is_none());
+			assert!(CredentialSubjects::<Test>::get(credential_id).is_none());
 
 			// Check deposit release logic
 			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
@@ -775,7 +775,7 @@ fn test_change_deposit_owner() {
 
 			// Check
 			assert_eq!(
-				Credentials::<Test>::get(&subject_id, &credential_id)
+				Credentials::<Test>::get(subject_id, credential_id)
 					.expect("credential should exist")
 					.deposit
 					.owner,
@@ -867,7 +867,7 @@ fn test_update_deposit() {
 
 			// Check
 			assert_eq!(
-				Credentials::<Test>::get(&subject_id, &credential_id)
+				Credentials::<Test>::get(subject_id, credential_id)
 					.expect("credential should exist")
 					.deposit
 					.amount,

--- a/runtime-api/did/Cargo.toml
+++ b/runtime-api/did/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtime-api/public-credentials/Cargo.toml
+++ b/runtime-api/public-credentials/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtime-api/staking/Cargo.toml
+++ b/runtime-api/staking/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/clone/Cargo.toml
+++ b/runtimes/clone/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1258,13 +1258,13 @@ impl_runtime_apis! {
 
 	impl kilt_runtime_api_public_credentials::PublicCredentials<Block, Vec<u8>, Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>, PublicCredentialsFilter<Hash, AccountId>, PublicCredentialsApiError> for Runtime {
 		fn get_by_id(credential_id: Hash) -> Option<public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>> {
-			let subject = public_credentials::CredentialSubjects::<Runtime>::get(&credential_id)?;
-			public_credentials::Credentials::<Runtime>::get(&subject, &credential_id)
+			let subject = public_credentials::CredentialSubjects::<Runtime>::get(credential_id)?;
+			public_credentials::Credentials::<Runtime>::get(subject, credential_id)
 		}
 
 		fn get_by_subject(subject: Vec<u8>, filter: Option<PublicCredentialsFilter<Hash, AccountId>>) -> Result<Vec<(Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>)>, PublicCredentialsApiError> {
 			let asset_did = AssetDid::try_from(subject).map_err(|_| PublicCredentialsApiError::InvalidSubjectId)?;
-			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(&asset_did);
+			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(asset_did);
 			if let Some(filter) = filter {
 				Ok(credentials_prefix.filter(|(_, entry)| filter.should_include(entry)).collect())
 			} else {

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -1254,13 +1254,13 @@ impl_runtime_apis! {
 
 	impl kilt_runtime_api_public_credentials::PublicCredentials<Block, Vec<u8>, Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>, PublicCredentialsFilter<Hash, AccountId>, PublicCredentialsApiError> for Runtime {
 		fn get_by_id(credential_id: Hash) -> Option<public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>> {
-			let subject = public_credentials::CredentialSubjects::<Runtime>::get(&credential_id)?;
-			public_credentials::Credentials::<Runtime>::get(&subject, &credential_id)
+			let subject = public_credentials::CredentialSubjects::<Runtime>::get(credential_id)?;
+			public_credentials::Credentials::<Runtime>::get(subject, credential_id)
 		}
 
 		fn get_by_subject(subject: Vec<u8>, filter: Option<PublicCredentialsFilter<Hash, AccountId>>) -> Result<Vec<(Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>)>, PublicCredentialsApiError> {
 			let asset_did = AssetDid::try_from(subject).map_err(|_| PublicCredentialsApiError::InvalidSubjectId)?;
-			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(&asset_did);
+			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(asset_did);
 			if let Some(filter) = filter {
 				Ok(credentials_prefix.filter(|(_, entry)| filter.should_include(entry)).collect())
 			} else {

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -1003,13 +1003,13 @@ impl_runtime_apis! {
 
 	impl kilt_runtime_api_public_credentials::PublicCredentials<Block, Vec<u8>, Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>, PublicCredentialsFilter<Hash, AccountId>, PublicCredentialsApiError> for Runtime {
 		fn get_by_id(credential_id: Hash) -> Option<public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>> {
-			let subject = public_credentials::CredentialSubjects::<Runtime>::get(&credential_id)?;
-			public_credentials::Credentials::<Runtime>::get(&subject, &credential_id)
+			let subject = public_credentials::CredentialSubjects::<Runtime>::get(credential_id)?;
+			public_credentials::Credentials::<Runtime>::get(subject, credential_id)
 		}
 
 		fn get_by_subject(subject: Vec<u8>, filter: Option<PublicCredentialsFilter<Hash, AccountId>>) -> Result<Vec<(Hash, public_credentials::CredentialEntry<Hash, DidIdentifier, BlockNumber, AccountId, Balance, AuthorizationId<<Runtime as delegation::Config>::DelegationNodeId>>)>, PublicCredentialsApiError> {
 			let asset_did = AssetDid::try_from(subject).map_err(|_| PublicCredentialsApiError::InvalidSubjectId)?;
-			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(&asset_did);
+			let credentials_prefix = public_credentials::Credentials::<Runtime>::iter_prefix(asset_did);
 			if let Some(filter) = filter {
 				Ok(credentials_prefix.filter(|(_, entry)| filter.should_include(entry)).collect())
 			} else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "nightly-2022-07-24"
+channel = "nightly"
+components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-11-29"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-11-29"
+channel = "nightly-2022-10-09"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-11-29"
+channel = "nightly"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 authors.workspace = true
 documentation.workspace = true


### PR DESCRIPTION
Since rust-analyzer has been merged into the main rustlang repo, it is tested for breaking changes. This means that we don't need to pin the nightly to a specific version anymore, as using the latest nightly is always guaranteed to work with the latest version of the rust-analyzer extension (try it yourselves, for me it finally just works).

This PR then does the following:

- update the toolchain file to use the latest nightly, which gives us access to potentially new clippy warnings, and to better rust-analyzer performances
- update the runtime builder to use Rust 1.64 as also nowadays done by Polkadot
- remove the deprecated `cargo-features = ["workspace-inheritance"]`, since from 1.64 it has been stabilised (this could be caught only by using a recent enough nightly version)
- Let the CI job use the same version as in the toolchain file, by removing the `+nightly` flag. This will ensure we have a consistent behaviour between local machine and CI server.

The only thing to consider is that the nightly will differ from the version that srtool uses to build the runtime WASM. That was the case also before, and it will always be until substrate will support compilation with the stable toolchain.