### PR TITLE
feat: restrict charset of a DID service ID and endpoint

### DIFF
--- a/pallets/did/src/mock_utils.rs
+++ b/pallets/did/src/mock_utils.rs
@@ -60,8 +60,9 @@ pub fn get_service_endpoints<T: Config>(
 ) -> Vec<DidEndpoint<T>> {
 	(0..count)
 		.map(|i| {
-			let mut endpoint_id = i.to_be_bytes().to_vec();
-			endpoint_id.resize(endpoint_id_length.saturated_into(), 0u8);
+			// Create a string of characters of all 'a', 'b', 'c', and so on depending on
+			// the current iteration value, given by `i`.
+			let endpoint_id = vec![b'a' + i as u8; endpoint_id_length.saturated_into()];
 			let endpoint_types = (0..endpoint_type_count)
 				.map(|t| {
 					let mut endpoint_type = t.to_be_bytes().to_vec();
@@ -71,9 +72,9 @@ pub fn get_service_endpoints<T: Config>(
 				.collect();
 			let endpoint_urls = (0..endpoint_url_count)
 				.map(|u| {
-					let mut endpoint_url = u.to_be_bytes().to_vec();
-					endpoint_url.resize(endpoint_url_length.saturated_into(), 0u8);
-					endpoint_url
+					// Create a string of characters of all 'a', 'b', 'c', and so on depending on
+					// the  iteration value, given by `u`.current
+					vec![b'a' + u as u8; endpoint_url_length.saturated_into()]
 				})
 				.collect();
 			DidEndpoint::new(endpoint_id, endpoint_types, endpoint_urls)

--- a/pallets/did/src/mock_utils.rs
+++ b/pallets/did/src/mock_utils.rs
@@ -22,6 +22,7 @@ use sp_runtime::{traits::Zero, AccountId32, SaturatedConversion};
 use sp_std::{
 	collections::btree_set::BTreeSet,
 	convert::{TryFrom, TryInto},
+	vec,
 	vec::Vec,
 };
 

--- a/pallets/did/src/service_endpoints.rs
+++ b/pallets/did/src/service_endpoints.rs
@@ -70,7 +70,7 @@ impl<T: Config> DidEndpoint<T> {
 			self.urls.len() <= T::MaxNumberOfUrlsPerService::get().saturated_into(),
 			errors::InputError::MaxUrlCountExceeded
 		);
-		// Check that the ID is the maximum allowed length and only contain ASCII
+		// Check that the ID is the maximum allowed length and only contain URI fragment
 		// characters.
 		ensure!(
 			self.id.len() <= T::MaxServiceIdLength::get().saturated_into(),
@@ -78,7 +78,7 @@ impl<T: Config> DidEndpoint<T> {
 		);
 		let str_id = str::from_utf8(&self.id).map_err(|_| errors::InputError::InvalidEncoding)?;
 		ensure!(
-			crate_utils::is_valid_ascii_string(str_id),
+			crate_utils::is_valid_uri_fragment(str_id),
 			errors::InputError::InvalidEncoding
 		);
 		// Check that all types are the maximum allowed length and only contain ASCII
@@ -95,8 +95,8 @@ impl<T: Config> DidEndpoint<T> {
 			);
 			Ok(())
 		})?;
-		// Check that all URLs are the maximum allowed length AND only contain ASCII
-		// characters.
+		// Check that all URLs are the maximum allowed length AND only contain URI
+		// fragment characters.
 		for s_url in self.urls.iter() {
 			ensure!(
 				s_url.len() <= T::MaxServiceUrlLength::get().saturated_into(),
@@ -104,7 +104,7 @@ impl<T: Config> DidEndpoint<T> {
 			);
 			let str_url = str::from_utf8(s_url).map_err(|_| errors::InputError::InvalidEncoding)?;
 			ensure!(
-				crate_utils::is_valid_ascii_string(str_url),
+				crate_utils::is_valid_uri_fragment(str_url),
 				errors::InputError::InvalidEncoding
 			);
 		}

--- a/pallets/did/src/utils.rs
+++ b/pallets/did/src/utils.rs
@@ -33,6 +33,45 @@ pub(crate) fn is_valid_ascii_string(input: &str) -> bool {
 	input.chars().all(|c| c.is_ascii())
 }
 
+/// Verifies that an input string contains only a subset of characters allowed
+/// for a URI fragment according to W3C RFC3986. The subset is composed of all
+/// the elements that can form a "fragment" component, minus the 'pct-encoded'
+/// sequences that make the 'pchar' component.
+pub(crate) fn is_valid_uri_fragment(input: &str) -> bool {
+	input.chars().all(|c| {
+		matches!(
+			c,
+			// ALPHA
+			'a'..='z' |
+			'A'..='Z' |
+
+			// DIGIT
+			'0'..='9'|
+
+			'-' |
+			'.' |
+			'_' |
+			'~' |
+
+			// sub-delims
+			'!' |
+			'$' |
+			'&' |
+			'\'' |
+			'(' |
+			')' |
+			'*' |
+			'+' |
+			',' |
+			';' |
+			'=' |
+
+			':' |
+			'@'
+		)
+	})
+}
+
 #[test]
 fn check_is_valid_ascii_string() {
 	let test_cases = [
@@ -52,6 +91,35 @@ fn check_is_valid_ascii_string() {
 	test_cases.iter().for_each(|(input, expected_result)| {
 		assert_eq!(
 			is_valid_ascii_string(input),
+			*expected_result,
+			"Test case for \"{}\" returned wrong result.",
+			input
+		);
+	});
+}
+
+#[test]
+fn check_is_valid_uri_fragment_string() {
+	let test_cases = [
+		("kilt.io", true),
+		(
+			"super.long.domain.com:12345/path/to/directory#fragment?arg=value",
+			false,
+		),
+		("super.long.domain.com:12345/path/to/directory/file.txt", false),
+		("domain.with.only.valid.characters.:/?#[]@!$&'()*+,;=-._~", false),
+		("invalid.châracter.domain.org", false),
+		("âinvalid.character.domain.org", false),
+		("invalid.character.domain.orgâ", false),
+		("", true),
+		("例子.領域.cn", false),
+		("kilt.io/%3Ctag%3E/encoded_upper_case_ascii.com", false),
+		("kilt.io/%3ctag%3e/encoded_lower_case_ascii.com", false),
+	];
+
+	test_cases.iter().for_each(|(input, expected_result)| {
+		assert_eq!(
+			is_valid_uri_fragment(input),
 			*expected_result,
 			"Test case for \"{}\" returned wrong result.",
 			input


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2626.

Right now, we only check for `is_ascii()` for all elements of a DID service. The [DID core spec](https://www.w3.org/TR/did-core/#services) defines a service ID and a service endpoints as URIs by requiring the presence of a `#`, which makes an ID and a service endpoint without the leading `kilt:did:...` prefix a fragment by all means. This PR implements this requirement, by only allowing fragment-allowed characters as part of a service ID and endpoint, further restricting the set to not include percent-encoded characters, for the sake of ease of implementation, without deviating from the standard (which we now kinda do). This requirement can be relaxed in the future, if needed.