### PR TITLE
ci: add try-runtime builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ build-wasm-try-runtime:
   script:
     - cargo build --release -p $RUNTIME-runtime --features try-runtime
     - mkdir ./out
-    - mv target/release/wbuild/$RUNTIME-runtime/*.wasm /out/
+    - mv target/release/wbuild/$RUNTIME-runtime/*.wasm ./out/
   artifacts:
     paths:
       - out/*.wasm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,6 +118,10 @@ build-wasm-try-runtime:
       - RUNTIME: "spiritnet"
   image: paritytech/ci-unified:bullseye-1.70.0
   stage: build
+  only:
+    - develop
+    - master
+    - /^[0-9]+(?:\.[0-9]+){2}(?:-(rc)*([0-9])+)?$/
   script:
     - cargo build --release -p $RUNTIME-runtime --features try-runtime
     - mkdir ./out

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ build-wasm-try-runtime:
   script:
     - cargo build --release -p $RUNTIME-runtime --features try-runtime
     - mkdir ./out
-    - mv target/release/wbuild/$RUNTIME-runtime/*.wasm ./out/
+    - mv target/release/wbuild/$RUNTIME-runtime/$RUNTIME_runtime.compact.compressed.wasm ./out/dangerous_${RUNTIME}_${CI_COMMIT_TAG}.try-runtime.wasm
   artifacts:
     paths:
       - out/*.wasm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,7 @@ build-wasm-try-runtime:
     - mkdir ./out
     - mv target/release/wbuild/$RUNTIME-runtime/$RUNTIME_runtime.compact.compressed.wasm ./out/dangerous_${RUNTIME}_${CI_COMMIT_TAG}.try-runtime.wasm
   artifacts:
+    name: ${RUNTIME}_${CI_COMMIT_TAG}_try-runtime
     paths:
       - out/*.wasm
     expire_in: 12 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,3 +110,19 @@ build-wasm-spiritnet:
       - out/*.json
       - out/*.txt
     expire_in: 12 week
+
+build-wasm-try-runtime:
+  parallel:
+    matrix:
+      - RUNTIME: "peregrine"
+      - RUNTIME: "spiritnet"
+  image: paritytech/ci-unified:bullseye-1.70.0
+  stage: build
+  script:
+    - cargo build --release -p $RUNTIME-runtime --features try-runtime
+    - mkdir ./out
+    - mv target/release/wbuild/$RUNTIME-runtime/*.wasm /out/
+  artifacts:
+    paths:
+      - out/*.wasm
+    expire_in: 12 week


### PR DESCRIPTION
This PR adds Wasm builds with the `try-runtime` feature enabled. This is in preparation for more automation in the release process.

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
