### PR TITLE
feat: configurable origin check for 'commit_identity'

### DIFF
--- a/dip-template/runtimes/dip-provider/src/dip.rs
+++ b/dip-template/runtimes/dip-provider/src/dip.rs
@@ -16,13 +16,16 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
+use did::EnsureDidOrigin;
 use dip_support::IdentityDetailsAction;
+use frame_support::traits::EitherOfDiverse;
+use frame_system::EnsureRoot;
 use pallet_dip_provider::traits::{TxBuilder, XcmRouterDispatcher};
 use parity_scale_codec::{Decode, Encode};
 use runtime_common::dip::{did::LinkedDidInfoProviderOf, merkle::DidMerkleRootGenerator};
 use xcm::{latest::MultiLocation, DoubleEncoded};
 
-use crate::{DidIdentifier, Hash, Runtime, RuntimeEvent, XcmRouter};
+use crate::{AccountId, DidIdentifier, Hash, Runtime, RuntimeEvent, XcmRouter};
 
 #[derive(Encode, Decode)]
 enum ConsumerParachainCalls {
@@ -53,6 +56,7 @@ impl TxBuilder<DidIdentifier, Hash> for ConsumerParachainTxBuilder {
 }
 
 impl pallet_dip_provider::Config for Runtime {
+	type CommitOrigin = EitherOfDiverse<EnsureRoot<AccountId>, EnsureDidOrigin<DidIdentifier, AccountId>>;
 	type Identifier = DidIdentifier;
 	type IdentityProofDispatcher = XcmRouterDispatcher<XcmRouter, DidIdentifier, Hash>;
 	type IdentityProofGenerator = DidMerkleRootGenerator<Runtime>;

--- a/dip-template/runtimes/xcm-tests/src/tests.rs
+++ b/dip-template/runtimes/xcm-tests/src/tests.rs
@@ -46,7 +46,7 @@ use dip_consumer_runtime_template::{
 	BlockNumber, DidIdentifier, DidLookup, DipConsumer, Runtime as ConsumerRuntime, RuntimeCall as ConsumerRuntimeCall,
 	RuntimeEvent, System,
 };
-use dip_provider_runtime_template::{AccountId as ProviderAccountId, DipProvider, Runtime as ProviderRuntime};
+use dip_provider_runtime_template::{DipProvider, Runtime as ProviderRuntime};
 
 #[test]
 fn commit_identity() {
@@ -57,7 +57,7 @@ fn commit_identity() {
 	// 1. Send identity commitment from DIP provider to DIP consumer.
 	ProviderParachain::execute_with(|| {
 		assert_ok!(DipProvider::commit_identity(
-			RawOrigin::Signed(ProviderAccountId::from([0u8; 32])).into(),
+			RawOrigin::Root.into(),
 			did.clone(),
 			Box::new(ParentThen(X1(Parachain(para::consumer::PARA_ID))).into()),
 			Box::new((Here, 1_000_000_000).into()),

--- a/pallets/pallet-dip-provider/src/lib.rs
+++ b/pallets/pallet-dip-provider/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::pallet::*;
 pub mod pallet {
 	use super::*;
 
-	use frame_support::{pallet_prelude::*, weights::Weight};
+	use frame_support::{pallet_prelude::*, traits::EnsureOrigin, weights::Weight};
 	use frame_system::pallet_prelude::*;
 	use sp_std::{boxed::Box, fmt::Debug};
 	use xcm::{latest::prelude::*, VersionedMultiAsset, VersionedMultiLocation};
@@ -44,6 +44,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
+		type CommitOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 		type Identifier: Parameter;
 		type IdentityProofGenerator: IdentityProofGenerator<
 			Self::Identifier,
@@ -90,7 +91,7 @@ pub mod pallet {
 			weight: Weight,
 		) -> DispatchResult {
 			// TODO: Charge the dispatcher based on the destination weight configuration
-			ensure_signed(origin)?;
+			T::CommitOrigin::ensure_origin(origin)?;
 
 			let destination: MultiLocation = (*destination).try_into().map_err(|_| Error::<T>::BadVersion)?;
 			let action: IdentityProofActionOf<T> = match T::IdentityProvider::retrieve(&identifier) {


### PR DESCRIPTION
Identity information should be entirely under the control of the DID subject. Until now, it was not the case as anyone could have called the `commit_identity` extrinsic for any DID subject.
This PR changes the origin check for the `commit_identity` extrinsic of provider pallet from `EnsureSigned` to a configurable origin check.
The XCM integration tests have also been updated to use the `EitherOfDiverse<EnsureRoot<AccountId>, EnsureDidOrigin<DidIdentifier, AccountId>>;` implementation.
Now, except for cases where democracy decides to do this operation, the DID subject has to agree to it by signing the operation, which will then be dispatched via the `submit_did_call` extrinsic of the DID pallet.

The feature that any account can pay for the fees still applies, as that is the same also for DID-signed extrinsics.