### PR TITLE
feat: add DID key verification relationship logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
+ "did",
  "frame-executive",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-utility",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",

--- a/dip-template/runtimes/dip-receiver/Cargo.toml
+++ b/dip-template/runtimes/dip-receiver/Cargo.toml
@@ -36,6 +36,7 @@ pallet-sudo.workspace = true
 pallet-timestamp.workspace = true
 pallet-transaction-payment.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
+pallet-utility.workspace = true
 polkadot-parachain.workspace = true
 sp-api.workspace = true
 sp-block-builder.workspace = true
@@ -90,6 +91,7 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
+  "pallet-utility/std",
   "polkadot-parachain/std",
 	"sp-api/std",
 	"sp-block-builder/std",

--- a/dip-template/runtimes/dip-receiver/Cargo.toml
+++ b/dip-template/runtimes/dip-receiver/Cargo.toml
@@ -18,6 +18,7 @@ codec = {package = "parity-scale-codec", workspace = true, features = ["derive"]
 scale-info = {workspace = true, features = ["derive"]}
 
 # DIP
+did.workspace = true
 pallet-did-lookup.workspace = true
 pallet-dip-receiver.workspace = true
 runtime-common.workspace = true
@@ -73,6 +74,7 @@ default = [
 std = [
 	"codec/std",
 	"scale-info/std",
+  "did/std",
   "pallet-did-lookup/std",
   "pallet-dip-receiver/std",
   "runtime-common/std",
@@ -117,10 +119,10 @@ std = [
 ]
 
 runtime-benchmarks = [
-  "frame-system/runtime-benchmarks",
-  "frame-support/runtime-benchmarks",
   "pallet-dip-receiver/runtime-benchmarks",
   "runtime-common/runtime-benchmarks",
-  "xcm-builder/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
   "pallet-xcm/runtime-benchmarks",
+  "xcm-builder/runtime-benchmarks",
 ]

--- a/dip-template/runtimes/dip-receiver/src/dip.rs
+++ b/dip-template/runtimes/dip-receiver/src/dip.rs
@@ -47,7 +47,10 @@ impl DipCallOriginFilter for DipCallFilter {
 	type Proof = VerificationResult<BlockNumber>;
 	type Success = ();
 
+	// Accepts only a DipOrigin for the DidLookup pallet calls.
 	fn check_proof(call: Self::Call, proof: Self::Proof) -> Result<Self::Success, Self::Error> {
+		// All calls in the pallet require a DID authentication key.
+		// TODO: Add support for nested calls.
 		if matches!(call, Self::Call::DidLookup { .. }) {
 			if proof
 				.0

--- a/dip-template/runtimes/dip-receiver/src/dip.rs
+++ b/dip-template/runtimes/dip-receiver/src/dip.rs
@@ -32,7 +32,6 @@ impl pallet_dip_receiver::Config for Runtime {
 	type Identifier = DidIdentifier;
 	type ProofLeaf = ProofLeaf<Hash, BlockNumber>;
 	type ProofDigest = Hash;
-	type ProofVerificationResult = ();
 	type ProofVerifier = DidMerkleProofVerifier<Hash, BlockNumber, Hasher>;
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;

--- a/dip-template/runtimes/dip-receiver/src/dip.rs
+++ b/dip-template/runtimes/dip-receiver/src/dip.rs
@@ -38,6 +38,34 @@ impl pallet_dip_receiver::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 }
 
+fn derive_verification_key_relationship(call: &RuntimeCall) -> Option<DidVerificationKeyRelationship> {
+	match call {
+		RuntimeCall::DidLookup { .. } => Some(DidVerificationKeyRelationship::Authentication),
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) => single_key_relationship(calls).ok(),
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) => single_key_relationship(calls).ok(),
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) => single_key_relationship(calls).ok(),
+		_ => None,
+	}
+}
+
+// Taken and adapted from `impl
+// did::DeriveDidCallAuthorizationVerificationKeyRelationship for RuntimeCall`
+// in Spiritnet/Peregrine runtime.
+fn single_key_relationship(calls: &[RuntimeCall]) -> Result<DidVerificationKeyRelationship, ()> {
+	let first_call_relationship = calls.get(0).and_then(derive_verification_key_relationship).ok_or(())?;
+	calls
+		.iter()
+		.skip(1)
+		.map(derive_verification_key_relationship)
+		.try_fold(first_call_relationship, |acc, next| {
+			if next == Some(acc) {
+				Ok(acc)
+			} else {
+				Err(())
+			}
+		})
+}
+
 pub struct DipCallFilter;
 
 impl DipCallOriginFilter<RuntimeCall> for DipCallFilter {
@@ -47,20 +75,52 @@ impl DipCallOriginFilter<RuntimeCall> for DipCallFilter {
 
 	// Accepts only a DipOrigin for the DidLookup pallet calls.
 	fn check_proof(call: RuntimeCall, proof: Self::Proof) -> Result<Self::Success, Self::Error> {
-		// All calls in the pallet require a DID authentication key.
-		// TODO: Add support for nested calls.
-		if matches!(call, RuntimeCall::DidLookup { .. }) {
-			if proof
-				.0
-				.iter()
-				.any(|l| l.relationship == DidVerificationKeyRelationship::Authentication.into())
-			{
-				Ok(())
-			} else {
-				Err(())
-			}
+		let key_relationship = single_key_relationship(&[call])?;
+		if proof.0.iter().any(|l| l.relationship == key_relationship.into()) {
+			Ok(())
 		} else {
 			Err(())
 		}
+	}
+}
+
+#[cfg(test)]
+mod dip_call_origin_filter_tests {
+	use super::*;
+
+	use frame_support::assert_err;
+
+	#[test]
+	fn test_key_relationship_derivation() {
+		// Can call DidLookup functions with an authentication key
+		let did_lookup_call = RuntimeCall::DidLookup(pallet_did_lookup::Call::associate_sender {});
+		assert_eq!(
+			single_key_relationship(&[did_lookup_call]),
+			Ok(DidVerificationKeyRelationship::Authentication)
+		);
+		// Can't call System functions with a DID key (hence a DIP origin)
+		let system_call = RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+		assert_err!(single_key_relationship(&[system_call]), ());
+		// Can't call empty batch with a DID key
+		let empty_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all { calls: vec![] });
+		assert_err!(single_key_relationship(&[empty_batch_call]), ());
+		// Can call batch with a DipLookup with an authentication key
+		let did_lookup_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+			calls: vec![pallet_did_lookup::Call::associate_sender {}.into()],
+		});
+		assert_eq!(
+			single_key_relationship(&[did_lookup_batch_call]),
+			Ok(DidVerificationKeyRelationship::Authentication)
+		);
+		// Can't call a batch with different required keys
+		let did_lookup_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all {
+			calls: vec![
+				// Authentication key
+				pallet_did_lookup::Call::associate_sender {}.into(),
+				// No key
+				frame_system::Call::remark { remark: vec![] }.into(),
+			],
+		});
+		assert_err!(single_key_relationship(&[did_lookup_batch_call]), ());
 	}
 }

--- a/dip-template/runtimes/dip-receiver/src/dip.rs
+++ b/dip-template/runtimes/dip-receiver/src/dip.rs
@@ -40,17 +40,16 @@ impl pallet_dip_receiver::Config for Runtime {
 
 pub struct DipCallFilter;
 
-impl DipCallOriginFilter for DipCallFilter {
-	type Call = RuntimeCall;
+impl DipCallOriginFilter<RuntimeCall> for DipCallFilter {
 	type Error = ();
 	type Proof = VerificationResult<BlockNumber>;
 	type Success = ();
 
 	// Accepts only a DipOrigin for the DidLookup pallet calls.
-	fn check_proof(call: Self::Call, proof: Self::Proof) -> Result<Self::Success, Self::Error> {
+	fn check_proof(call: RuntimeCall, proof: Self::Proof) -> Result<Self::Success, Self::Error> {
 		// All calls in the pallet require a DID authentication key.
 		// TODO: Add support for nested calls.
-		if matches!(call, Self::Call::DidLookup { .. }) {
+		if matches!(call, RuntimeCall::DidLookup { .. }) {
 			if proof
 				.0
 				.iter()

--- a/dip-template/runtimes/dip-receiver/src/dip.rs
+++ b/dip-template/runtimes/dip-receiver/src/dip.rs
@@ -16,10 +16,11 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
+use did::DidVerificationKeyRelationship;
 use pallet_dip_receiver::traits::DipCallOriginFilter;
 use runtime_common::dip::{
 	receiver::{DidMerkleProofVerifier, VerificationResult},
-	ProofLeaf, KeyRelationship,
+	ProofLeaf,
 };
 use sp_std::vec::Vec;
 
@@ -50,7 +51,8 @@ impl DipCallOriginFilter for DipCallFilter {
 		if matches!(call, Self::Call::DidLookup { .. }) {
 			if proof
 				.0
-				.contains(|l| matches!(l.relationship, KeyRelationship::))
+				.iter()
+				.any(|l| l.relationship == DidVerificationKeyRelationship::Authentication.into())
 			{
 				Ok(())
 			} else {

--- a/dip-template/runtimes/dip-receiver/src/lib.rs
+++ b/dip-template/runtimes/dip-receiver/src/lib.rs
@@ -358,8 +358,8 @@ impl pallet_did_lookup::Config for Runtime {
 	type Currency = Balances;
 	type Deposit = ConstU128<UNIT>;
 	type DidIdentifier = DidIdentifier;
-	type EnsureOrigin = EnsureDipOrigin<DidIdentifier, AccountId>;
-	type OriginSuccess = DipOrigin<DidIdentifier, AccountId>;
+	type EnsureOrigin = EnsureDipOrigin<DidIdentifier, AccountId, ()>;
+	type OriginSuccess = DipOrigin<DidIdentifier, AccountId, ()>;
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 }

--- a/dip-template/runtimes/dip-receiver/src/lib.rs
+++ b/dip-template/runtimes/dip-receiver/src/lib.rs
@@ -119,6 +119,7 @@ construct_runtime!(
 		Timestamp: pallet_timestamp = 2,
 		ParachainInfo: parachain_info = 3,
 		Sudo: pallet_sudo = 4,
+		Utility: pallet_utility = 5,
 
 		// Money
 		Balances: pallet_balances = 10,
@@ -275,6 +276,13 @@ impl parachain_info::Config for Runtime {}
 impl pallet_sudo::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
+}
+
+impl pallet_utility::Config for Runtime {
+	type PalletsOrigin = OriginCaller;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
 }
 
 pub const EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;

--- a/pallets/pallet-dip-receiver/src/lib.rs
+++ b/pallets/pallet-dip-receiver/src/lib.rs
@@ -40,6 +40,7 @@ pub mod pallet {
 
 	pub type VersionedIdentityProofOf<T> =
 		VersionedIdentityProof<<T as Config>::BlindedValue, <T as Config>::ProofLeaf>;
+	pub type VerificationResultOf<T> = <<T as Config>::ProofVerifier as IdentityProofVerifier>::VerificationResult;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -55,12 +56,10 @@ pub mod pallet {
 		type DipCallOriginFilter: DipCallOriginFilter<
 			Call = <Self as Config>::RuntimeCall,
 			Proof = <Self::ProofVerifier as IdentityProofVerifier>::VerificationResult,
-			Success = Self::ProofVerificationResult,
 		>;
 		type Identifier: Parameter + MaxEncodedLen;
 		type ProofLeaf: Parameter;
 		type ProofDigest: Parameter + MaxEncodedLen;
-		type ProofVerificationResult;
 		type ProofVerifier: IdentityProofVerifier<
 			BlindedValue = Self::BlindedValue,
 			ProofDigest = Self::ProofDigest,
@@ -100,7 +99,7 @@ pub mod pallet {
 	pub type Origin<T> = DipOrigin<
 		<T as Config>::Identifier,
 		<T as frame_system::Config>::AccountId,
-		<T as Config>::ProofVerificationResult,
+		<<T as Config>::DipCallOriginFilter as DipCallOriginFilter>::Success,
 	>;
 
 	// TODO: Benchmarking

--- a/pallets/pallet-dip-receiver/src/lib.rs
+++ b/pallets/pallet-dip-receiver/src/lib.rs
@@ -36,7 +36,7 @@ pub mod pallet {
 
 	use dip_support::{latest::IdentityProofAction, VersionedIdentityProof, VersionedIdentityProofAction};
 
-	use crate::traits::IdentityProofVerifier;
+	use crate::traits::{DipCallOriginFilter, IdentityProofVerifier};
 
 	pub type VersionedIdentityProofOf<T> =
 		VersionedIdentityProof<<T as Config>::BlindedValue, <T as Config>::ProofLeaf>;
@@ -52,9 +52,15 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type BlindedValue: Parameter;
+		type DipCallOriginFilter: DipCallOriginFilter<
+			Call = <Self as Config>::RuntimeCall,
+			Proof = <Self::ProofVerifier as IdentityProofVerifier>::VerificationResult,
+			Success = Self::ProofVerificationResult,
+		>;
 		type Identifier: Parameter + MaxEncodedLen;
 		type ProofLeaf: Parameter;
 		type ProofDigest: Parameter + MaxEncodedLen;
+		type ProofVerificationResult;
 		type ProofVerifier: IdentityProofVerifier<
 			BlindedValue = Self::BlindedValue,
 			ProofDigest = Self::ProofDigest,
@@ -80,7 +86,9 @@ pub mod pallet {
 	}
 
 	#[pallet::error]
+
 	pub enum Error<T> {
+		BadOrigin,
 		Dispatch,
 		IdentityNotFound,
 		InvalidProof,
@@ -89,7 +97,11 @@ pub mod pallet {
 
 	// The new origin other pallets can use.
 	#[pallet::origin]
-	pub type Origin<T> = DipOrigin<<T as Config>::Identifier, <T as frame_system::Config>::AccountId>;
+	pub type Origin<T> = DipOrigin<
+		<T as Config>::Identifier,
+		<T as frame_system::Config>::AccountId,
+		<T as Config>::ProofVerificationResult,
+	>;
 
 	// TODO: Benchmarking
 	#[pallet::call]
@@ -130,12 +142,17 @@ pub mod pallet {
 		) -> DispatchResult {
 			let submitter = ensure_signed(origin)?;
 			let proof_digest = IdentityProofs::<T>::get(&identifier).ok_or(Error::<T>::IdentityNotFound)?;
-			let _ = T::ProofVerifier::verify_proof_against_digest(proof, proof_digest)
+			let proof_verification_result = T::ProofVerifier::verify_proof_against_digest(proof, proof_digest)
 				.map_err(|_| Error::<T>::InvalidProof)?;
+			// TODO: Better error handling
+			// TODO: Avoid cloning `call`
+			let proof_result = T::DipCallOriginFilter::check_proof(*call.clone(), proof_verification_result)
+				.map_err(|_| Error::<T>::BadOrigin)?;
 			// TODO: Proper DID signature verification (and cross-chain replay protection)
 			let did_origin = DipOrigin {
 				identifier,
 				account_address: submitter,
+				proof: proof_result,
 			};
 			// TODO: Use dispatch info for weight calculation
 			let _ = call.dispatch(did_origin.into()).map_err(|_| Error::<T>::Dispatch)?;

--- a/pallets/pallet-dip-receiver/src/lib.rs
+++ b/pallets/pallet-dip-receiver/src/lib.rs
@@ -53,10 +53,7 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type BlindedValue: Parameter;
-		type DipCallOriginFilter: DipCallOriginFilter<
-			Call = <Self as Config>::RuntimeCall,
-			Proof = VerificationResultOf<Self>,
-		>;
+		type DipCallOriginFilter: DipCallOriginFilter<<Self as Config>::RuntimeCall, Proof = VerificationResultOf<Self>>;
 		type Identifier: Parameter + MaxEncodedLen;
 		type ProofLeaf: Parameter;
 		type ProofDigest: Parameter + MaxEncodedLen;
@@ -98,7 +95,7 @@ pub mod pallet {
 	pub type Origin<T> = DipOrigin<
 		<T as Config>::Identifier,
 		<T as frame_system::Config>::AccountId,
-		<<T as Config>::DipCallOriginFilter as DipCallOriginFilter>::Success,
+		<<T as Config>::DipCallOriginFilter as DipCallOriginFilter<<T as Config>::RuntimeCall>>::Success,
 	>;
 
 	// TODO: Benchmarking

--- a/pallets/pallet-dip-receiver/src/lib.rs
+++ b/pallets/pallet-dip-receiver/src/lib.rs
@@ -38,9 +38,9 @@ pub mod pallet {
 
 	use crate::traits::{DipCallOriginFilter, IdentityProofVerifier};
 
+	pub type VerificationResultOf<T> = <<T as Config>::ProofVerifier as IdentityProofVerifier>::VerificationResult;
 	pub type VersionedIdentityProofOf<T> =
 		VersionedIdentityProof<<T as Config>::BlindedValue, <T as Config>::ProofLeaf>;
-	pub type VerificationResultOf<T> = <<T as Config>::ProofVerifier as IdentityProofVerifier>::VerificationResult;
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
@@ -55,7 +55,7 @@ pub mod pallet {
 		type BlindedValue: Parameter;
 		type DipCallOriginFilter: DipCallOriginFilter<
 			Call = <Self as Config>::RuntimeCall,
-			Proof = <Self::ProofVerifier as IdentityProofVerifier>::VerificationResult,
+			Proof = VerificationResultOf<Self>,
 		>;
 		type Identifier: Parameter + MaxEncodedLen;
 		type ProofLeaf: Parameter;
@@ -85,7 +85,6 @@ pub mod pallet {
 	}
 
 	#[pallet::error]
-
 	pub enum Error<T> {
 		BadOrigin,
 		Dispatch,

--- a/pallets/pallet-dip-receiver/src/lib.rs
+++ b/pallets/pallet-dip-receiver/src/lib.rs
@@ -152,7 +152,7 @@ pub mod pallet {
 			let did_origin = DipOrigin {
 				identifier,
 				account_address: submitter,
-				proof: proof_result,
+				details: proof_result,
 			};
 			// TODO: Use dispatch info for weight calculation
 			let _ = call.dispatch(did_origin.into()).map_err(|_| Error::<T>::Dispatch)?;

--- a/pallets/pallet-dip-receiver/src/origin.rs
+++ b/pallets/pallet-dip-receiver/src/origin.rs
@@ -22,22 +22,22 @@ use scale_info::TypeInfo;
 use sp_std::marker::PhantomData;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-pub struct DipOrigin<Identifier, AccountId, Proof> {
+pub struct DipOrigin<Identifier, AccountId, Details> {
 	pub identifier: Identifier,
 	pub account_address: AccountId,
-	pub proof: Proof,
+	pub details: Details,
 }
 
-pub struct EnsureDipOrigin<Identifier, AccountId, Proof>(PhantomData<(Identifier, AccountId, Proof)>);
+pub struct EnsureDipOrigin<Identifier, AccountId, Details>(PhantomData<(Identifier, AccountId, Details)>);
 
 #[cfg(not(feature = "runtime-benchmarks"))]
-impl<OuterOrigin, Identifier, AccountId, Proof> EnsureOrigin<OuterOrigin>
-	for EnsureDipOrigin<Identifier, AccountId, Proof>
+impl<OuterOrigin, Identifier, AccountId, Details> EnsureOrigin<OuterOrigin>
+	for EnsureDipOrigin<Identifier, AccountId, Details>
 where
-	OuterOrigin: From<DipOrigin<Identifier, AccountId, Proof>>
-		+ Into<Result<DipOrigin<Identifier, AccountId, Proof>, OuterOrigin>>,
+	OuterOrigin: From<DipOrigin<Identifier, AccountId, Details>>
+		+ Into<Result<DipOrigin<Identifier, AccountId, Details>, OuterOrigin>>,
 {
-	type Success = DipOrigin<Identifier, AccountId, Proof>;
+	type Success = DipOrigin<Identifier, AccountId, Details>;
 
 	fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
 		o.into()
@@ -45,17 +45,17 @@ where
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-impl<OuterOrigin, Identifier, AccountId, Proof> EnsureOrigin<OuterOrigin>
-	for EnsureDipOrigin<Identifier, AccountId, Proof>
+impl<OuterOrigin, Identifier, AccountId, Details> EnsureOrigin<OuterOrigin>
+	for EnsureDipOrigin<Identifier, AccountId, Details>
 where
-	OuterOrigin: From<DipOrigin<Identifier, AccountId, Proof>>
-		+ Into<Result<DipOrigin<Identifier, AccountId, Proof>, OuterOrigin>>,
+	OuterOrigin: From<DipOrigin<Identifier, AccountId, Details>>
+		+ Into<Result<DipOrigin<Identifier, AccountId, Details>, OuterOrigin>>,
 	// Additional trait bounds only valid when benchmarking
 	Identifier: From<[u8; 32]>,
 	AccountId: From<[u8; 32]>,
-	Proof: Default,
+	Details: Default,
 {
-	type Success = DipOrigin<Identifier, AccountId, Proof>;
+	type Success = DipOrigin<Identifier, AccountId, Details>;
 
 	fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
 		o.into()
@@ -65,13 +65,13 @@ where
 		Ok(OuterOrigin::from(DipOrigin {
 			identifier: Identifier::from([0u8; 32]),
 			account_address: AccountId::from([0u8; 32]),
-			proof: Default::default(),
+			details: Default::default(),
 		}))
 	}
 }
 
-impl<Identifier, AccountId, Proof> kilt_support::traits::CallSources<AccountId, Identifier>
-	for DipOrigin<Identifier, AccountId, Proof>
+impl<Identifier, AccountId, Details> kilt_support::traits::CallSources<AccountId, Identifier>
+	for DipOrigin<Identifier, AccountId, Details>
 where
 	Identifier: Clone,
 	AccountId: Clone,

--- a/pallets/pallet-dip-receiver/src/origin.rs
+++ b/pallets/pallet-dip-receiver/src/origin.rs
@@ -55,7 +55,7 @@ where
 	AccountId: From<[u8; 32]>,
 	Proof: Default,
 {
-	type Success = DipOrigin<Identifier, AccountId>;
+	type Success = DipOrigin<Identifier, AccountId, Proof>;
 
 	fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
 		o.into()

--- a/pallets/pallet-dip-receiver/src/traits.rs
+++ b/pallets/pallet-dip-receiver/src/traits.rs
@@ -51,11 +51,10 @@ impl<ProofDigest, Leaf, BlindedValue> IdentityProofVerifier
 	}
 }
 
-pub trait DipCallOriginFilter {
-	type Call;
+pub trait DipCallOriginFilter<Call> {
 	type Error;
 	type Proof;
 	type Success;
 
-	fn check_proof(call: Self::Call, proof: Self::Proof) -> Result<Self::Success, Self::Error>;
+	fn check_proof(call: Call, proof: Self::Proof) -> Result<Self::Success, Self::Error>;
 }

--- a/pallets/pallet-dip-receiver/src/traits.rs
+++ b/pallets/pallet-dip-receiver/src/traits.rs
@@ -50,3 +50,12 @@ impl<ProofDigest, Leaf, BlindedValue> IdentityProofVerifier
 		Ok(())
 	}
 }
+
+pub trait DipCallOriginFilter {
+	type Call;
+	type Error;
+	type Proof;
+	type Success;
+
+	fn check_proof(call: Self::Call, proof: Self::Proof) -> Result<Self::Success, Self::Error>;
+}

--- a/runtimes/common/src/dip/receiver.rs
+++ b/runtimes/common/src/dip/receiver.rs
@@ -45,6 +45,12 @@ impl<BlockNumber> From<Vec<ProofEntry<BlockNumber>>> for VerificationResult<Bloc
 	}
 }
 
+impl<BlockNumber> VerificationResult<BlockNumber> {
+	pub fn into_inner(self) -> Vec<ProofEntry<BlockNumber>> {
+		self.0
+	}
+}
+
 pub struct DidMerkleProofVerifier<KeyId, BlockNumber, Hasher>(PhantomData<(KeyId, BlockNumber, Hasher)>);
 
 impl<KeyId, BlockNumber, Hasher> IdentityProofVerifier for DidMerkleProofVerifier<KeyId, BlockNumber, Hasher>

--- a/runtimes/common/src/dip/receiver.rs
+++ b/runtimes/common/src/dip/receiver.rs
@@ -45,12 +45,6 @@ impl<BlockNumber> From<Vec<ProofEntry<BlockNumber>>> for VerificationResult<Bloc
 	}
 }
 
-impl<BlockNumber> VerificationResult<BlockNumber> {
-	pub fn into_inner(self) -> Vec<ProofEntry<BlockNumber>> {
-		self.0
-	}
-}
-
 pub struct DidMerkleProofVerifier<KeyId, BlockNumber, Hasher>(PhantomData<(KeyId, BlockNumber, Hasher)>);
 
 impl<KeyId, BlockNumber, Hasher> IdentityProofVerifier for DidMerkleProofVerifier<KeyId, BlockNumber, Hasher>


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2587.

This PR adds a new trait `DipCallOriginFilter` that exposes a `fn check_proof(call: Call, proof: Self::Proof) -> Result<Self::Success, Self::Error>` function, called by the runtime to verify if a call can be dispatched with the provided proof or not.