### PR TITLE
refactor: use explicit `exclude_parts`

### DIFF
--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -942,9 +942,9 @@ construct_runtime! {
 		// DELETED: RandomnessCollectiveFlip: pallet_insecure_randomness_collective_flip = 1,
 
 		Timestamp: pallet_timestamp = 2,
-		Indices: pallet_indices::{Pallet, Call, Storage, Event<T>} = 5,
+		Indices: pallet_indices exclude_parts { Config } = 5,
 		Balances: pallet_balances = 6,
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>} = 7,
+		TransactionPayment: pallet_transaction_payment exclude_parts { Config } = 7,
 		Sudo: pallet_sudo = 8,
 		Configuration: pallet_configuration = 9,
 
@@ -954,7 +954,7 @@ construct_runtime! {
 		Aura: pallet_aura = 23,
 		Session: pallet_session = 22,
 		ParachainStaking: parachain_staking = 21,
-		Authorship: pallet_authorship::{Pallet, Storage} = 20,
+		Authorship: pallet_authorship = 20,
 		AuraExt: cumulus_pallet_aura_ext = 24,
 
 		Democracy: pallet_democracy = 30,
@@ -972,17 +972,17 @@ construct_runtime! {
 		// Vesting. Usable initially, but removed once all vesting is finished.
 		Vesting: pallet_vesting = 41,
 
-		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 42,
+		Scheduler: pallet_scheduler = 42,
 
 		// Allowing accounts to give permission to other accounts to dispatch types of calls from their signed origin
-		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>} = 43,
+		Proxy: pallet_proxy = 43,
 
 		// Preimage pallet allows the storage of large bytes blob
-		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 44,
+		Preimage: pallet_preimage = 44,
 
 		// Tips module to reward contributions to the ecosystem with small amount of KILTs.
 		TipsMembership: pallet_membership::<Instance2> = 45,
-		Tips: pallet_tips::{Pallet, Call, Storage, Event<T>} = 46,
+		Tips: pallet_tips = 46,
 
 		Multisig: pallet_multisig = 47,
 
@@ -1002,15 +1002,15 @@ construct_runtime! {
 
 		// Among others: Send and receive DMP and XCMP messages.
 		ParachainSystem: cumulus_pallet_parachain_system = 80,
-		ParachainInfo: parachain_info::{Pallet, Storage, Config} = 81,
+		ParachainInfo: parachain_info = 81,
 		// Wrap and unwrap XCMP messages to send and receive them. Queue them for later processing.
-		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 82,
+		XcmpQueue: cumulus_pallet_xcmp_queue = 82,
 		// Build XCM scripts.
-		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config} = 83,
+		PolkadotXcm: pallet_xcm = 83,
 		// Does nothing cool, just provides an origin.
-		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 84,
+		CumulusXcm: cumulus_pallet_xcm exclude_parts { Call } = 84,
 		// Queue and pass DMP messages on to be executed.
-		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 85,
+		DmpQueue: cumulus_pallet_dmp_queue = 85,
 	}
 }
 

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -931,9 +931,9 @@ construct_runtime! {
 		// DELETED: RandomnessCollectiveFlip: pallet_insecure_randomness_collective_flip = 1,
 
 		Timestamp: pallet_timestamp = 2,
-		Indices: pallet_indices::{Pallet, Call, Storage, Event<T>} = 5,
+		Indices: pallet_indices exclude_parts { Config } = 5,
 		Balances: pallet_balances = 6,
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>} = 7,
+		TransactionPayment: pallet_transaction_payment exclude_parts { Config } = 7,
 
 		// Consensus support.
 		// The following order MUST NOT be changed: Aura -> Session -> Staking -> Authorship -> AuraExt
