### PR TITLE
feat: add support for relay chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6773,6 +6773,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-postit"
+version = "1.11.0-dev"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#5e49f6e44820affccaf517fd22af564f4b495d40"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "pallet-collator-selection",
  "pallet-did-lookup",
  "pallet-dip-consumer",
+ "pallet-postit",
  "pallet-relay-store",
  "pallet-session",
  "pallet-sudo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-postit"
-version = "1.11.0-dev"
+version = "1.12.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "1.12.0-dev"
 members = [
   "crates/*",
   "dip-template/nodes/*",
+  "dip-template/pallets/*",
   "dip-template/runtimes/*",
   "nodes/*",
   "pallets/*",
@@ -72,6 +73,7 @@ runtime-common = {path = "runtimes/common", default-features = false}
 # Templates
 dip-consumer-runtime-template = {path = "dip-template/runtimes/dip-consumer", default-features = false}
 dip-provider-runtime-template = {path = "dip-template/runtimes/dip-provider", default-features = false}
+pallet-postit = {path = "dip-template/pallets/pallet-postit", default-features = false}
 
 # Internal runtime API (with default disabled)
 kilt-runtime-api-did = {path = "runtime-api/did", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ jsonrpsee = "0.16.2"
 libsecp256k1 = {version = "0.7", default-features = false}
 log = "0.4.17"
 parity-scale-codec = {version = "3.1.5", default-features = false}
-scale-info = {version = "2.1.1", default-features = false}
+scale-info = {version = "2.7.0", default-features = false}
 serde = "1.0.144"
 serde_json = "1.0.85"
 sha3 = {version = "0.10.0", default-features = false}

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -43,6 +43,10 @@ pub mod state_proofs;
 pub mod traits;
 pub mod utils;
 
+pub use state_proofs::{
+	parachain::KiltDipCommitmentsForDipProviderPallet, relay_chain::RococoStateRootsViaRelayStorePallet,
+};
+
 #[derive(Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, Clone)]
 pub struct SiblingParachainDipStateProof<
 	RelayBlockHeight,
@@ -241,7 +245,3 @@ impl<
 		Ok(proof_leaves)
 	}
 }
-
-pub use state_proofs::{
-	parachain::KiltDipCommitmentsForDipProviderPallet, relay_chain::RococoStateRootsViaRelayStorePallet,
-};

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -38,7 +38,7 @@ use crate::{
 	state_proofs::{parachain::DipIdentityCommitmentProofVerifier, relay_chain::SiblingParachainHeadProofVerifier},
 	traits::{
 		Bump, DidSignatureVerifierContext, DipCallOriginFilter, HistoryProvider, ProviderParachainStateInfo,
-		RelayChainStateInfo, RelayChainStorageInfo,
+		RelayChainStorageInfo,
 	},
 	utils::OutputOf,
 };
@@ -332,15 +332,14 @@ impl<
 	TxSubmitter: Encode,
 
 	RelayChainInfo: RelayChainStorageInfo
-		+ RelayChainStateInfo
 		+ HistoryProvider<
-			BlockNumber = <RelayChainInfo as RelayChainStateInfo>::BlockNumber,
-			Hasher = <RelayChainInfo as RelayChainStateInfo>::Hasher,
+			BlockNumber = <RelayChainInfo as RelayChainStorageInfo>::BlockNumber,
+			Hasher = <RelayChainInfo as RelayChainStorageInfo>::Hasher,
 		>,
-	<RelayChainInfo as RelayChainStateInfo>::Hasher: 'static,
-	OutputOf<<RelayChainInfo as RelayChainStateInfo>::Hasher>:
+	<RelayChainInfo as RelayChainStorageInfo>::Hasher: 'static,
+	OutputOf<<RelayChainInfo as RelayChainStorageInfo>::Hasher>:
 		Ord + Default + sp_std::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Codec,
-	<RelayChainInfo as RelayChainStateInfo>::BlockNumber: Copy
+	<RelayChainInfo as RelayChainStorageInfo>::BlockNumber: Copy
 		+ Into<U256>
 		+ TryFrom<U256>
 		+ HasCompact
@@ -356,7 +355,7 @@ impl<
 	SiblingProviderStateInfo:
 		ProviderParachainStateInfo<Identifier = Subject, Commitment = ProviderDipMerkleHasher::Out>,
 	SiblingProviderStateInfo::Hasher: 'static,
-	OutputOf<SiblingProviderStateInfo::Hasher>: Ord + From<OutputOf<<RelayChainInfo as RelayChainStateInfo>::Hasher>>,
+	OutputOf<SiblingProviderStateInfo::Hasher>: Ord + From<OutputOf<<RelayChainInfo as RelayChainStorageInfo>::Hasher>>,
 	SiblingProviderStateInfo::BlockNumber: Encode + Clone,
 	SiblingProviderStateInfo::Commitment: Decode,
 	SiblingProviderStateInfo::Key: AsRef<[u8]>,
@@ -376,8 +375,8 @@ impl<
 	type Error = ();
 	type IdentityDetails = LocalDidDetails;
 	type Proof = ChildParachainDipStateProof<
