### PR TITLE
chore: add manual trigger for Polkadot releases dependencies

### DIFF
--- a/.github/workflows/polkadot-release-list.yml
+++ b/.github/workflows/polkadot-release-list.yml
@@ -23,8 +23,8 @@ on:
         - Ad96el
 
 jobs:
-  runs-on: ubuntu-latest
   create-ticket:
+    runs-on: ubuntu-latest
     steps:
       - name: Install cargo
         run: curl https://sh.rustup.rs -sSf | sh

--- a/.github/workflows/polkadot-release-list.yml
+++ b/.github/workflows/polkadot-release-list.yml
@@ -1,0 +1,49 @@
+name: create-polkadot-release-ticket
+
+on:
+  workflow_dispatch:
+    inputs:
+      current-version:
+        description: Current version of the Polkadot/Cumulus dependency
+        required: true
+        type: string
+      target-version:
+        description: Target version of the Polkadot/Cumulus dependency
+        required: true
+        type: string
+jobs:
+  runs-on: ubuntu-latest
+  create-ticket:
+    steps:
+      - name: Install cargo
+        run: curl https://sh.rustup.rs -sSf | sh
+      - name: Install subalfred
+        env:
+          - SUBALFRED_VERSION: 0.9.1
+        run: cargo install --version $SUBALFRED_VERSION --git https://github.com/hack-ink/subalfred.git subalfred
+      - name: Run subalfred for Substrate
+        run: subalfred track-updates paritytech/substrate --from polkadot-v${{ inputs.current-version }} --to polkadot-v${{ inputs.target-version }} > substrate-out.md
+      - name: Run subalfred for Cumulus
+        run: subalfred track-updates paritytech/cumulus --from polkadot-v${{ inputs.current-version }} --to polkadot-v${{ inputs.target-version }} > cumulus-out.md
+      - name: Merge outputs into single file
+        run: |
+          echo "## Substrate changes" > out.md
+          cat substrate-out.md >> out.md
+          echo "## Cumulus changes" >> out.md
+          cat cumulus-out.md >> out.md
+      - name: Create issue from commands output
+        id: new-issue
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: "chore: update Polkadot dependencies from ${{ inputs.current-version }} to ${{ inputs.target-version }}"
+          repository: KILTProtocol/ticket
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          content-filepath: out.md
+      - name: Put issue into weekly board
+        uses: peter-evans/create-or-update-project-card@v2
+        with:
+          # TODO: This will break if we change the name of the project
+          project-name: "Weekly Board 📅 Test & Release public credentials Chain 1.9.0 SDK 0.31 / CType Draft V2 / Documentation Engagement"
+          column-name: "📥  Inbox"
+          issue-number: ${{ steps.new-issue.outputs.issue-number }}
+

--- a/.github/workflows/polkadot-release-list.yml
+++ b/.github/workflows/polkadot-release-list.yml
@@ -11,6 +11,17 @@ on:
         description: Target version of the Polkadot/Cumulus dependency
         required: true
         type: string
+      asignee:
+        description: Person assigned for this upgrade
+        required: false
+        default: weichweich
+        type: choice
+        options:
+        - weichweich
+        - ntn-x2
+        - trusch
+        - Ad96el
+
 jobs:
   runs-on: ubuntu-latest
   create-ticket:
@@ -42,8 +53,8 @@ jobs:
       - name: Put issue into weekly board
         uses: peter-evans/create-or-update-project-card@v2
         with:
-          # TODO: This will break if we change the name of the project
-          project-name: "Weekly Board 📅 Test & Release public credentials Chain 1.9.0 SDK 0.31 / CType Draft V2 / Documentation Engagement"
+          # Weekly board
+          project-number: 24
           column-name: "📥  Inbox"
           issue-number: ${{ steps.new-issue.outputs.issue-number }}
 


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2403.

I was playing around with `subalfred` and found out this nice feature, which we might want to integrate into our update flow. The action is configured to be run manually by providing the versions we are updating from and to.

~There is one thing that would break if we keep changing the weekly board project name to include the sprint goal, I think we could start tracking that separately.~ -> replaced `project-name` with `project-number`, thanks @ggera 

What do you guys think? Would it make sense?