### PR TITLE
refactor: update to the latest benchmark syntax

### DIFF
--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::{account, benchmarks};
 use frame_support::traits::{fungible::Mutate, Get};
 use frame_system::RawOrigin;
 use sp_runtime::traits::Hash;
@@ -195,10 +195,10 @@ benchmarks! {
 			}
 		}));
 	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::ExtBuilder::default().build_with_keystore(),
-	crate::mock::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::ExtBuilder::default().build_with_keystore(),
+		crate::mock::Test
+	)
 }

--- a/pallets/ctype/src/benchmarking.rs
+++ b/pallets/ctype/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::{account, benchmarks};
 use frame_support::{
 	sp_runtime::traits::Hash,
 	traits::{
@@ -89,10 +89,10 @@ benchmarks! {
 		// Verify the CType has the right block number
 		assert_eq!(stored_ctype_entry.created_at, new_block_number);
 	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
-	crate::mock::runtime::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
+		crate::mock::runtime::Test
+	)
 }

--- a/pallets/delegation/src/benchmarking.rs
+++ b/pallets/delegation/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::{account, benchmarks};
 use frame_support::{
 	dispatch::DispatchErrorWithPostInfo,
 	storage::bounded_btree_set::BoundedBTreeSet,
@@ -416,8 +416,6 @@ benchmarks! {
 		};
 
 	}: { ac.can_attest(&leaf_acc, &ctype, &claim).expect("Should be allowed") }
-	verify {
-	}
 
 	can_revoke {
 		let c in 1 .. T::MaxParentChecks::get();
@@ -435,8 +433,6 @@ benchmarks! {
 		};
 
 	}: { ac.can_revoke(&root_acc, &ctype, &claim, &leaf_id).expect("Should be allowed") }
-	verify {
-	}
 
 	can_remove {
 		let c in 1 .. T::MaxParentChecks::get();
@@ -454,8 +450,6 @@ benchmarks! {
 		};
 
 	}: { ac.can_remove(&root_acc, &ctype, &claim, &leaf_id).expect("Should be allowed") }
-	verify {
-	}
 
 	change_deposit_owner {
 		let deposit_owner_old: T::AccountId = account("sender", 0, SEED);
@@ -493,12 +487,10 @@ benchmarks! {
 
 		let origin = RawOrigin::Signed(deposit_owner);
 	}: _(origin, hierarchy_id)
-	verify {
-	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
-	crate::mock::runtime::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
+		crate::mock::runtime::Test
+	)
 }

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -604,7 +604,7 @@ benchmarks! {
 		let origin = RawOrigin::Signed(did_subject.clone());
 		let cloned_new_delegation_key = new_delegation_key.clone();
 	}: set_delegation_key(origin, cloned_new_delegation_key)
-		verify {
+	verify {
 		let new_delegation_key_id = utils::calculate_key_id::<T>(&DidPublicKey::from(new_delegation_key));
 		assert_eq!(Did::<T>::get(&did_subject).unwrap().delegation_key, Some(new_delegation_key_id));
 	}
@@ -1052,7 +1052,7 @@ benchmarks! {
 		let origin = RawOrigin::Signed(did_subject.clone());
 		let cloned_endpoint_id = endpoint_id.clone();
 	}: _(origin, cloned_endpoint_id)
-		verify {
+	verify {
 		assert!(
 			ServiceEndpoints::<T>::get(&did_subject, &endpoint_id).is_none()
 		);
@@ -1092,7 +1092,7 @@ benchmarks! {
 	}: {
 		DidSignatureVerify::<T>::verify(&did_subject, &payload, &did_signature).expect("should verify");
 	}
-	verify {}
+
 	signature_verification_ed25519 {
 		let l in 1 .. MAX_PAYLOAD_BYTE_LENGTH;
 
@@ -1119,7 +1119,7 @@ benchmarks! {
 	}: {
 		DidSignatureVerify::<T>::verify(&did_subject, &payload, &did_signature).expect("should verify");
 	}
-	verify {}
+
 	signature_verification_ecdsa {
 		let l in 1 .. MAX_PAYLOAD_BYTE_LENGTH;
 
@@ -1146,7 +1146,6 @@ benchmarks! {
 	}: {
 		DidSignatureVerify::<T>::verify(&did_subject, &payload, &did_signature).expect("should verify");
 	}
-	verify {}
 
 	change_deposit_owner {
 		let did_public_auth_key = get_ed25519_public_authentication_key();

--- a/pallets/pallet-configuration/src/benchmarking.rs
+++ b/pallets/pallet-configuration/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::benchmarks;
 use frame_support::traits::EnsureOriginWithArg;
 
 use crate::*;
@@ -31,10 +31,10 @@ benchmarks! {
 	verify {
 		assert_eq!(ConfigurationStore::<T>::get(), Configuration { relay_block_strictly_increasing: true });
 	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
-	crate::mock::runtime::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::runtime::ExtBuilder::default().build_with_keystore(),
+		crate::mock::runtime::Test
+	)
 }

--- a/pallets/pallet-web3-names/src/benchmarking.rs
+++ b/pallets/pallet-web3-names/src/benchmarking.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 #![cfg(feature = "runtime-benchmarks")]
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, vec, Vec, Zero};
+use frame_benchmarking::{account, benchmarks, vec, Vec, Zero};
 use frame_support::{
 	pallet_prelude::EnsureOrigin,
 	sp_runtime::SaturatedConversion,
@@ -199,10 +199,10 @@ benchmarks! {
 			amount: <T as Config>::Deposit::get(),
 		});
 	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::ExtBuilder::default().build_with_keystore(),
-	crate::mock::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::ExtBuilder::default().build_with_keystore(),
+		crate::mock::Test
+	)
 }

--- a/pallets/public-credentials/src/benchmarking.rs
+++ b/pallets/public-credentials/src/benchmarking.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, Zero};
+use frame_benchmarking::{account, benchmarks, Zero};
 use frame_support::{
 	dispatch::RawOrigin,
 	traits::{fungible::Mutate, Get},
@@ -288,10 +288,10 @@ benchmarks! {
 			T::Deposit::get()
 		);
 	}
-}
 
-impl_benchmark_test_suite! {
-	Pallet,
-	crate::mock::ExtBuilder::default().build_with_keystore(),
-	crate::mock::Test
+	impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::ExtBuilder::default().build_with_keystore(),
+		crate::mock::Test
+	)
 }


### PR DESCRIPTION
With the new syntax each benchmark case is tested individually. If one of them fails, you'll know exactly which one failed.

## Checklist:

- [X] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [X] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [X] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [X] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
