### PR TITLE
ci: replace ci-linux with ci-unified

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,33 +3,25 @@ stages:
   - build
 
 clippy:
-  # Corresponds to paritytech/ci-linux:production at the time of this PR
-  # https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e?context=explore
-  image: paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e
+  image: paritytech/ci-unified:bullseye-1.70.0
   stage: test
   script:
     - cargo clippy --all-features --all-targets --locked -- -D warnings
 
 fmt:
-  # Corresponds to paritytech/ci-linux:production at the time of this PR
-  # https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e?context=explore
-  image: paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e
+  image: paritytech/ci-unified:bullseye-1.70.0
   stage: test
   script:
     - cargo fmt -- --check
 
 test:
-  # Corresponds to paritytech/ci-linux:production at the time of this PR
-  # https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e?context=explore
-  image: paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e
+  image: paritytech/ci-unified:bullseye-1.70.0
   stage: test
   script:
     - cargo test --all --all-targets --locked
 
 test-features:
-  # Corresponds to paritytech/ci-linux:production at the time of this PR
-  # https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e?context=explore
-  image: paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e
+  image: paritytech/ci-unified:bullseye-1.70.0
   stage: test
   script:
     - cargo test --all --all-features --all-targets --locked

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # this container builds the kilt-parachain binary from source files and the runtime library
 # pinned the version to avoid build cache invalidation
 
-# Corresponds to paritytech/ci-linux:production at the time of this PR
-# https://hub.docker.com/layers/ci-linux/paritytech/ci-linux/production/images/sha256-4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e?context=explore
-FROM paritytech/ci-linux@sha256:4e8c072ea12bc17d99cb531adb58dea5a4c7d4880a8a86525052d24d1454e89e as builder
+FROM paritytech/ci-unified:bullseye-1.70.0 as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## fixes KILTProtocol/kilt-node/issues/536

Replace deprecated of `ci-linux:production` image tag with the `ci-unified`
## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