@@ -941,7 +941,7 @@ construct_runtime! {
 		Aura: pallet_aura = 23,
 		Session: pallet_session = 22,
 		ParachainStaking: parachain_staking = 21,
-		Authorship: pallet_authorship::{Pallet, Storage} = 20,
+		Authorship: pallet_authorship = 20,
 		AuraExt: cumulus_pallet_aura_ext = 24,
 
 		Democracy: pallet_democracy = 30,
@@ -959,17 +959,17 @@ construct_runtime! {
 		// Vesting. Usable initially, but removed once all vesting is finished.
 		Vesting: pallet_vesting = 41,
 
-		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 42,
+		Scheduler: pallet_scheduler = 42,
 
 		// Allowing accounts to give permission to other accounts to dispatch types of calls from their signed origin
-		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>} = 43,
+		Proxy: pallet_proxy = 43,
 
 		// Preimage pallet allows the storage of large bytes blob
-		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 44,
+		Preimage: pallet_preimage = 44,
 
 		// Tips module to reward contributions to the ecosystem with small amount of KILTs.
 		TipsMembership: pallet_membership::<Instance2> = 45,
-		Tips: pallet_tips::{Pallet, Call, Storage, Event<T>} = 46,
+		Tips: pallet_tips = 46,
 
 		Multisig: pallet_multisig = 47,
 
@@ -989,15 +989,15 @@ construct_runtime! {
 
 		// Among others: Send and receive DMP and XCMP messages.
 		ParachainSystem: cumulus_pallet_parachain_system = 80,
-		ParachainInfo: parachain_info::{Pallet, Storage, Config} = 81,
+		ParachainInfo: parachain_info = 81,
 		// Wrap and unwrap XCMP messages to send and receive them. Queue them for later processing.
-		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 82,
+		XcmpQueue: cumulus_pallet_xcmp_queue = 82,
 		// Build XCM scripts.
-		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config} = 83,
+		PolkadotXcm: pallet_xcm = 83,
 		// Does nothing cool, just provides an origin.
-		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 84,
+		CumulusXcm: cumulus_pallet_xcm exclude_parts { Call } = 84,
 		// Queue and pass DMP messages on to be executed.
-		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 85,
+		DmpQueue: cumulus_pallet_dmp_queue = 85,
 	}
 }
 

--- a/scripts/diff-runtimes.sh
+++ b/scripts/diff-runtimes.sh
@@ -15,7 +15,8 @@ curl -o artifacts-pere.zip -L --raw --header "Private-Token: ${GITLAB_TOKEN}" "h
 unzip -u artifacts-spirit.zip -d artifacts-spirit
 unzip -u artifacts-pere.zip -d artifacts-pere
 
-cargo build --release -p kilt-parachain
+cargo build --release -p spiritnet-runtime
+cargo build --release -p peregrine-runtime
 
 subwasm diff --no-color $SPIRITNET_DIR/out/spiritnet_runtime.compact.compressed.wasm target/release/wbuild/spiritnet-runtime/spiritnet_runtime.compact.compressed.wasm | tee develop-diff-spiritnet.txt
 subwasm diff --no-color $PEREGRINE_DIR/out/peregrine_runtime.compact.compressed.wasm target/release/wbuild/peregrine-runtime/peregrine_runtime.compact.compressed.wasm | tee develop-diff-peregrine.txt


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2815

This PR checks what's part of our runtime and what is not. We only didn't add the PolkadotXcm storage metadata. Everything else seems to be ok.
I still exclude the genesis config for `indices` and `transaction_payment` since we don't plan to customize them for any new chains. If we need them, we can still enable both.

## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>

```
!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
[≠] pallet 83: PolkadotXcm -> 12 change(s)
  - storages changes:
    [+] StorageDesc { name: "AssetTraps", modifier: "Default", default_value: [0, 0, 0, 0] }
    [+] StorageDesc { name: "CurrentMigration", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "LockedFungibles", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "Queries", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "QueryCounter", modifier: "Default", default_value: [0, 0, 0, 0, 0, 0, 0, 0] }
    [+] StorageDesc { name: "RemoteLockedFungibles", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "SafeXcmVersion", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "SupportedVersion", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "VersionDiscoveryQueue", modifier: "Default", default_value: [0] }
    [+] StorageDesc { name: "VersionNotifiers", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "VersionNotifyTargets", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "XcmExecutionSuspended", modifier: "Default", default_value: [0] }

SUMMARY:
- Compatible.......................: true
- Require transaction_version bump.: false

!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!

```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
[≠] pallet 83: PolkadotXcm -> 12 change(s)
  - storages changes:
    [+] StorageDesc { name: "AssetTraps", modifier: "Default", default_value: [0, 0, 0, 0] }
    [+] StorageDesc { name: "CurrentMigration", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "LockedFungibles", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "Queries", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "QueryCounter", modifier: "Default", default_value: [0, 0, 0, 0, 0, 0, 0, 0] }
    [+] StorageDesc { name: "RemoteLockedFungibles", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "SafeXcmVersion", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "SupportedVersion", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "VersionDiscoveryQueue", modifier: "Default", default_value: [0] }
    [+] StorageDesc { name: "VersionNotifiers", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "VersionNotifyTargets", modifier: "Optional", default_value: [0] }
    [+] StorageDesc { name: "XcmExecutionSuspended", modifier: "Default", default_value: [0] }

SUMMARY:
- Compatible.......................: true
- Require transaction_version bump.: false

!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!

```

</details>

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
