### PR TITLE
feat: bump number of URLs for a service endpoint to 2

### DIFF
--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -321,20 +321,23 @@ pub mod multisig {
 pub mod did {
 	use super::*;
 
-	/// The size is checked in the runtime by a test.
-	pub const MAX_DID_BYTE_LENGTH: u32 = 9918;
-
 	///  Max length of a key
 	pub const MAX_KEY_LENGTH: u32 = 32;
 
-	pub const MAX_SERVICE_ENDPOINT_BYTE_LENGTH: u32 =
-		MAX_SERVICE_URL_LENGTH + MAX_SERVICE_ID_LENGTH + MAX_SERVICE_TYPE_LENGTH;
+	///  Max length of a single service entry.
+	/// It is the sum of:
+	/// - the maximum service ID length
+	/// - the maximum service type length * the maximum number of service types
+	///   for a single service
+	/// - the maximum service URL length * the maximum number of URLs for a
+	///   single service
+	pub const MAX_SERVICE_ENDPOINT_BYTE_LENGTH: u32 = MAX_SERVICE_ID_LENGTH
+		+ MAX_NUMBER_OF_TYPES_PER_SERVICE * MAX_SERVICE_TYPE_LENGTH
+		+ MAX_NUMBER_OF_URLS_PER_SERVICE * MAX_SERVICE_URL_LENGTH;
 
 	pub const DID_BASE_DEPOSIT: Balance = 2 * KILT;
 	pub const KEY_DEPOSIT: Balance = deposit(0, MAX_KEY_LENGTH);
 	pub const SERVICE_ENDPOINT_DEPOSIT: Balance = deposit(1, MAX_SERVICE_ENDPOINT_BYTE_LENGTH);
-	pub const MAX_DEPOSIT_DID: Balance =
-		deposit(2 + MAX_NUMBER_OF_SERVICES_PER_DID, MAX_DID_BYTE_LENGTH) + DID_BASE_DEPOSIT;
 
 	pub const DID_FEE: Balance = 50 * MILLI_KILT;
 	pub const MAX_KEY_AGREEMENT_KEYS: u32 = 10;
@@ -350,7 +353,7 @@ pub mod did {
 	pub const MAX_SERVICE_TYPE_LENGTH: u32 = 50;
 	pub const MAX_NUMBER_OF_TYPES_PER_SERVICE: u32 = 1;
 	pub const MAX_SERVICE_URL_LENGTH: u32 = 200;
-	pub const MAX_NUMBER_OF_URLS_PER_SERVICE: u32 = 1;
+	pub const MAX_NUMBER_OF_URLS_PER_SERVICE: u32 = 2;
 
 	parameter_types! {
 		pub const MaxNewKeyAgreementKeys: u32 = MAX_KEY_AGREEMENT_KEYS;

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -321,8 +321,8 @@ pub mod multisig {
 pub mod did {
 	use super::*;
 
-	///  Max length of a key
-	pub const MAX_KEY_LENGTH: u32 = 32;
+	///  Max length of a key (including its enum discriminants).
+	pub const MAX_KEY_LENGTH: u32 = 35;
 
 	///  Max length of a single service entry.
 	/// It is the sum of:
@@ -331,9 +331,13 @@ pub mod did {
 	///   for a single service
 	/// - the maximum service URL length * the maximum number of URLs for a
 	///   single service
+	/// - Additional padding bytes to make up for the different encoding size of
+	///   the different const values (each BoundedVec has additional bytes
+	///   encoded in compact form indicating the max length of the vec)
 	pub const MAX_SERVICE_ENDPOINT_BYTE_LENGTH: u32 = MAX_SERVICE_ID_LENGTH
 		+ MAX_NUMBER_OF_TYPES_PER_SERVICE * MAX_SERVICE_TYPE_LENGTH
-		+ MAX_NUMBER_OF_URLS_PER_SERVICE * MAX_SERVICE_URL_LENGTH;
+		+ MAX_NUMBER_OF_URLS_PER_SERVICE * MAX_SERVICE_URL_LENGTH
+		+ 8;
 
 	pub const DID_BASE_DEPOSIT: Balance = 2 * KILT;
 	pub const KEY_DEPOSIT: Balance = deposit(0, MAX_KEY_LENGTH);

--- a/runtimes/peregrine/src/tests.rs
+++ b/runtimes/peregrine/src/tests.rs
@@ -25,8 +25,11 @@ use pallet_treasury::BalanceOf;
 use pallet_web3_names::{Web3NameOf, Web3OwnershipOf};
 use runtime_common::{
 	constants::{
-		attestation::MAX_ATTESTATION_BYTE_LENGTH, did::MAX_DID_BYTE_LENGTH, did_lookup::MAX_CONNECTION_BYTE_LENGTH,
-		public_credentials::MAX_PUBLIC_CREDENTIAL_STORAGE_LENGTH, web3_names::MAX_NAME_BYTE_LENGTH,
+		attestation::MAX_ATTESTATION_BYTE_LENGTH,
+		did::{MAX_KEY_LENGTH, MAX_SERVICE_ENDPOINT_BYTE_LENGTH},
+		did_lookup::MAX_CONNECTION_BYTE_LENGTH,
+		public_credentials::MAX_PUBLIC_CREDENTIAL_STORAGE_LENGTH,
+		web3_names::MAX_NAME_BYTE_LENGTH,
 		MAX_INDICES_BYTE_LENGTH,
 	},
 	AccountId, BlockNumber,
@@ -60,14 +63,13 @@ fn attestation_storage_sizes() {
 
 #[test]
 fn did_storage_sizes() {
-	let did_size = did::did_details::DidDetails::<Runtime>::max_encoded_len();
+	// Service endpoint
+	let max_did_endpoint_size = did::service_endpoints::DidEndpoint::<Runtime>::max_encoded_len();
+	assert_eq!(max_did_endpoint_size, MAX_SERVICE_ENDPOINT_BYTE_LENGTH as usize);
 
-	// service endpoints and counter
-	let did_endpoint_size = did::service_endpoints::DidEndpoint::<Runtime>::max_encoded_len()
-		* (<Runtime as did::Config>::MaxNumberOfServicesPerDid::get() as usize)
-		+ u32::max_encoded_len();
-
-	assert_eq!(did_size + did_endpoint_size, MAX_DID_BYTE_LENGTH as usize)
+	// DID key
+	let max_did_key_size = did::did_details::DidPublicKey::max_encoded_len();
+	assert_eq!(max_did_key_size, MAX_KEY_LENGTH as usize);
 }
 
 #[test]

--- a/runtimes/spiritnet/src/tests.rs
+++ b/runtimes/spiritnet/src/tests.rs
@@ -25,8 +25,11 @@ use pallet_treasury::BalanceOf;
 use pallet_web3_names::{Web3NameOf, Web3OwnershipOf};
 use runtime_common::{
 	constants::{
-		attestation::MAX_ATTESTATION_BYTE_LENGTH, did::MAX_DID_BYTE_LENGTH, did_lookup::MAX_CONNECTION_BYTE_LENGTH,
-		public_credentials::MAX_PUBLIC_CREDENTIAL_STORAGE_LENGTH, web3_names::MAX_NAME_BYTE_LENGTH,
+		attestation::MAX_ATTESTATION_BYTE_LENGTH,
+		did::{MAX_KEY_LENGTH, MAX_SERVICE_ENDPOINT_BYTE_LENGTH},
+		did_lookup::MAX_CONNECTION_BYTE_LENGTH,
+		public_credentials::MAX_PUBLIC_CREDENTIAL_STORAGE_LENGTH,
+		web3_names::MAX_NAME_BYTE_LENGTH,
 		MAX_INDICES_BYTE_LENGTH,
 	},
 	AccountId, BlockNumber,
@@ -60,14 +63,13 @@ fn attestation_storage_sizes() {
 
 #[test]
 fn did_storage_sizes() {
-	let did_size = did::did_details::DidDetails::<Runtime>::max_encoded_len();
+	// Service endpoint
+	let max_did_endpoint_size = did::service_endpoints::DidEndpoint::<Runtime>::max_encoded_len();
+	assert_eq!(max_did_endpoint_size, MAX_SERVICE_ENDPOINT_BYTE_LENGTH as usize);
 
-	// service endpoints and counter
-	let did_endpoint_size = did::service_endpoints::DidEndpoint::<Runtime>::max_encoded_len()
-		* (<Runtime as did::Config>::MaxNumberOfServicesPerDid::get() as usize)
-		+ u32::max_encoded_len();
-
-	assert_eq!(did_size + did_endpoint_size, MAX_DID_BYTE_LENGTH as usize)
+	// DID key
+	let max_did_key_size = did::did_details::DidPublicKey::max_encoded_len();
+	assert_eq!(max_did_key_size, MAX_KEY_LENGTH as usize);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2633.

It also removes some unused constants and adjusts the value of the max encoded length for both a service endpoint and a DID key, keeping in mind the additional bytes that a `BoundedVec` stores along with the actual data. The padding for a service endpoint is added after running the test, since the number of additional bytes depends on the encoding of the maximum limit for it. Tests as they are run now should ALWAYS catch any changes in this value.