### PR TITLE
chore: Bump to 1.11.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "attestation"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "ctype",
  "frame-benchmarking",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "ctype"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "delegation"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "attestation",
  "bitflags",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "did"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "ctype",
  "env_logger 0.10.0",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-asset-dids"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "base58",
  "frame-support",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-parachain"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-runtime-api-did"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "did",
  "kilt-support",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-runtime-api-public-credentials"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "kilt-support",
  "parity-scale-codec",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-runtime-api-staking"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-support"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "attestation",
  "ctype",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-lookup"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "base58",
  "blake2",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-inflation"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-web3-names"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6755,7 +6755,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "peregrine-runtime"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "attestation",
  "ctype",
@@ -8367,7 +8367,7 @@ dependencies = [
 
 [[package]]
 name = "public-credentials"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "ctype",
  "frame-benchmarking",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "attestation",
  "ctype",
@@ -11291,7 +11291,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spiritnet-runtime"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 dependencies = [
  "attestation",
  "ctype",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://kilt.io/"
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.10.0-dev"
+version = "1.11.0-dev"
 
 [workspace.dependencies]
 # Build deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
-[profile.release]
-panic = "unwind"
-lto = "fat"
+[workspace.package]
+authors = ["KILT <info@kilt.io>"]
+documentation = "https://docs.kilt.io"
+edition = "2021"
+homepage = "https://kilt.io/"
+license-file = "LICENSE"
+readme = "README.md"
+repository = "https://github.com/KILTprotocol/kilt-node"
+version = "1.11.0-dev"
 
 [workspace]
 members = [
@@ -12,15 +18,9 @@ members = [
   "crates/*",
 ]
 
-[workspace.package]
-authors = ["KILT <info@kilt.io>"]
-documentation = "https://docs.kilt.io"
-edition = "2021"
-homepage = "https://kilt.io/"
-license-file = "LICENSE"
-readme = "README.md"
-repository = "https://github.com/KILTprotocol/kilt-node"
-version = "1.11.0-dev"
+[profile.release]
+lto = "fat"
+panic = "unwind"
 
 [workspace.dependencies]
 # Build deps
@@ -32,9 +32,9 @@ bitflags = {version = "1.3.2", default-features = false}
 clap = "4.0.9"
 codec = {package = "parity-scale-codec", version = "3.1.5", default-features = false}
 env_logger = "0.10.0"
-futures = { version = "0.3.21", default-features = false}
-hex-literal = "0.3.4"
+futures = {version = "0.3.21", default-features = false}
 hex = {version = "0.4.0", default-features = false}
+hex-literal = "0.3.4"
 jsonrpsee = "0.16.2"
 libsecp256k1 = {version = "0.7", default-features = false}
 log = "0.4.17"
@@ -49,10 +49,10 @@ attestation = {path = "pallets/attestation", default-features = false}
 ctype = {path = "pallets/ctype", default-features = false}
 delegation = {path = "pallets/delegation", default-features = false}
 did = {path = "pallets/did", default-features = false}
-pallet-inflation = {path = "pallets/pallet-inflation", default-features = false}
-parachain-staking = {path = "pallets/parachain-staking", default-features = false}
 pallet-did-lookup = {path = "pallets/pallet-did-lookup", default-features = false}
+pallet-inflation = {path = "pallets/pallet-inflation", default-features = false}
 pallet-web3-names = {path = "pallets/pallet-web3-names", default-features = false}
+parachain-staking = {path = "pallets/parachain-staking", default-features = false}
 public-credentials = {path = "pallets/public-credentials", default-features = false}
 
 # Internal support (with default disabled)
@@ -62,8 +62,8 @@ runtime-common = {path = "runtimes/common", default-features = false}
 
 # Internal runtime API (with default disabled)
 kilt-runtime-api-did = {path = "runtime-api/did", default-features = false}
-kilt-runtime-api-staking = {path = "runtime-api/staking", default-features = false}
 kilt-runtime-api-public-credentials = {path = "runtime-api/public-credentials", default-features = false}
+kilt-runtime-api-staking = {path = "runtime-api/staking", default-features = false}
 
 # Internal KILT runtimes (with default disabled)
 mashnet-node-runtime = {path = "runtimes/standalone", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ mashnet-node-runtime = {path = "runtimes/standalone", default-features = false}
 peregrine-runtime = {path = "runtimes/peregrine", default-features = false}
 spiritnet-runtime = {path = "runtimes/spiritnet", default-features = false}
 
-
 # Benchmarking (with default disabled)
 cumulus-pallet-session-benchmarking = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
 frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.38"}
@@ -78,7 +77,6 @@ frame-system-benchmarking = {git = "https://github.com/paritytech/substrate", de
 # Cumulus (with default disabled)
 cumulus-pallet-aura-ext = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
 cumulus-pallet-dmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
-cumulus-pallet-solo-to-para = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
 cumulus-pallet-parachain-system = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
 cumulus-pallet-xcm = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}
 cumulus-pallet-xcmp-queue = {git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.38"}

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 11000,
+	spec_version: 11100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kilt-spiritnet"),
 	impl_name: create_runtime_str!("kilt-spiritnet"),
 	authoring_version: 1,
-	spec_version: 11000,
+	spec_version: 11100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 11000,
+	spec_version: 11100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,


### PR DESCRIPTION
increase the development version.

Future work on the develop branch will be part of 1.11.0. We therefore set the version to 1.11.0-dev.


In this PR I also removed an unused dependency (`cumulus-pallet-solo-to-para`) and reordered the dependencies in the Cargo.toml.


## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
