### PR TITLE
feat: add tracing support to peregrine&spiritnet

### DIFF
--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -268,3 +268,7 @@ try-runtime = [
   "public-credentials/try-runtime",
   "runtime-common/try-runtime",
 ]
+with-tracing = [
+  "frame-executive/with-tracing",
+  "sp-io/with-tracing"
+]

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -260,3 +260,7 @@ try-runtime = [
   "public-credentials/try-runtime",
   "runtime-common/try-runtime",
 ]
+with-tracing = [
+  "frame-executive/with-tracing",
+  "sp-io/with-tracing"
+]


### PR DESCRIPTION
## fixes 

Add `with-tracing` feature to the peregrine and spiritnet runtime.

This should never be used for production runtimes. But runtimes build with tracing support can be used to temporarily replace the on-chain code (`--wasm-runtime-overrides`).

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
