### PR TITLE
chore: update relay chain references

### DIFF
--- a/runtimes/common/src/xcm_config.rs
+++ b/runtimes/common/src/xcm_config.rs
@@ -35,7 +35,7 @@ parameter_types! {
 }
 
 match_types! {
-	// The legislative of our parent (i.e. Kusama majority vote).
+	// The legislative of our parent (i.e. Polkadot majority vote for Spiritnet).
 	pub type ParentLegislative: impl Contains<MultiLocation> = {
 		MultiLocation { parents: 1, interior: X1(Plurality { id: BodyId::Legislative, .. }) }
 	};

--- a/runtimes/peregrine/src/xcm_config.rs
+++ b/runtimes/peregrine/src/xcm_config.rs
@@ -40,6 +40,7 @@ use runtime_common::xcm_config::{
 parameter_types! {
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	// TODO: This needs to be updated once we deploy Peregrine on Rococo
 	pub const RelayNetworkId: NetworkId = NetworkId::Any;
 }
 

--- a/runtimes/spiritnet/src/xcm_config.rs
+++ b/runtimes/spiritnet/src/xcm_config.rs
@@ -38,7 +38,7 @@ use runtime_common::xcm_config::{LocalAssetTransactor, MaxInstructions, RelayLoc
 parameter_types! {
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	pub const RelayNetworkId: NetworkId = NetworkId::Kusama;
+	pub const RelayNetworkId: NetworkId = NetworkId::Polkadot;
 }
 
 /// This is the type we use to convert an (incoming) XCM origin into a local


### PR DESCRIPTION
After the move to Polkadot, Spiritnet XCM config was still referring to Kusama as the relay chain. This should be updated now.