-		<RelayChainInfo as RelayChainStateInfo>::BlockNumber,
-		<RelayChainInfo as RelayChainStateInfo>::Hasher,
+		<RelayChainInfo as RelayChainStorageInfo>::BlockNumber,
+		<RelayChainInfo as RelayChainStorageInfo>::Hasher,
 		Vec<Vec<u8>>,
 		RevealedDidMerkleProofLeaf<
 			ProviderDidKeyId,

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -77,6 +77,7 @@ pub struct DipMerkleProofAndDidSignature<BlindedValues, Leaf, BlockNumber> {
 	signature: TimeBoundDidSignature<BlockNumber>,
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct DipSiblingProviderStateProofVerifier<
 	RelayChainStateInfo,
 	SiblingProviderParachainId,
@@ -249,6 +250,7 @@ impl<
 	}
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct ChildParachainDipStateProof<
 	RelayBlockHeight: Copy + Into<U256> + TryFrom<U256>,
 	RelayBlockHasher: Hash,

--- a/crates/kilt-dip-support/src/state_proofs.rs
+++ b/crates/kilt-dip-support/src/state_proofs.rs
@@ -86,9 +86,9 @@ mod substrate_no_std_port {
 }
 
 pub(super) mod relay_chain {
-	use sp_runtime::traits::BlakeTwo256;
-
 	use super::*;
+
+	use sp_runtime::traits::BlakeTwo256;
 
 	use crate::traits::{RelayChainStateInfo, RelayChainStorageInfo};
 
@@ -278,31 +278,6 @@ pub(super) mod parachain {
 			}
 			let Some(Some(encoded_commitment)) = revealed_leaves.get(dip_commitment_storage_key.as_ref()) else { return Err(()) };
 			ParaInfo::Commitment::decode(&mut &encoded_commitment[..]).map_err(|_| ())
-		}
-	}
-
-	pub struct KiltDipCommitmentsForDipProviderPallet<Runtime>(PhantomData<Runtime>);
-
-	impl<Runtime> ProviderParachainStateInfo for KiltDipCommitmentsForDipProviderPallet<Runtime>
-	where
-		Runtime: pallet_dip_provider::Config,
-	{
-		type BlockNumber = <Runtime as frame_system::Config>::BlockNumber;
-		type Commitment = <Runtime as pallet_dip_provider::Config>::IdentityCommitment;
-		type Hasher = <Runtime as frame_system::Config>::Hashing;
-		type Identifier = <Runtime as pallet_dip_provider::Config>::Identifier;
-		type Key = StorageKey;
-
-		fn dip_subject_storage_key(identifier: &Self::Identifier) -> Self::Key {
-			// TODO: Replace with actual runtime definition
-			let encoded_identifier = identifier.encode();
-			let storage_key = [
-				frame_support::storage::storage_prefix(b"DipProvider", b"IdentityCommitments").as_slice(),
-				sp_io::hashing::twox_64(&encoded_identifier).as_slice(),
-				encoded_identifier.as_slice(),
-			]
-			.concat();
-			StorageKey(storage_key)
 		}
 	}
 

