### PR TITLE
chore: update gitlab cargo test steps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ test-features:
   image: paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e
   stage: test
   script:
-    - cargo test --all --all-features --all-targets
+    - cargo test --all --all-features --all-targets --locked
 
 build:
   timeout: 2 hours

--- a/runtimes/common/src/migrations.rs
+++ b/runtimes/common/src/migrations.rs
@@ -24,6 +24,7 @@ use sp_io::MultiRemovalResults;
 use sp_std::marker::PhantomData;
 
 const PALLET_RUNTIME_NAME: &[u8] = b"RandomnessCollectiveFlip";
+#[cfg(feature = "try-runtime")]
 const PALLET_STORAGE_NAME: &[u8] = b"RandomMaterial";
 
 pub struct RemoveInsecureRandomnessPallet<T>(PhantomData<T>);


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2637.

I wanted to also remove the `test-features` step, but we still do something weird inside the DID pallet, so I would remove that only when we have a proper mechanism in place to distinguish between tests and tests + benchmarks flag.

I also fixed a small Clippy warning for the randomness pallet removal migration 😄