--- a/crates/kilt-dip-support/src/state_proofs.rs
+++ b/crates/kilt-dip-support/src/state_proofs.rs
@@ -88,17 +88,15 @@ mod substrate_no_std_port {
 pub(super) mod relay_chain {
 	use super::*;
 
-	use frame_support::ensure;
-	use parity_scale_codec::Codec;
-	use sp_runtime::traits::{AtLeast32BitUnsigned, BlakeTwo256, MaybeDisplay, Member, SimpleBitOps};
+	use sp_runtime::traits::BlakeTwo256;
 
-	use crate::traits::{self, RelayChainStateInfo, RelayChainStorageInfo};
+	use crate::traits::{RelayChainStateInfo, RelayChainStorageInfo};
 
 	pub struct SiblingParachainHeadProofVerifier<RelayChainState>(PhantomData<RelayChainState>);
 
 	impl<RelayChainState> SiblingParachainHeadProofVerifier<RelayChainState>
 	where
-		RelayChainState: RelayChainStorageInfo + RelayChainStateInfo<LookupInfo = ()>,
+		RelayChainState: RelayChainStorageInfo + RelayChainStateInfo,
 		RelayChainState::Hasher: 'static,
 		OutputOf<RelayChainState::Hasher>: Ord,
 		RelayChainState::BlockNumber: Copy + Into<U256> + TryFrom<U256> + HasCompact,
@@ -110,15 +108,20 @@ pub(super) mod relay_chain {
 			relay_height: &RelayChainState::BlockNumber,
 			proof: impl IntoIterator<Item = Vec<u8>>,
 		) -> Result<Header<RelayChainState::BlockNumber, RelayChainState::Hasher>, ()> {
-			let relay_state_root = RelayChainState::state_root_for_block(relay_height, &()).ok_or(())?;
+			let relay_state_root = RelayChainState::state_root_for_block(relay_height).ok_or(())?;
+			Self::verify_proof_for_parachain_with_root(para_id, &relay_state_root, proof)
+		}
+
+		pub(crate) fn verify_proof_for_parachain_with_root(
+			para_id: &RelayChainState::ParaId,
+			root: &OutputOf<<RelayChainState as RelayChainStateInfo>::Hasher>,
+			proof: impl IntoIterator<Item = Vec<u8>>,
+		) -> Result<Header<RelayChainState::BlockNumber, RelayChainState::Hasher>, ()> {
 			let parachain_storage_key = RelayChainState::parachain_head_storage_key(para_id);
 			let storage_proof = StorageProof::new(proof);
-			let revealed_leaves = read_proof_check::<RelayChainState::Hasher, _>(
-				relay_state_root,
-				storage_proof,
-				[&parachain_storage_key].iter(),
-			)
-			.map_err(|_| ())?;
+			let revealed_leaves =
+				read_proof_check::<RelayChainState::Hasher, _>(*root, storage_proof, [&parachain_storage_key].iter())
+					.map_err(|_| ())?;
 			// TODO: Remove at some point
 			{
 				debug_assert!(revealed_leaves.len() == 1usize);
@@ -159,12 +162,8 @@ pub(super) mod relay_chain {
 	{
 		type BlockNumber = u32;
 		type Hasher = BlakeTwo256;
-		type LookupInfo = ();
 
-		fn state_root_for_block(
-			block_height: &Self::BlockNumber,
-			_lookup_info: &Self::LookupInfo,
-		) -> Option<OutputOf<Self::Hasher>> {
+		fn state_root_for_block(block_height: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>> {
 			pallet_relay_store::Pallet::<Runtime>::latest_relay_head_for_block(block_height)
 				.map(|relay_header| relay_header.relay_parent_storage_root)
 		}
@@ -203,12 +202,8 @@ pub(super) mod relay_chain {
 		impl RelayChainStateInfo for StaticPolkadotInfoProvider {
 			type BlockNumber = u32;
 			type Hasher = BlakeTwo256;
-			type LookupInfo = ();
 
-			fn state_root_for_block(
-				_block_height: &Self::BlockNumber,
-				_lookup_info: &Self::LookupInfo,
-			) -> Option<OutputOf<Self::Hasher>> {
+			fn state_root_for_block(_block_height: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>> {
 				Some(hex!("81b75d95075d16005ee0a987a3f061d3011ada919b261e9b02961b9b3725f3fd").into())
 			}
 		}
@@ -237,114 +232,6 @@ pub(super) mod relay_chain {
 				)
 				.expect("Parachain head proof verification should not fail.");
 			assert!(returned_head.encode() == expected_spiritnet_head_at_block, "Parachain head returned from the state proof verification should not be different than the pre-computed one.");
-		}
-	}
-
-	pub struct PastStateRootProvider<HistoryProvider>(PhantomData<HistoryProvider>);
-
-	impl<HistoryProvider> PastStateRootProvider<HistoryProvider>
-	where
-		HistoryProvider: traits::HistoryProvider,
-		HistoryProvider::BlockNumber: Member
-			+ sp_std::hash::Hash
-			+ Copy
-			+ MaybeDisplay
-			+ AtLeast32BitUnsigned
-			+ Codec
-			+ Into<U256>
-			+ TryFrom<U256>,
-		<HistoryProvider::Hasher as sp_runtime::traits::Hash>::Output:
-			Default + sp_std::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Codec,
-	{
-		pub fn verify_past_state(
-			block_number: HistoryProvider::BlockNumber,
-			header: Header<HistoryProvider::BlockNumber, HistoryProvider::Hasher>,
-		) -> Result<<HistoryProvider::Hasher as sp_runtime::traits::Hash>::Output, ()> {
-			let block_hash = HistoryProvider::block_hash_for(&block_number).ok_or(())?;
-			ensure!(block_hash == header.hash(), ());
-			Ok(header.state_root)
-		}
-	}
-
-	#[cfg(test)]
-	mod past_state_root_provider_tests {
-		use super::*;
-
-		use hex_literal::hex;
-		use sp_runtime::{Digest, DigestItem};
-
-		use crate::traits::HistoryProvider;
-
-		const BLOCK_NUMBER: u64 = 4_362_970;
-
-		struct SpiritnetStaticBlockProvider;
-
-		impl HistoryProvider for SpiritnetStaticBlockProvider {
-			type BlockNumber = u64;
-			type Hasher = BlakeTwo256;
-
-			fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output> {
-				if block == &BLOCK_NUMBER {
-					Some(hex!("b9700ad2c2cad8ba5bf1affb98c377e9ba4f28ceaecc22285f636a3971a7c3f4").into())
-				} else {
-					None
-				}
-			}
-		}
-
-		#[test]
-		fn test_correct_block_verification() {
-			let header_at_block = Header::<u64, BlakeTwo256> {
-				digest: Digest {
-					logs: vec![
-						DigestItem::PreRuntime(*b"aura", hex!("9ad3660800000000").to_vec()),
-						DigestItem::Seal(*b"aura", hex!("066a1734615150b91a99779f770a47a47e91680cf0dbc97fea08d10b0bad19066eaccd401394589b84e346145713e98ae709fd52933871d2383640bd76c3158b").to_vec())
-					]
-				},
-				extrinsics_root: hex!("5031bb2622631dc5da356f9023a5b751c837854de0de9af746942e7594c051f8").into(),
-				number: BLOCK_NUMBER,
-				parent_hash: hex!("bd5f86c2de02153751ebbe12986103f9b7a809fda03d4564495de83fd37280d0").into(),
-				state_root: hex!("5963f41159ad1ff28f6617cf9519f48a5ca9927ffa98c692d3841ab702006c4d").into()
-			};
-			let state_root =
-				PastStateRootProvider::<SpiritnetStaticBlockProvider>::verify_past_state(BLOCK_NUMBER, header_at_block)
-					.expect("State verification should not fail.");
-			assert_eq!(
-				state_root,
-				hex!("5963f41159ad1ff28f6617cf9519f48a5ca9927ffa98c692d3841ab702006c4d").into()
-			);
-		}
-
-		#[test]
-		fn test_invalid_block_verification() {
-			let invalid_header_at_block = Header::<u64, BlakeTwo256> {
-				digest: Digest {
-					logs: vec![
-						DigestItem::PreRuntime(*b"aura", hex!("9ad3660800000000").to_vec()),
-						DigestItem::Seal(*b"aura", hex!("066a1734615150b91a99779f770a47a47e91680cf0dbc97fea08d10b0bad19066eaccd401394589b84e346145713e98ae709fd52933871d2383640bd76c3158b").to_vec())
-					]
-				},
-				extrinsics_root: hex!("5031bb2622631dc5da356f9023a5b751c837854de0de9af746942e7594c051f8").into(),
-				number: BLOCK_NUMBER,
-				parent_hash: hex!("bd5f86c2de02153751ebbe12986103f9b7a809fda03d4564495de83fd37280d0").into(),
-				// Changed the last byte from 0x4d to 0x4c.
-				state_root: hex!("5963f41159ad1ff28f6617cf9519f48a5ca9927ffa98c692d3841ab702006c4c").into()
-			};
-			let state_root = PastStateRootProvider::<SpiritnetStaticBlockProvider>::verify_past_state(
-				BLOCK_NUMBER,
-				invalid_header_at_block,
-			);
-			assert_eq!(state_root, Err(()));
-		}
-
-		#[test]
-		fn test_block_not_found() {
-			let non_existing_block_number = 1;
-			let state_root = PastStateRootProvider::<SpiritnetStaticBlockProvider>::verify_past_state(
-				non_existing_block_number,
-				Header::<u64, BlakeTwo256>::new_from_number(non_existing_block_number),
-			);
-			assert_eq!(state_root, Err(()));
 		}
 	}
 }

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -55,16 +55,15 @@ pub trait DipCallOriginFilter<Call> {
 }
 
 pub trait RelayChainStorageInfo {
+	type BlockNumber;
+	type Hasher: sp_runtime::traits::Hash;
 	type Key;
 	type ParaId;
 
 	fn parachain_head_storage_key(para_id: &Self::ParaId) -> Self::Key;
 }
 
-pub trait RelayChainStateInfo {
-	type BlockNumber;
-	type Hasher: sp_runtime::traits::Hash;
-
+pub trait RelayChainStateInfo: RelayChainStorageInfo {
 	fn state_root_for_block(block_height: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>>;
 }
 

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -117,7 +117,7 @@ pub trait HistoryProvider {
 	type BlockNumber;
 	type Hasher: sp_runtime::traits::Hash;
 
-	fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output>;
+	fn block_hash_for(block: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>>;
 }
 
 impl<T> HistoryProvider for T
@@ -127,7 +127,7 @@ where
 	type BlockNumber = T::BlockNumber;
 	type Hasher = T::Hashing;
 
-	fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output> {
+	fn block_hash_for(block: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>> {
 		let retrieved_block = frame_system::Pallet::<T>::block_hash(block);
 		let default_block_hash_value = <T::Hash as Default>::default();
 

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -125,8 +125,8 @@ where
 	type Hasher = T::Hashing;
 
 	fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output> {
-		let default_block_hash_value = <T::Hash as Default>::default();
 		let retrieved_block = frame_system::Pallet::<T>::block_hash(block);
+		let default_block_hash_value = <T::Hash as Default>::default();
 
 		if retrieved_block == default_block_hash_value {
 			None

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -109,3 +109,29 @@ where
 
 	fn signed_extra() -> Self::SignedExtra {}
 }
+
+pub trait HistoryProvider {
+	type BlockNumber;
+	type Hasher: sp_runtime::traits::Hash;
+
+	fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output>;
+}
+
+impl<T> HistoryProvider for T
+where
+	T: frame_system::Config,
+{
+	type BlockNumber = T::BlockNumber;
+	type Hasher = T::Hashing;
+
+	fn block_hash_for(block: &Self::BlockNumber) -> Option<<Self::Hasher as sp_runtime::traits::Hash>::Output> {
+		let default_block_hash_value = <T::Hash as Default>::default();
+		let retrieved_block = frame_system::Pallet::<T>::block_hash(block);
+
+		if retrieved_block == default_block_hash_value {
+			None
+		} else {
+			Some(retrieved_block)
+		}
+	}
+}

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -64,12 +64,8 @@ pub trait RelayChainStorageInfo {
 pub trait RelayChainStateInfo {
 	type BlockNumber;
 	type Hasher: sp_runtime::traits::Hash;
-	type LookupInfo;
 
-	fn state_root_for_block(
-		block_height: &Self::BlockNumber,
-		lookup_info: &Self::LookupInfo,
-	) -> Option<OutputOf<Self::Hasher>>;
+	fn state_root_for_block(block_height: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>>;
 }
 
 pub trait ProviderParachainStateInfo {

--- a/crates/kilt-dip-support/src/traits.rs
+++ b/crates/kilt-dip-support/src/traits.rs
@@ -54,14 +54,22 @@ pub trait DipCallOriginFilter<Call> {
 	fn check_call_origin_info(call: &Call, info: &Self::OriginInfo) -> Result<Self::Success, Self::Error>;
 }
 
-pub trait RelayChainStateInfo {
-	type BlockNumber;
+pub trait RelayChainStorageInfo {
 	type Key;
-	type Hasher: sp_runtime::traits::Hash;
 	type ParaId;
 
-	fn state_root_for_block(block_height: &Self::BlockNumber) -> Option<OutputOf<Self::Hasher>>;
 	fn parachain_head_storage_key(para_id: &Self::ParaId) -> Self::Key;
+}
+
+pub trait RelayChainStateInfo {
+	type BlockNumber;
+	type Hasher: sp_runtime::traits::Hash;
+	type LookupInfo;
+
+	fn state_root_for_block(
+		block_height: &Self::BlockNumber,
+		lookup_info: &Self::LookupInfo,
+	) -> Option<OutputOf<Self::Hasher>>;
 }
 
 pub trait ProviderParachainStateInfo {

--- a/dip-template/nodes/dip-consumer/src/chain_spec.rs
+++ b/dip-template/nodes/dip-consumer/src/chain_spec.rs
@@ -99,7 +99,6 @@ fn testnet_genesis(
 		},
 		aura: Default::default(),
 		aura_ext: Default::default(),
-		did_lookup: Default::default(),
 	}
 }
 

--- a/dip-template/pallets/pallet-postit/Cargo.toml
+++ b/dip-template/pallets/pallet-postit/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+authors.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+name = "pallet-postit"
+description = "Simple pallet to store on-chain comments, replies, and likes."
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# External dependencies
+parity-scale-codec = {workspace = true, features = ["derive"]}
+scale-info = {workspace = true, features = ["derive"]}
+
+#External dependencies
+frame-support.workspace = true
+frame-system.workspace = true
+sp-runtime.workspace = true
+sp-std.workspace = true
+
+[features]
+default = ["std"]
+runtime-benchmarks = [
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks"
+]
+std = [
+  "parity-scale-codec/std",
+  "scale-info/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-runtime/std",
+  "sp-std/std",
+]

--- a/dip-template/pallets/pallet-postit/src/lib.rs
+++ b/dip-template/pallets/pallet-postit/src/lib.rs
@@ -21,7 +21,7 @@
 pub mod post;
 pub mod traits;
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod pallet {
 
 	use super::*;
@@ -64,7 +64,6 @@ pub mod pallet {
 	pub type Comments<T> = StorageMap<_, Twox64Concat, <T as frame_system::Config>::Hash, CommentOf<T>>;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 

--- a/dip-template/pallets/pallet-postit/src/lib.rs
+++ b/dip-template/pallets/pallet-postit/src/lib.rs
@@ -21,6 +21,8 @@
 pub mod post;
 pub mod traits;
 
+pub use pallet::*;
+
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
 
@@ -48,9 +50,9 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
+		type MaxTextLength: Get<u32>;
 		type OriginCheck: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
 		type OriginSuccess: Usernamable<Username = Self::Username>;
-		type MaxTextLength: Get<u32>;
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type Username: Encode + Decode + TypeInfo + MaxEncodedLen + Clone + PartialEq + Debug + Default;
 	}
@@ -75,9 +77,13 @@ pub mod pallet {
 			author: T::Username,
 		},
 		NewComment {
-			post_id: T::Hash,
+			resource_id: T::Hash,
 			comment_id: T::Hash,
 			author: T::Username,
+		},
+		NewLike {
+			resource_id: T::Hash,
+			liker: T::Username,
 		},
 	}
 
@@ -134,8 +140,13 @@ pub mod pallet {
 				})
 			})
 			.map_err(|_| DispatchError::Other("No post or comment with provided ID found."))?;
-			let comment = CommentOf::<T>::from_post_id_text_and_author(resource_id, text, author);
+			let comment = CommentOf::<T>::from_post_id_text_and_author(resource_id, text, author.clone());
 			Comments::<T>::insert(comment_id, comment);
+			Self::deposit_event(Event::NewComment {
+				resource_id,
+				comment_id,
+				author,
+			});
 			Ok(())
 		}
 
@@ -158,7 +169,7 @@ pub mod pallet {
 						comment
 							.details
 							.likes
-							.try_push(liker)
+							.try_push(liker.clone())
 							.expect("Failed to add like to comment.");
 						Ok(())
 					} else {
@@ -167,6 +178,7 @@ pub mod pallet {
 				})
 			})
 			.map_err(|_| DispatchError::Other("No post or comment with provided ID found."))?;
+			Self::deposit_event(Event::NewLike { resource_id, liker });
 			Ok(())
 		}
 	}

--- a/dip-template/pallets/pallet-postit/src/lib.rs
+++ b/dip-template/pallets/pallet-postit/src/lib.rs
@@ -1,0 +1,174 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2023 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod post;
+pub mod traits;
+
+#[frame_support::pallet]
+pub mod pallet {
+
+	use super::*;
+
+	use frame_support::{
+		pallet_prelude::{DispatchResult, *},
+		traits::EnsureOrigin,
+		BoundedVec,
+	};
+	use frame_system::pallet_prelude::*;
+	use sp_runtime::traits::Hash;
+	use sp_std::fmt::Debug;
+
+	use crate::{
+		post::{Comment, Post},
+		traits::Usernamable,
+	};
+
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
+	pub type BoundedTextOf<T> = BoundedVec<u8, <T as Config>::MaxTextLength>;
+	pub type PostOf<T> = Post<<T as frame_system::Config>::Hash, BoundedTextOf<T>, <T as Config>::Username>;
+	pub type CommentOf<T> = Comment<<T as frame_system::Config>::Hash, BoundedTextOf<T>, <T as Config>::Username>;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type OriginCheck: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
+		type OriginSuccess: Usernamable<Username = Self::Username>;
+		type MaxTextLength: Get<u32>;
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type Username: Encode + Decode + TypeInfo + MaxEncodedLen + Clone + PartialEq + Debug + Default;
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn posts)]
+	pub type Posts<T> = StorageMap<_, Twox64Concat, <T as frame_system::Config>::Hash, PostOf<T>>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn comments)]
+	pub type Comments<T> = StorageMap<_, Twox64Concat, <T as frame_system::Config>::Hash, CommentOf<T>>;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		NewPost {
+			post_id: T::Hash,
+			author: T::Username,
+		},
+		NewComment {
+			post_id: T::Hash,
+			comment_id: T::Hash,
+			author: T::Username,
+		},
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(1_000)]
+		pub fn post(origin: OriginFor<T>, text: BoundedTextOf<T>) -> DispatchResult {
+			let success_origin = T::OriginCheck::ensure_origin(origin)?;
+			let author = success_origin.username().map_err(DispatchError::Other)?;
+			let post_id = T::Hashing::hash(
+				(&frame_system::Pallet::<T>::block_number(), &author, &text)
+					.encode()
+					.as_slice(),
+			);
+			let post = PostOf::<T>::from_text_and_author(text, author.clone());
+			Posts::<T>::insert(post_id, post);
+			Self::deposit_event(Event::NewPost { post_id, author });
+			Ok(())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(1_000)]
+		pub fn comment(origin: OriginFor<T>, resource_id: T::Hash, text: BoundedTextOf<T>) -> DispatchResult {
+			let success_origin = T::OriginCheck::ensure_origin(origin)?;
+			let author = success_origin.username().map_err(DispatchError::Other)?;
+			let comment_id = T::Hashing::hash(
+				(&frame_system::Pallet::<T>::block_number(), &author, &text)
+					.encode()
+					.as_slice(),
+			);
+			Posts::<T>::try_mutate(resource_id, |post| {
+				if let Some(post) = post {
+					post.comments
+						.try_push(comment_id)
+						.expect("Failed to add comment to post.");
+					Ok(())
+				} else {
+					Err(())
+				}
+			})
+			.or_else(|_| {
+				Comments::<T>::try_mutate(resource_id, |comment| {
+					if let Some(comment) = comment {
+						comment
+							.details
+							.comments
+							.try_push(comment_id)
+							.expect("Failed to add comment to comment.");
+						Ok(())
+					} else {
+						Err(())
+					}
+				})
+			})
+			.map_err(|_| DispatchError::Other("No post or comment with provided ID found."))?;
+			let comment = CommentOf::<T>::from_post_id_text_and_author(resource_id, text, author);
+			Comments::<T>::insert(comment_id, comment);
+			Ok(())
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(1_000)]
+		pub fn like(origin: OriginFor<T>, resource_id: T::Hash) -> DispatchResult {
+			let success_origin = T::OriginCheck::ensure_origin(origin)?;
+			let liker = success_origin.username().map_err(DispatchError::Other)?;
+			Posts::<T>::try_mutate(resource_id, |post| {
+				if let Some(post) = post {
+					post.likes.try_push(liker.clone()).expect("Failed to add like to post.");
+					Ok(())
+				} else {
+					Err(())
+				}
+			})
+			.or_else(|_| {
+				Comments::<T>::try_mutate(resource_id, |comment| {
+					if let Some(comment) = comment {
+						comment
+							.details
+							.likes
+							.try_push(liker)
+							.expect("Failed to add like to comment.");
+						Ok(())
+					} else {
+						Err(())
+					}
+				})
+			})
+			.map_err(|_| DispatchError::Other("No post or comment with provided ID found."))?;
+			Ok(())
+		}
+	}
+}

--- a/dip-template/pallets/pallet-postit/src/post.rs
+++ b/dip-template/pallets/pallet-postit/src/post.rs
@@ -1,0 +1,55 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2023 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use frame_support::{traits::ConstU32, BoundedVec};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Default)]
+pub struct Post<Id, Text, Username> {
+	pub author: Username,
+	pub text: Text,
+	pub likes: BoundedVec<Username, ConstU32<1_000>>,
+	pub comments: BoundedVec<Id, ConstU32<1_000>>,
+}
+
+impl<Id, Text, Username> Post<Id, Text, Username> {
+	pub(crate) fn from_text_and_author(text: Text, author: Username) -> Self {
+		Self {
+			text,
+			author,
+			likes: BoundedVec::default(),
+			comments: BoundedVec::default(),
+		}
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Default)]
+pub struct Comment<Id, Text, Username> {
+	pub details: Post<Id, Text, Username>,
+	pub in_response_to: Id,
+}
+
+impl<Id, Text, Username> Comment<Id, Text, Username> {
+	pub(crate) fn from_post_id_text_and_author(in_response_to: Id, text: Text, author: Username) -> Self {
+		Self {
+			in_response_to,
+			details: Post::from_text_and_author(text, author),
+		}
+	}
+}

--- a/dip-template/pallets/pallet-postit/src/traits.rs
+++ b/dip-template/pallets/pallet-postit/src/traits.rs
@@ -1,0 +1,23 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2023 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+pub trait Usernamable {
+	type Username;
+
+	fn username(&self) -> Result<Self::Username, &'static str>;
+}

--- a/dip-template/runtimes/dip-consumer/Cargo.toml
+++ b/dip-template/runtimes/dip-consumer/Cargo.toml
@@ -23,6 +23,7 @@ did.workspace = true
 kilt-dip-support.workspace = true
 pallet-did-lookup.workspace = true
 pallet-dip-consumer.workspace = true
+pallet-postit.workspace = true
 pallet-relay-store.workspace = true
 runtime-common.workspace = true
 
@@ -75,6 +76,7 @@ std = [
   "kilt-dip-support/std",
   "pallet-did-lookup/std",
   "pallet-dip-consumer/std",
+  "pallet-postit/std",
   "pallet-relay-store/std",
   "runtime-common/std",
 	"frame-executive/std",

--- a/dip-template/runtimes/dip-consumer/src/dip.rs
+++ b/dip-template/runtimes/dip-consumer/src/dip.rs
@@ -30,6 +30,8 @@ use sp_runtime::traits::BlakeTwo256;
 
 use crate::{AccountId, DidIdentifier, Runtime, RuntimeCall, RuntimeOrigin};
 
+pub type MerkleProofVerifierOutputOf<Call, Subject> =
+	<ProofVerifier as IdentityProofVerifier<Call, Subject>>::VerificationResult;
 pub type ProofVerifier = DipSiblingProviderStateProofVerifier<
 	RococoStateRootsViaRelayStorePallet<Runtime>,
 	ConstU32<2_000>,
@@ -63,7 +65,7 @@ impl Contains<RuntimeCall> for PreliminaryDipOriginFilter {
 	fn contains(t: &RuntimeCall) -> bool {
 		matches!(
 			t,
-			RuntimeCall::DidLookup { .. }
+			RuntimeCall::PostIt { .. }
 				| RuntimeCall::Utility(pallet_utility::Call::batch { .. })
 				| RuntimeCall::Utility(pallet_utility::Call::batch_all { .. })
 				| RuntimeCall::Utility(pallet_utility::Call::force_batch { .. })
@@ -73,7 +75,7 @@ impl Contains<RuntimeCall> for PreliminaryDipOriginFilter {
 
 fn derive_verification_key_relationship(call: &RuntimeCall) -> Option<DidVerificationKeyRelationship> {
 	match call {
-		RuntimeCall::DidLookup { .. } => Some(DidVerificationKeyRelationship::Authentication),
+		RuntimeCall::PostIt { .. } => Some(DidVerificationKeyRelationship::Authentication),
 		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) => single_key_relationship(calls.iter()).ok(),
 		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) => single_key_relationship(calls.iter()).ok(),
 		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) => single_key_relationship(calls.iter()).ok(),
@@ -118,47 +120,6 @@ impl DipCallOriginFilter<RuntimeCall> for DipCallFilter {
 		} else {
 			Err(())
 		}
-	}
-}
-
-#[cfg(test)]
-mod dip_call_origin_filter_tests {
-	use super::*;
-
-	use frame_support::assert_err;
-
-	#[test]
-	fn test_key_relationship_derivation() {
-		// Can call DidLookup functions with an authentication key
-		let did_lookup_call = RuntimeCall::DidLookup(pallet_did_lookup::Call::associate_sender {});
-		assert_eq!(
-			single_key_relationship(vec![did_lookup_call].iter()),
-			Ok(DidVerificationKeyRelationship::Authentication)
-		);
-		// Can't call System functions with a DID key (hence a DIP origin)
-		let system_call = RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
-		assert_err!(single_key_relationship(vec![system_call].iter()), ());
-		// Can't call empty batch with a DID key
-		let empty_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all { calls: vec![] });
-		assert_err!(single_key_relationship(vec![empty_batch_call].iter()), ());
-		// Can call batch with a DipLookup with an authentication key
-		let did_lookup_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all {
-			calls: vec![pallet_did_lookup::Call::associate_sender {}.into()],
-		});
-		assert_eq!(
-			single_key_relationship(vec![did_lookup_batch_call].iter()),
-			Ok(DidVerificationKeyRelationship::Authentication)
-		);
-		// Can't call a batch with different required keys
-		let did_lookup_batch_call = RuntimeCall::Utility(pallet_utility::Call::batch_all {
-			calls: vec![
-				// Authentication key
-				pallet_did_lookup::Call::associate_sender {}.into(),
-				// No key
-				frame_system::Call::remark { remark: vec![] }.into(),
-			],
-		});
-		assert_err!(single_key_relationship(vec![did_lookup_batch_call].iter()), ());
 	}
 }
 

--- a/dip-template/runtimes/dip-consumer/src/dip.rs
+++ b/dip-template/runtimes/dip-consumer/src/dip.rs
@@ -20,8 +20,8 @@ use did::{did_details::DidVerificationKey, DidVerificationKeyRelationship, KeyId
 use dip_provider_runtime_template::{Runtime as ProviderRuntime, Web3Name};
 use frame_support::traits::Contains;
 use kilt_dip_support::{
-	traits::{DipCallOriginFilter, FrameSystemDidSignatureContext},
-	DipSiblingProviderStateProofVerifier, KiltDipCommitmentsForDipProviderPallet, RococoStateRootsViaRelayStorePallet,
+	traits::{DipCallOriginFilter, FrameSystemDidSignatureContext, ProviderParachainStateInfoViaProviderPallet},
+	DipSiblingProviderStateProofVerifier, RococoStateRootsViaRelayStorePallet,
 };
 use pallet_did_lookup::linkable_account::LinkableAccountId;
 use pallet_dip_consumer::traits::IdentityProofVerifier;
@@ -35,7 +35,7 @@ pub type MerkleProofVerifierOutputOf<Call, Subject> =
 pub type ProofVerifier = DipSiblingProviderStateProofVerifier<
 	RococoStateRootsViaRelayStorePallet<Runtime>,
 	ConstU32<2_000>,
-	KiltDipCommitmentsForDipProviderPallet<ProviderRuntime>,
+	ProviderParachainStateInfoViaProviderPallet<ProviderRuntime>,
 	AccountId,
 	BlakeTwo256,
 	KeyIdOf<ProviderRuntime>,

--- a/dip-template/runtimes/dip-consumer/src/dip.rs
+++ b/dip-template/runtimes/dip-consumer/src/dip.rs
@@ -33,7 +33,7 @@ use crate::{AccountId, DidIdentifier, Runtime, RuntimeCall, RuntimeOrigin};
 pub type ProofVerifier = DipSiblingProviderStateProofVerifier<
 	RococoStateRootsViaRelayStorePallet<Runtime>,
 	ConstU32<2_000>,
-	KiltDipCommitmentsForDipProviderPallet<dip_provider_runtime_template::Runtime>,
+	KiltDipCommitmentsForDipProviderPallet<ProviderRuntime>,
 	AccountId,
 	BlakeTwo256,
 	KeyIdOf<ProviderRuntime>,

--- a/dip-template/runtimes/dip-consumer/src/origin_adapter.rs
+++ b/dip-template/runtimes/dip-consumer/src/origin_adapter.rs
@@ -1,0 +1,53 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2023 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use crate::{AccountId, DidIdentifier, MerkleProofVerifierOutputOf, RuntimeCall, RuntimeOrigin, Web3Name};
+use frame_support::traits::EnsureOrigin;
+use pallet_dip_consumer::{DipOrigin, EnsureDipOrigin};
+use pallet_postit::traits::Usernamable;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::RuntimeDebug;
+
+pub struct EnsureDipOriginAdapter;
+
+impl EnsureOrigin<RuntimeOrigin> for EnsureDipOriginAdapter {
+	type Success = DipOriginAdapter;
+
+	fn try_origin(o: RuntimeOrigin) -> Result<Self::Success, RuntimeOrigin> {
+		EnsureDipOrigin::try_origin(o).map(DipOriginAdapter)
+	}
+}
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct DipOriginAdapter(
+	DipOrigin<DidIdentifier, AccountId, MerkleProofVerifierOutputOf<RuntimeCall, DidIdentifier>>,
+);
+
+impl Usernamable for DipOriginAdapter {
+	type Username = Web3Name;
+
+	fn username(&self) -> Result<Self::Username, &'static str> {
+		self.0
+			.details
+			.web3_name
+			.as_ref()
+			.map(|leaf| leaf.web3_name.clone())
+			.ok_or("No username for the subject.")
+	}
+}

--- a/dip-template/runtimes/dip-provider/src/lib.rs
+++ b/dip-template/runtimes/dip-provider/src/lib.rs
@@ -188,7 +188,8 @@ register_validate_block! {
 	CheckInherents = CheckInherents,
 }
 
-pub const SS58_PREFIX: u16 = 100;
+// Same as official KILT prefix.
+pub const SS58_PREFIX: u16 = 38;
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(


### PR DESCRIPTION
Builds on the new state proofs by adding support for a relay chain to be a consumer with the new `ChildParachainDipStateProof` and `DipChildProviderStateProofVerifier` types. Some traits and types have also been renamed.

The new feature has been tested with a local Rococo 0.9.43 deployment, and can be reproduced by download and compiling our Polkadot fork at the [demo-sub0-23 tag](https://github.com/KILTprotocol/polkadot/tree/demo-sub0-23).

This PR also adds the `postit` pallet that was written for the Decoded demo, and uses that instead of the lookup pallet as an example pallet integrating DIP.