### PR TITLE
feat: add meaningful errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,6 +4530,7 @@ dependencies = [
  "frame-system",
  "hash-db",
  "hex-literal 0.3.4",
+ "log",
  "pallet-dip-consumer",
  "pallet-dip-provider",
  "pallet-relay-store",

--- a/crates/kilt-dip-support/Cargo.toml
+++ b/crates/kilt-dip-support/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 # External dependencies
 hash-db.workspace = true
+log.workspace = true
 
 # Internal dependencies
 did.workspace = true

--- a/crates/kilt-dip-support/src/did.rs
+++ b/crates/kilt-dip-support/src/did.rs
@@ -22,12 +22,13 @@ use did::{
 };
 use frame_support::ensure;
 use parity_scale_codec::{Decode, Encode};
-use scale_info::prelude::string::String;
-use scale_info::TypeInfo;
+use scale_info::{
+	prelude::string::{String, ToString},
+	TypeInfo,
+};
 use sp_core::RuntimeDebug;
 use sp_runtime::traits::CheckedSub;
-use sp_std::marker::PhantomData;
-use sp_std::vec::Vec;
+use sp_std::{marker::PhantomData, vec::Vec};
 
 use crate::{
 	merkle::RevealedDidKey,
@@ -115,8 +116,7 @@ impl<
 		local_details: &mut Option<DidLocalDetails>,
 		merkle_revealed_did_signature: RevealedDidKeysAndSignature<MerkleProofEntries, ContextProvider::BlockNumber>,
 	) -> Result<(DidVerificationKey<RemoteAccountId>, DidVerificationKeyRelationship), String> {
-		let block_number: <ContextProvider as DidSignatureVerifierContext>::BlockNumber =
-			ContextProvider::block_number();
+		let block_number = ContextProvider::block_number();
 		let is_signature_fresh = if let Some(blocks_ago_from_now) =
 			block_number.checked_sub(&merkle_revealed_did_signature.did_signature.block_number)
 		{

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -21,9 +21,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use parity_scale_codec::{Codec, Decode, Encode, HasCompact};
-use scale_info::prelude::string::String;
-use scale_info::prelude::string::ToString;
-use scale_info::TypeInfo;
+use scale_info::{
+	prelude::string::{String, ToString},
+	TypeInfo,
+};
 use sp_core::{Get, RuntimeDebug, U256};
 use sp_runtime::{
 	generic::Header,

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -129,13 +129,13 @@ where
 				error.into().to_be().into()
 			}
 			DipSiblingProviderStateProofVerifierError::IdentityCommitmentMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (1 << 8)
+				u16::from(error.into().to_be()) | (0b1 << 15)
 			}
 			DipSiblingProviderStateProofVerifierError::DipProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (2 << 8)
+				u16::from(error.into().to_be()) | (0b11 << 14)
 			}
 			DipSiblingProviderStateProofVerifierError::DidSignatureVerificationError(error) => {
-				u16::from(error.into().to_be()) | (3 << 8)
+				u16::from(error.into().to_be()) | (0b111 << 13)
 			}
 		}
 	}
@@ -391,16 +391,16 @@ where
 			DipChildProviderStateProofVerifierError::InvalidBlockHeight => 0,
 			DipChildProviderStateProofVerifierError::InvalidBlockHash => 1,
 			DipChildProviderStateProofVerifierError::ParachainHeadMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (1 << 8)
+				u16::from(error.into().to_be()) | (0b1 << 15)
 			}
 			DipChildProviderStateProofVerifierError::IdentityCommitmentMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (2 << 8)
+				u16::from(error.into().to_be()) | (0b11 << 14)
 			}
 			DipChildProviderStateProofVerifierError::DipProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (3 << 8)
+				u16::from(error.into().to_be()) | (0b111 << 13)
 			}
 			DipChildProviderStateProofVerifierError::DidSignatureVerificationError(error) => {
-				u16::from(error.into().to_be()) | (4 << 8)
+				u16::from(error.into().to_be()) | (0b1111 << 12)
 			}
 		}
 	}

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -126,16 +126,16 @@ where
 	) -> Self {
 		match value {
 			DipSiblingProviderStateProofVerifierError::ParachainHeadMerkleProofVerificationError(error) => {
-				error.into().to_be().into()
+				error.into() as u16
 			}
 			DipSiblingProviderStateProofVerifierError::IdentityCommitmentMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b1 << 15)
+				u8::MAX as u16 + error.into() as u16
 			}
 			DipSiblingProviderStateProofVerifierError::DipProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b11 << 14)
+				u8::MAX as u16 * 2 + error.into() as u16
 			}
 			DipSiblingProviderStateProofVerifierError::DidSignatureVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b111 << 13)
+				u8::MAX as u16 * 3 + error.into() as u16
 			}
 		}
 	}
@@ -391,16 +391,16 @@ where
 			DipChildProviderStateProofVerifierError::InvalidBlockHeight => 0,
 			DipChildProviderStateProofVerifierError::InvalidBlockHash => 1,
 			DipChildProviderStateProofVerifierError::ParachainHeadMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b1 << 15)
+				u8::MAX as u16 + error.into() as u16
 			}
 			DipChildProviderStateProofVerifierError::IdentityCommitmentMerkleProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b11 << 14)
+				u8::MAX as u16 * 2 + error.into() as u16
 			}
 			DipChildProviderStateProofVerifierError::DipProofVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b111 << 13)
+				u8::MAX as u16 * 3 + error.into() as u16
 			}
 			DipChildProviderStateProofVerifierError::DidSignatureVerificationError(error) => {
-				u16::from(error.into().to_be()) | (0b1111 << 12)
+				u8::MAX as u16 * 4 + error.into() as u16
 			}
 		}
 	}

--- a/crates/kilt-dip-support/src/lib.rs
+++ b/crates/kilt-dip-support/src/lib.rs
@@ -21,6 +21,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use parity_scale_codec::{Codec, Decode, Encode, HasCompact};
+use scale_info::prelude::string::String;
+use scale_info::prelude::string::ToString;
 use scale_info::TypeInfo;
 use sp_core::{Get, RuntimeDebug, U256};
 use sp_runtime::{
@@ -165,8 +167,11 @@ impl<
 	LocalContextProvider::Hash: Encode,
 	LocalContextProvider::SignedExtra: Encode,
 	LocalDidDetails: Bump + Default + Encode,
-	LocalDidCallVerifier:
-		DipCallOriginFilter<Call, OriginInfo = (DidVerificationKey<ProviderAccountId>, DidVerificationKeyRelationship)>,
+	LocalDidCallVerifier: DipCallOriginFilter<
+		Call,
+		OriginInfo = (DidVerificationKey<ProviderAccountId>, DidVerificationKeyRelationship),
+		Error = String,
+	>,
 
 	ProviderDipMerkleHasher: sp_core::Hasher,
 	ProviderDidKeyId: Encode + Clone + Into<ProviderDipMerkleHasher::Out>,
@@ -174,7 +179,7 @@ impl<
 	ProviderLinkedAccountId: Encode + Clone,
 	ProviderWeb3Name: Encode + Clone,
 {
-	type Error = ();
+	type Error = String;
 	type IdentityDetails = LocalDidDetails;
 	type Proof = SiblingParachainDipStateProof<
 		RelayChainStateInfo::BlockNumber,
@@ -373,8 +378,11 @@ impl<
 	LocalContextProvider::Hash: Encode,
 	LocalContextProvider::SignedExtra: Encode,
 	LocalDidDetails: Bump + Default + Encode,
-	LocalDidCallVerifier:
-		DipCallOriginFilter<Call, OriginInfo = (DidVerificationKey<ProviderAccountId>, DidVerificationKeyRelationship)>,
+	LocalDidCallVerifier: DipCallOriginFilter<
+		Call,
+		OriginInfo = (DidVerificationKey<ProviderAccountId>, DidVerificationKeyRelationship),
+		Error = String,
+	>,
 
 	ProviderDipMerkleHasher: sp_core::Hasher,
 	ProviderDidKeyId: Encode + Clone + Into<ProviderDipMerkleHasher::Out>,
@@ -382,7 +390,7 @@ impl<
 	ProviderLinkedAccountId: Encode + Clone,
 	ProviderWeb3Name: Encode + Clone,
 {
-	type Error = ();
+	type Error = String;
 	type IdentityDetails = LocalDidDetails;
 	type Proof = ChildParachainDipStateProof<
 		<RelayChainInfo as RelayChainStorageInfo>::BlockNumber,
@@ -415,12 +423,12 @@ impl<
 		proof: Self::Proof,
 	) -> Result<Self::VerificationResult, Self::Error> {
 		// 1. Retrieve block hash from provider at the proof height
-		let block_hash_at_height =
-			RelayChainInfo::block_hash_for(&proof.para_state_root.relay_block_height).ok_or(())?;
+		let block_hash_at_height = RelayChainInfo::block_hash_for(&proof.para_state_root.relay_block_height)
+			.ok_or("Could not find block hash for provided block height.")?;
 
 		// 1.1 Verify that the provided header hashes to the same block has retrieved
 		if block_hash_at_height != proof.relay_header.hash() {
-			return Err(());
+			return Err("Block height mismatch between retrieved block and provided block.".to_string());
 		}
 		// 1.2 If so, extract the state root from the header
 		let state_root_at_height = proof.relay_header.state_root;

--- a/crates/kilt-dip-support/src/merkle.rs
+++ b/crates/kilt-dip-support/src/merkle.rs
@@ -19,8 +19,7 @@
 use did::{did_details::DidPublicKeyDetails, DidVerificationKeyRelationship};
 use frame_support::{traits::ConstU32, DefaultNoBound, RuntimeDebug};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::prelude::string::String;
-use scale_info::TypeInfo;
+use scale_info::{prelude::string::String, TypeInfo};
 use sp_runtime::{BoundedVec, SaturatedConversion};
 use sp_std::{fmt::Debug, marker::PhantomData, vec::Vec};
 use sp_trie::{verify_trie_proof, LayoutV1};

--- a/crates/kilt-dip-support/src/merkle.rs
+++ b/crates/kilt-dip-support/src/merkle.rs
@@ -44,7 +44,6 @@ impl From<DidVerificationKeyRelationship> for DidKeyRelationship {
 }
 
 impl TryFrom<DidKeyRelationship> for DidVerificationKeyRelationship {
-	// TODO: Error handling
 	type Error = ();
 
 	fn try_from(value: DidKeyRelationship) -> Result<Self, Self::Error> {

--- a/crates/kilt-dip-support/src/merkle.rs
+++ b/crates/kilt-dip-support/src/merkle.rs
@@ -19,7 +19,7 @@
 use did::{did_details::DidPublicKeyDetails, DidVerificationKeyRelationship};
 use frame_support::{traits::ConstU32, DefaultNoBound, RuntimeDebug};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::{prelude::string::String, TypeInfo};
+use scale_info::TypeInfo;
 use sp_runtime::{BoundedVec, SaturatedConversion};
 use sp_std::{fmt::Debug, marker::PhantomData, vec::Vec};
 use sp_trie::{verify_trie_proof, LayoutV1};
@@ -203,6 +203,22 @@ impl<
 	}
 }
 
+pub enum DidMerkleProofVerifierError {
+	InvalidMerkleProof,
+	TooManyRevealedKeys,
+	TooManyRevealedAccounts,
+}
+
+impl From<DidMerkleProofVerifierError> for u8 {
+	fn from(value: DidMerkleProofVerifierError) -> Self {
+		match value {
+			DidMerkleProofVerifierError::InvalidMerkleProof => 0,
+			DidMerkleProofVerifierError::TooManyRevealedKeys => 1,
+			DidMerkleProofVerifierError::TooManyRevealedAccounts => 2,
+		}
+	}
+}
+
 /// A type that verifies a Merkle proof that reveals some leaves representing
 /// keys in a DID Document.
 /// Can also be used on its own, without any DID signature verification.
@@ -262,7 +278,7 @@ impl<
 			MAX_REVEALED_KEYS_COUNT,
 			MAX_REVEALED_ACCOUNTS_COUNT,
 		>,
-		String,
+		DidMerkleProofVerifierError,
 	> {
 		// TODO: more efficient by removing cloning and/or collecting.
 		// Did not find another way of mapping a Vec<(Vec<u8>, Vec<u8>)> to a
@@ -273,7 +289,7 @@ impl<
 			.map(|leaf| (leaf.encoded_key(), Some(leaf.encoded_value())))
 			.collect::<Vec<(Vec<u8>, Option<Vec<u8>>)>>();
 		verify_trie_proof::<LayoutV1<Hasher>, _, _, _>(identity_commitment, &proof.blinded, &proof_leaves)
-			.map_err(|_| "Failed to verify DIP proof for provided DIP identity commitment.")?;
+			.map_err(|_| DidMerkleProofVerifierError::InvalidMerkleProof)?;
 
 		// At this point, we know the proof is valid. We just need to map the revealed
 		// leaves to something the consumer can easily operate on.
@@ -296,8 +312,8 @@ impl<
 						relationship: key_id.1,
 						details: key_value.0.clone(),
 					})
-					.map_err(|_| "Reached maximum number of keys that can be revealed in a DIP proof.")?;
-					Ok::<_, String>((keys, web3_name, linked_accounts))
+					.map_err(|_| DidMerkleProofVerifierError::TooManyRevealedKeys)?;
+					Ok::<_, DidMerkleProofVerifierError>((keys, web3_name, linked_accounts))
 				}
 				// TODO: Avoid cloning if possible
 				RevealedDidMerkleProofLeaf::Web3Name(revealed_web3_name, details) => Ok((
@@ -309,10 +325,10 @@ impl<
 					linked_accounts,
 				)),
 				RevealedDidMerkleProofLeaf::LinkedAccount(account_id, _) => {
-					linked_accounts.try_push(account_id.0.clone()).map_err(|_| {
-						"Reached maximum number of linked accounts that can be revealed in a DIP proof."
-					})?;
-					Ok::<_, String>((keys, web3_name, linked_accounts))
+					linked_accounts
+						.try_push(account_id.0.clone())
+						.map_err(|_| DidMerkleProofVerifierError::TooManyRevealedAccounts)?;
+					Ok::<_, DidMerkleProofVerifierError>((keys, web3_name, linked_accounts))
 				}
 			},
 		)?;

--- a/crates/kilt-dip-support/src/state_proofs.rs
+++ b/crates/kilt-dip-support/src/state_proofs.rs
@@ -17,8 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, HasCompact};
-use scale_info::prelude::string::String;
-use scale_info::prelude::string::ToString;
+use scale_info::prelude::string::{String, ToString};
 use sp_core::{storage::StorageKey, U256};
 use sp_runtime::generic::Header;
 use sp_std::{marker::PhantomData, vec::Vec};
@@ -120,11 +119,11 @@ pub(super) mod relay_chain {
 				debug_assert!(revealed_leaves.contains_key(parachain_storage_key.as_ref()));
 			}
 			let Some(Some(encoded_head)) = revealed_leaves.get(parachain_storage_key.as_ref()) else {
-				return Err("No parachain head leaf revealed in the provided Merkle proof.");
+				return Err("No parachain head leaf revealed in the provided Merkle proof.".to_string());
 			};
 			// TODO: Figure out why RPC call returns 2 bytes in front which we don't need
 			let mut unwrapped_head = &encoded_head[2..];
-			Header::decode(&mut unwrapped_head).map_err(|_| "Failed to decode revealed header.")
+			Header::decode(&mut unwrapped_head).map_err(|_| "Failed to decode revealed header.".to_string())
 		}
 	}
 

--- a/crates/kilt-dip-support/src/state_proofs.rs
+++ b/crates/kilt-dip-support/src/state_proofs.rs
@@ -17,6 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, HasCompact};
+use sp_core::RuntimeDebug;
 use sp_core::{storage::StorageKey, U256};
 use sp_runtime::generic::Header;
 use sp_std::{marker::PhantomData, vec::Vec};
@@ -92,6 +93,7 @@ pub(super) mod relay_chain {
 
 	use crate::traits::{RelayChainStateInfo, RelayChainStorageInfo};
 
+	#[derive(RuntimeDebug)]
 	pub enum ParachainHeadProofVerifierError {
 		InvalidMerkleProof,
 		RequiredLeafNotRevealed,
@@ -269,6 +271,7 @@ pub(super) mod parachain {
 
 	use crate::traits::ProviderParachainStateInfo;
 
+	#[derive(RuntimeDebug)]
 	pub enum DipIdentityCommitmentProofVerifierError {
 		InvalidMerkleProof,
 		RequiredLeafNotRevealed,

--- a/crates/kilt-dip-support/src/state_proofs.rs
+++ b/crates/kilt-dip-support/src/state_proofs.rs
@@ -17,8 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, HasCompact};
-use sp_core::RuntimeDebug;
-use sp_core::{storage::StorageKey, U256};
+use sp_core::{storage::StorageKey, RuntimeDebug, U256};
 use sp_runtime::generic::Header;
 use sp_std::{marker::PhantomData, vec::Vec};
 use sp_trie::StorageProof;
@@ -98,7 +97,7 @@ pub(super) mod relay_chain {
 		InvalidMerkleProof,
 		RequiredLeafNotRevealed,
 		HeaderDecode,
-		ParachainStateRootNotFound,
+		RelaychainStateRootNotFound,
 	}
 
 	impl From<ParachainHeadProofVerifierError> for u8 {
@@ -107,7 +106,7 @@ pub(super) mod relay_chain {
 				ParachainHeadProofVerifierError::InvalidMerkleProof => 0,
 				ParachainHeadProofVerifierError::RequiredLeafNotRevealed => 1,
 				ParachainHeadProofVerifierError::HeaderDecode => 2,
-				ParachainHeadProofVerifierError::ParachainStateRootNotFound => 3,
+				ParachainHeadProofVerifierError::RelaychainStateRootNotFound => 3,
 			}
 		}
 	}
@@ -162,7 +161,7 @@ pub(super) mod relay_chain {
 			proof: impl IntoIterator<Item = Vec<u8>>,
 		) -> Result<Header<RelayChainState::BlockNumber, RelayChainState::Hasher>, ParachainHeadProofVerifierError> {
 			let relay_state_root = RelayChainState::state_root_for_block(relay_height)
-				.ok_or(ParachainHeadProofVerifierError::ParachainStateRootNotFound)?;
+				.ok_or(ParachainHeadProofVerifierError::RelaychainStateRootNotFound)?;
 			Self::verify_proof_for_parachain_with_root(para_id, &relay_state_root, proof)
 		}
 	}

--- a/crates/kilt-dip-support/src/utils.rs
+++ b/crates/kilt-dip-support/src/utils.rs
@@ -90,6 +90,21 @@ pub enum CombineError<ErrorA, ErrorB, ErrorC> {
 	C(ErrorC),
 }
 
+impl<ErrorA, ErrorB, ErrorC> From<CombineError<ErrorA, ErrorB, ErrorC>> for u16
+where
+	ErrorA: Into<u16>,
+	ErrorB: Into<u16>,
+	ErrorC: Into<u16>,
+{
+	fn from(value: CombineError<ErrorA, ErrorB, ErrorC>) -> Self {
+		match value {
+			CombineError::A(error) => error.into(),
+			CombineError::B(error) => error.into(),
+			CombineError::C(error) => error.into(),
+		}
+	}
+}
+
 impl<Identifier, A, B, C> IdentityProvider<Identifier> for CombineIdentityFrom<A, B, C>
 where
 	A: IdentityProvider<Identifier>,

--- a/crates/kilt-dip-support/src/utils.rs
+++ b/crates/kilt-dip-support/src/utils.rs
@@ -17,6 +17,8 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use pallet_dip_provider::traits::IdentityProvider;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_std::marker::PhantomData;
 
 pub struct CombinedIdentityResult<OutputA, OutputB, OutputC> {
@@ -81,6 +83,7 @@ where
 
 pub struct CombineIdentityFrom<A, B, C>(PhantomData<(A, B, C)>);
 
+#[derive(Encode, Decode, TypeInfo)]
 pub enum CombineError<ErrorA, ErrorB, ErrorC> {
 	A(ErrorA),
 	B(ErrorB),

--- a/dip-template/runtimes/dip-consumer/src/dip.rs
+++ b/dip-template/runtimes/dip-consumer/src/dip.rs
@@ -25,7 +25,7 @@ use kilt_dip_support::{
 };
 use pallet_did_lookup::linkable_account::LinkableAccountId;
 use pallet_dip_consumer::traits::IdentityProofVerifier;
-use scale_info::prelude::string::String;
+use scale_info::prelude::string::{String, ToString};
 use sp_core::ConstU32;
 use sp_runtime::traits::BlakeTwo256;
 

--- a/dip-template/runtimes/dip-consumer/src/dip.rs
+++ b/dip-template/runtimes/dip-consumer/src/dip.rs
@@ -25,11 +25,10 @@ use kilt_dip_support::{
 };
 use pallet_did_lookup::linkable_account::LinkableAccountId;
 use pallet_dip_consumer::traits::IdentityProofVerifier;
-use scale_info::prelude::string::{String, ToString};
 use sp_core::ConstU32;
 use sp_runtime::traits::BlakeTwo256;
 
-use crate::{AccountId, DidIdentifier, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin};
+use crate::{AccountId, DidIdentifier, Runtime, RuntimeCall, RuntimeOrigin};
 
 pub type MerkleProofVerifierOutputOf<Call, Subject> =
 	<ProofVerifier as IdentityProofVerifier<Call, Subject>>::VerificationResult;
@@ -56,10 +55,9 @@ impl pallet_dip_consumer::Config for Runtime {
 	type Identifier = DidIdentifier;
 	type IdentityProof = <ProofVerifier as IdentityProofVerifier<RuntimeCall, DidIdentifier>>::Proof;
 	type LocalIdentityInfo = u128;
-	type ProofVerificationError = String;
+	type ProofVerificationError = <ProofVerifier as IdentityProofVerifier<RuntimeCall, DidIdentifier>>::Error;
 	type ProofVerifier = ProofVerifier;
 	type RuntimeCall = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 }
 
@@ -109,24 +107,26 @@ fn single_key_relationship<'a>(
 		})
 }
 
+pub enum DipCallFilterError {
+	BadOrigin,
+	WrongVerificationRelationship,
+}
+
 pub struct DipCallFilter;
 
 impl DipCallOriginFilter<RuntimeCall> for DipCallFilter {
-	type Error = String;
+	type Error = DipCallFilterError;
 	type OriginInfo = (DidVerificationKey<ProviderAccountId>, DidVerificationKeyRelationship);
 	type Success = ();
 
 	// Accepts only a DipOrigin for the DidLookup pallet calls.
 	fn check_call_origin_info(call: &RuntimeCall, info: &Self::OriginInfo) -> Result<Self::Success, Self::Error> {
 		let key_relationship =
-			single_key_relationship([call].into_iter()).map_err(|_| "Call cannot be authorized by a DID origin.")?;
+			single_key_relationship([call].into_iter()).map_err(|_| DipCallFilterError::BadOrigin)?;
 		if info.1 == key_relationship {
 			Ok(())
 		} else {
-			Err(
-				"DID key used to authorize the operation is not of the same relationship expected by this call."
-					.to_string(),
-			)
+			Err(DipCallFilterError::WrongVerificationRelationship)
 		}
 	}
 }

--- a/dip-template/runtimes/dip-provider/src/dip.rs
+++ b/dip-template/runtimes/dip-provider/src/dip.rs
@@ -50,6 +50,7 @@ impl pallet_dip_provider::Config for Runtime {
 	type Identifier = DidIdentifier;
 	type IdentityCommitment = Hash;
 	type IdentityCommitmentGenerator = DidMerkleRootGenerator<Runtime>;
+	type IdentityCommitmentGeneratorError = DidMerkleProofError;
 	type IdentityProvider = LinkedDidInfoProviderOf<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 }

--- a/dip-template/runtimes/dip-provider/src/dip.rs
+++ b/dip-template/runtimes/dip-provider/src/dip.rs
@@ -52,5 +52,6 @@ impl pallet_dip_provider::Config for Runtime {
 	type IdentityCommitmentGenerator = DidMerkleRootGenerator<Runtime>;
 	type IdentityCommitmentGeneratorError = DidMerkleProofError;
 	type IdentityProvider = LinkedDidInfoProviderOf<Runtime>;
+	type IdentityProviderError = <LinkedDidInfoProviderOf<Runtime> as IdentityProvider<DidIdentifier>>::Error;
 	type RuntimeEvent = RuntimeEvent;
 }

--- a/dip-template/runtimes/dip-provider/src/dip.rs
+++ b/dip-template/runtimes/dip-provider/src/dip.rs
@@ -16,10 +16,33 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use did::{DidRawOrigin, EnsureDidOrigin};
-use runtime_common::dip::{did::LinkedDidInfoProviderOf, merkle::DidMerkleRootGenerator};
+use did::{DidRawOrigin, EnsureDidOrigin, KeyIdOf};
+use pallet_did_lookup::linkable_account::LinkableAccountId;
+use pallet_dip_provider::traits::IdentityProvider;
+use parity_scale_codec::{Decode, Encode};
+use runtime_common::dip::{
+	did::LinkedDidInfoProviderOf,
+	merkle::{DidMerkleProofError, DidMerkleRootGenerator},
+};
+use scale_info::TypeInfo;
+use sp_std::vec::Vec;
 
 use crate::{AccountId, DidIdentifier, Hash, Runtime, RuntimeEvent};
+
+#[derive(Encode, Decode, TypeInfo)]
+pub struct RuntimeApiDipProofRequest {
+	pub(crate) identifier: DidIdentifier,
+	pub(crate) keys: Vec<KeyIdOf<Runtime>>,
+	pub(crate) accounts: Vec<LinkableAccountId>,
+	pub(crate) should_include_web3_name: bool,
+}
+
+#[derive(Encode, Decode, TypeInfo)]
+pub enum RuntimeApiDipProofError {
+	IdentityProviderError(<LinkedDidInfoProviderOf<Runtime> as IdentityProvider<DidIdentifier>>::Error),
+	IdentityNotFound,
+	MerkleProofError(DidMerkleProofError),
+}
 
 impl pallet_dip_provider::Config for Runtime {
 	type CommitOriginCheck = EnsureDidOrigin<DidIdentifier, AccountId>;

--- a/dip-template/runtimes/dip-provider/src/dip.rs
+++ b/dip-template/runtimes/dip-provider/src/dip.rs
@@ -39,8 +39,8 @@ pub struct RuntimeApiDipProofRequest {
 
 #[derive(Encode, Decode, TypeInfo)]
 pub enum RuntimeApiDipProofError {
-	IdentityProviderError(<LinkedDidInfoProviderOf<Runtime> as IdentityProvider<DidIdentifier>>::Error),
 	IdentityNotFound,
+	IdentityProviderError(<LinkedDidInfoProviderOf<Runtime> as IdentityProvider<DidIdentifier>>::Error),
 	MerkleProofError(DidMerkleProofError),
 }
 

--- a/nodes/standalone/src/command.rs
+++ b/nodes/standalone/src/command.rs
@@ -16,12 +16,12 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use crate::service::ExecutorDispatch;
 use crate::{
 	benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
 	chain_spec,
 	cli::{Cli, Subcommand},
 	service,
+	service::ExecutorDispatch,
 };
 
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};

--- a/nodes/standalone/src/rpc.rs
+++ b/nodes/standalone/src/rpc.rs
@@ -72,7 +72,8 @@ where
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed
 	// to call into the runtime.
-	// `module.merge(YourRpcTrait::into_rpc(YourRpcStruct::new(ReferenceToClient, ...)))?;`
+	// `module.merge(YourRpcTrait::into_rpc(YourRpcStruct::new(ReferenceToClient,
+	// ...)))?;`
 
 	Ok(module)
 }

--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -18,8 +18,7 @@
 
 use frame_benchmarking::{account, benchmarks};
 use frame_support::traits::{fungible::Mutate, Get};
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::traits::Hash;
 
 use ctype::CtypeEntryOf;

--- a/pallets/delegation/src/benchmarking.rs
+++ b/pallets/delegation/src/benchmarking.rs
@@ -27,8 +27,7 @@ use frame_support::{
 		Get,
 	},
 };
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use parity_scale_codec::Encode;
 use sp_core::{offchain::KeyTypeId, sr25519};
 use sp_io::crypto::sr25519_generate;

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -22,8 +22,7 @@ use frame_support::{
 	assert_ok,
 	traits::fungible::{Inspect, Mutate, MutateHold},
 };
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use parity_scale_codec::Encode;
 use sp_core::{crypto::KeyTypeId, ecdsa, ed25519, sr25519};
 use sp_io::crypto::{ecdsa_generate, ecdsa_sign, ed25519_generate, ed25519_sign, sr25519_generate, sr25519_sign};

--- a/pallets/pallet-did-lookup/src/benchmarking.rs
+++ b/pallets/pallet-did-lookup/src/benchmarking.rs
@@ -27,8 +27,7 @@ use frame_support::{
 		Get,
 	},
 };
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sha3::{Digest, Keccak256};
 use sp_io::crypto::{ecdsa_generate, ed25519_generate, sr25519_generate};
 use sp_runtime::{

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -121,18 +121,13 @@ pub mod pallet {
 			// TODO: Proper error handling
 			ensure!(T::DipCallOriginFilter::contains(&*call), Error::<T>::Dispatch);
 			let mut identity_entry = IdentityEntries::<T>::get(&identifier);
-			let proof_verification_result: <<T as Config>::ProofVerifier as IdentityProofVerifier<
-				<T as Config>::RuntimeCall,
-				<T as Config>::Identifier,
-			>>::VerificationResult = T::ProofVerifier::verify_proof_for_call_against_details(
+			let proof_verification_result = T::ProofVerifier::verify_proof_for_call_against_details(
 				&*call,
 				&identifier,
 				&submitter,
 				&mut identity_entry,
 				proof,
 			)
-			// If verification fails, we generate an event with the details of why it failed (not possible to otherwise
-			// generate a generic message for the error). Inspiration taken from the utility pallet.
 			.map_err(|e| Error::<T>::InvalidProof(e.into()))?;
 			IdentityEntries::<T>::mutate(&identifier, |entry| *entry = identity_entry);
 			let did_origin = DipOrigin {

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -92,7 +92,7 @@ pub mod pallet {
 		/// An identity with the provided identifier could not be found.
 		IdentityNotFound,
 		/// The identity proof provided could not be successfully verified.
-		InvalidProof { reason: u16 },
+		InvalidProof(u16),
 		/// The specified call could not be dispatched.
 		Dispatch,
 	}
@@ -133,7 +133,7 @@ pub mod pallet {
 			)
 			// If verification fails, we generate an event with the details of why it failed (not possible to otherwise
 			// generate a generic message for the error). Inspiration taken from the utility pallet.
-			.map_err(|e| Error::<T>::InvalidProof { reason: e.into() })?;
+			.map_err(|e| Error::<T>::InvalidProof(e.into()))?;
 			IdentityEntries::<T>::mutate(&identifier, |entry| *entry = identity_entry);
 			let did_origin = DipOrigin {
 				identifier,

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -93,8 +93,8 @@ pub mod pallet {
 		IdentityNotFound,
 		/// The identity proof provided could not be successfully verified.
 		InvalidProof(u16),
-		/// The specified call could not be dispatched.
-		Dispatch,
+		/// The specified call is filtered by the DIP call origin filter.
+		Filtered,
 	}
 
 	/// The origin this pallet creates after a user has provided a valid
@@ -118,8 +118,7 @@ pub mod pallet {
 			// TODO: Make origin check configurable, and require that it at least returns
 			// the submitter's account.
 			let submitter = ensure_signed(origin)?;
-			// TODO: Proper error handling
-			ensure!(T::DipCallOriginFilter::contains(&*call), Error::<T>::Dispatch);
+			ensure!(T::DipCallOriginFilter::contains(&*call), Error::<T>::Filtered);
 			let mut identity_entry = IdentityEntries::<T>::get(&identifier);
 			let proof_verification_result = T::ProofVerifier::verify_proof_for_call_against_details(
 				&*call,
@@ -136,7 +135,7 @@ pub mod pallet {
 				details: proof_verification_result,
 			};
 			// TODO: Use dispatch info for weight calculation
-			let _ = call.dispatch(did_origin.into()).map_err(|_| Error::<T>::Dispatch)?;
+			let _ = call.dispatch(did_origin.into()).map_err(|e| e.error)?;
 			Ok(())
 		}
 	}

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
 		type IdentityProof: Parameter;
 		/// The details stored in this pallet associated with any given subject.
 		type LocalIdentityInfo: FullCodec + TypeInfo + MaxEncodedLen;
-		type ProofVerificationError: Clone + Eq + Debug + Decode;
+		type ProofVerificationError: Clone + Debug + PartialEq;
 		/// The logic of the proof verifier, called upon each execution of the
 		/// `dispatch_as` extrinsic.
 		type ProofVerifier: IdentityProofVerifier<

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -35,7 +35,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::{FullCodec, MaxEncodedLen};
 	use scale_info::TypeInfo;
-	use sp_std::{boxed::Box, fmt::Debug};
+	use sp_std::boxed::Box;
 
 	use crate::traits::IdentityProofVerifier;
 
@@ -66,7 +66,7 @@ pub mod pallet {
 		type IdentityProof: Parameter;
 		/// The details stored in this pallet associated with any given subject.
 		type LocalIdentityInfo: FullCodec + TypeInfo + MaxEncodedLen;
-		type ProofVerificationError: Clone + Debug + PartialEq;
+		type ProofVerificationError: Into<u16>;
 		/// The logic of the proof verifier, called upon each execution of the
 		/// `dispatch_as` extrinsic.
 		type ProofVerifier: IdentityProofVerifier<
@@ -79,8 +79,6 @@ pub mod pallet {
 		>;
 		/// The overarching runtime call type.
 		type RuntimeCall: Parameter + Dispatchable<RuntimeOrigin = <Self as Config>::RuntimeOrigin>;
-		/// The overarching event type.
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		/// The overarching runtime origin type.
 		type RuntimeOrigin: From<Origin<Self>> + From<<Self as frame_system::Config>::RuntimeOrigin>;
 	}
@@ -94,15 +92,9 @@ pub mod pallet {
 		/// An identity with the provided identifier could not be found.
 		IdentityNotFound,
 		/// The identity proof provided could not be successfully verified.
-		InvalidProof,
+		InvalidProof { reason: u16 },
 		/// The specified call could not be dispatched.
 		Dispatch,
-	}
-
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		ProofVerificationFailed(T::ProofVerificationError),
 	}
 
 	/// The origin this pallet creates after a user has provided a valid
@@ -141,10 +133,7 @@ pub mod pallet {
 			)
 			// If verification fails, we generate an event with the details of why it failed (not possible to otherwise
 			// generate a generic message for the error). Inspiration taken from the utility pallet.
-			.map_err(|e| {
-				Self::deposit_event(Event::<T>::ProofVerificationFailed(e));
-				Error::<T>::InvalidProof
-			})?;
+			.map_err(|e| Error::<T>::InvalidProof { reason: e.into() })?;
 			IdentityEntries::<T>::mutate(&identifier, |entry| *entry = identity_entry);
 			let did_origin = DipOrigin {
 				identifier,

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -129,7 +129,10 @@ pub mod pallet {
 			// TODO: Proper error handling
 			ensure!(T::DipCallOriginFilter::contains(&*call), Error::<T>::Dispatch);
 			let mut identity_entry = IdentityEntries::<T>::get(&identifier);
-			let proof_verification_result = T::ProofVerifier::verify_proof_for_call_against_details(
+			let proof_verification_result: <<T as Config>::ProofVerifier as IdentityProofVerifier<
+				<T as Config>::RuntimeCall,
+				<T as Config>::Identifier,
+			>>::VerificationResult = T::ProofVerifier::verify_proof_for_call_against_details(
 				&*call,
 				&identifier,
 				&submitter,

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -136,8 +136,8 @@ pub mod pallet {
 				&mut identity_entry,
 				proof,
 			)
-			// If verification fails, we generate an event with the details of why it failed (not possible to otherwise generate a generic message for the error).
-			// Inspiration taken from the utility pallet.
+			// If verification fails, we generate an event with the details of why it failed (not possible to otherwise
+			// generate a generic message for the error). Inspiration taken from the utility pallet.
 			.map_err(|e| {
 				Self::deposit_event(Event::<T>::ProofVerificationFailed(e));
 				Error::<T>::InvalidProof

--- a/pallets/pallet-dip-provider/src/lib.rs
+++ b/pallets/pallet-dip-provider/src/lib.rs
@@ -80,8 +80,8 @@ pub mod pallet {
 
 	#[pallet::error]
 	pub enum Error<T> {
-		IdentityProvider { reason: u16 },
-		IdentityCommitmentGenerator { reason: u16 },
+		IdentityProvider(u16),
+		IdentityCommitmentGenerator(u16),
 	}
 
 	#[pallet::call]
@@ -97,9 +97,9 @@ pub mod pallet {
 			let identity_commitment: Option<T::IdentityCommitment> = match T::IdentityProvider::retrieve(&identifier) {
 				Ok(Some(identity)) => T::IdentityCommitmentGenerator::generate_commitment(&identifier, &identity)
 					.map(Some)
-					.map_err(|error| Error::<T>::IdentityCommitmentGenerator { reason: error.into() }),
+					.map_err(|error| Error::<T>::IdentityCommitmentGenerator(error.into())),
 				Ok(None) => Ok(None),
-				Err(error) => Err(Error::<T>::IdentityProvider { reason: error.into() }),
+				Err(error) => Err(Error::<T>::IdentityProvider(error.into())),
 			}?;
 
 			if let Some(commitment) = identity_commitment {

--- a/pallets/pallet-migration/src/lib.rs
+++ b/pallets/pallet-migration/src/lib.rs
@@ -39,8 +39,7 @@ pub mod pallet {
 		traits::{fungible::Inspect, Currency, ReservableCurrency},
 	};
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::traits::Hash;
-	use sp_runtime::SaturatedConversion;
+	use sp_runtime::{traits::Hash, SaturatedConversion};
 
 	use attestation::{Attestations, ClaimHashOf};
 	use delegation::{DelegationNodeIdOf, DelegationNodes};

--- a/pallets/pallet-migration/src/test.rs
+++ b/pallets/pallet-migration/src/test.rs
@@ -292,7 +292,8 @@ fn check_attempt_to_migrate_already_migrated_keys() {
 				requested_migrations.clone()
 			));
 
-			// Since the keys are already migrated, a second attempt should have not affect to the storage.
+			// Since the keys are already migrated, a second attempt should have not affect
+			// to the storage.
 			assert_storage_noop!(
 				Migration::update_balance(RuntimeOrigin::signed(ACCOUNT_00), requested_migrations)
 					.expect("Update balance should not panic")

--- a/pallets/pallet-web3-names/src/benchmarking.rs
+++ b/pallets/pallet-web3-names/src/benchmarking.rs
@@ -27,8 +27,7 @@ use frame_support::{
 	},
 	BoundedVec,
 };
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::app_crypto::sr25519;
 
 use kilt_support::{traits::GenerateBenchmarkOrigin, Deposit};

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -143,7 +143,6 @@ pub mod pallet {
 	pub use crate::inflation::{InflationInfo, RewardRate, StakingInfo};
 
 	use core::cmp::Ordering;
-	use frame_support::traits::BuildGenesisConfig;
 	use frame_support::{
 		pallet_prelude::*,
 		storage::bounded_btree_map::BoundedBTreeMap,
@@ -153,7 +152,7 @@ pub mod pallet {
 				fungible::{Inspect, MutateFreeze, Unbalanced},
 				Fortitude, Precision, Preservation,
 			},
-			EstimateNextSessionRotation, Get, OnUnbalanced, StorageVersion,
+			BuildGenesisConfig, EstimateNextSessionRotation, Get, OnUnbalanced, StorageVersion,
 		},
 		BoundedVec,
 	};
@@ -2513,8 +2512,8 @@ pub mod pallet {
 		/// 2. In hook new_session: Read the current top n candidates from the
 		///    TopCandidates and assign this set to author blocks for the next
 		///    session.
-		/// 3. AuRa queries the authorities from the session pallet for
-		///    this session and picks authors on round-robin-basis from list of
+		/// 3. AuRa queries the authorities from the session pallet for this
+		///    session and picks authors on round-robin-basis from list of
 		///    authorities.
 		fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 			log::debug!(

--- a/runtimes/common/src/assets.rs
+++ b/runtimes/common/src/assets.rs
@@ -17,6 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::prelude::string::String;
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;

--- a/runtimes/common/src/assets.rs
+++ b/runtimes/common/src/assets.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::{prelude::string::String, TypeInfo};
+use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
 

--- a/runtimes/common/src/assets.rs
+++ b/runtimes/common/src/assets.rs
@@ -17,8 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
-use scale_info::prelude::string::String;
-use scale_info::TypeInfo;
+use scale_info::{prelude::string::String, TypeInfo};
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
 

--- a/runtimes/common/src/dip/did.rs
+++ b/runtimes/common/src/dip/did.rs
@@ -31,15 +31,14 @@ use sp_std::{marker::PhantomData, vec::Vec};
 #[derive(Encode, Decode, TypeInfo)]
 pub enum DidIdentityProviderError {
 	DidNotFound,
-	Internal(u16),
+	Internal,
 }
 
 impl From<DidIdentityProviderError> for u16 {
 	fn from(value: DidIdentityProviderError) -> Self {
 		match value {
 			DidIdentityProviderError::DidNotFound => 0,
-			// Must be 1 or higher, used mostly internally for easier debugging
-			DidIdentityProviderError::Internal(code) => code,
+			DidIdentityProviderError::Internal => u16::MAX,
 		}
 	}
 }
@@ -85,7 +84,7 @@ where
 				"Inconsistent reverse map pallet_web3_names::owner(web3_name). Cannot find owner for web3name {:#?}",
 				web3_name
 			);
-			return Err(DidIdentityProviderError::Internal(1));
+			return Err(DidIdentityProviderError::Internal);
 		};
 		Ok(Some(Web3OwnershipOf::<T> {
 			web3_name,

--- a/runtimes/common/src/dip/did.rs
+++ b/runtimes/common/src/dip/did.rs
@@ -24,7 +24,15 @@ use kilt_dip_support::{
 };
 use pallet_did_lookup::linkable_account::LinkableAccountId;
 use pallet_dip_provider::traits::IdentityProvider;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_std::{marker::PhantomData, vec::Vec};
+
+#[derive(Encode, Decode, TypeInfo)]
+pub enum DidIdentityProviderError {
+	DidNotFound,
+	InternalError,
+}
 
 pub struct DidIdentityProvider<T>(PhantomData<T>);
 
@@ -32,8 +40,7 @@ impl<T> IdentityProvider<T::DidIdentifier> for DidIdentityProvider<T>
 where
 	T: did::Config,
 {
-	// TODO: Proper error handling
-	type Error = ();
+	type Error = DidIdentityProviderError;
 	type Success = DidDetails<T>;
 
 	fn retrieve(identifier: &T::DidIdentifier) -> Result<Option<Self::Success>, Self::Error> {
@@ -43,7 +50,7 @@ where
 		) {
 			(Some(details), _) => Ok(Some(details)),
 			(_, Some(_)) => Ok(None),
-			_ => Err(()),
+			_ => Err(DidIdentityProviderError::DidNotFound),
 		}
 	}
 }
@@ -56,8 +63,7 @@ impl<T> IdentityProvider<T::Web3NameOwner> for DidWeb3NameProvider<T>
 where
 	T: pallet_web3_names::Config,
 {
-	// TODO: Proper error handling
-	type Error = ();
+	type Error = DidIdentityProviderError;
 	type Success = Web3OwnershipOf<T>;
 
 	fn retrieve(identifier: &T::Web3NameOwner) -> Result<Option<Self::Success>, Self::Error> {
@@ -65,7 +71,8 @@ where
 			return Ok(None);
 		};
 		let Some(details) = pallet_web3_names::Pallet::<T>::owner(&web3_name) else {
-			return Err(());
+			log::error!("Inconsistent reverse map pallet_web3_names::owner(web3_name). Cannot find owner for web3name {:#?}", web3_name);
+			return Err(DidIdentityProviderError::InternalError);
 		};
 		Ok(Some(Web3OwnershipOf::<T> {
 			web3_name,
@@ -80,8 +87,7 @@ impl<T> IdentityProvider<T::DidIdentifier> for DidLinkedAccountsProvider<T>
 where
 	T: pallet_did_lookup::Config,
 {
-	// TODO: Proper error handling
-	type Error = ();
+	type Error = DidIdentityProviderError;
 	type Success = Vec<LinkableAccountId>;
 
 	fn retrieve(identifier: &T::DidIdentifier) -> Result<Option<Self::Success>, Self::Error> {

--- a/runtimes/common/src/dip/did.rs
+++ b/runtimes/common/src/dip/did.rs
@@ -71,7 +71,10 @@ where
 			return Ok(None);
 		};
 		let Some(details) = pallet_web3_names::Pallet::<T>::owner(&web3_name) else {
-			log::error!("Inconsistent reverse map pallet_web3_names::owner(web3_name). Cannot find owner for web3name {:#?}", web3_name);
+			log::error!(
+				"Inconsistent reverse map pallet_web3_names::owner(web3_name). Cannot find owner for web3name {:#?}",
+				web3_name
+			);
 			return Err(DidIdentityProviderError::InternalError);
 		};
 		Ok(Some(Web3OwnershipOf::<T> {

--- a/runtimes/common/src/dip/did.rs
+++ b/runtimes/common/src/dip/did.rs
@@ -31,7 +31,17 @@ use sp_std::{marker::PhantomData, vec::Vec};
 #[derive(Encode, Decode, TypeInfo)]
 pub enum DidIdentityProviderError {
 	DidNotFound,
-	InternalError,
+	Internal(u16),
+}
+
+impl From<DidIdentityProviderError> for u16 {
+	fn from(value: DidIdentityProviderError) -> Self {
+		match value {
+			DidIdentityProviderError::DidNotFound => 0,
+			// Must be 1 or higher, used mostly internally for easier debugging
+			DidIdentityProviderError::Internal(code) => code,
+		}
+	}
 }
 
 pub struct DidIdentityProvider<T>(PhantomData<T>);
@@ -75,7 +85,7 @@ where
 				"Inconsistent reverse map pallet_web3_names::owner(web3_name). Cannot find owner for web3name {:#?}",
 				web3_name
 			);
-			return Err(DidIdentityProviderError::InternalError);
+			return Err(DidIdentityProviderError::Internal(1));
 		};
 		Ok(Some(Web3OwnershipOf::<T> {
 			web3_name,

--- a/runtimes/common/src/dip/merkle.rs
+++ b/runtimes/common/src/dip/merkle.rs
@@ -54,7 +54,7 @@ pub enum DidMerkleProofError {
 	KeyNotFound,
 	LinkedAccountNotFound,
 	Web3NameNotFound,
-	Internal(u16),
+	Internal,
 }
 
 impl From<DidMerkleProofError> for u16 {
@@ -64,8 +64,7 @@ impl From<DidMerkleProofError> for u16 {
 			DidMerkleProofError::KeyNotFound => 1,
 			DidMerkleProofError::LinkedAccountNotFound => 2,
 			DidMerkleProofError::Web3NameNotFound => 3,
-			// Must be 4 or higher, used mostly internally for easier debugging
-			DidMerkleProofError::Internal(code) => code,
+			DidMerkleProofError::Internal => u16::MAX,
 		}
 	}
 }
@@ -112,7 +111,7 @@ where
 			.get(&did_details.authentication_key)
 			.ok_or_else(|| {
 				log::error!("Authentication key should be part of the public keys.");
-				DidMerkleProofError::Internal(4)
+				DidMerkleProofError::Internal
 			})?;
 		let auth_leaf = ProofLeafOf::<T>::DidKey(
 			DidKeyMerkleKey(
@@ -128,13 +127,13 @@ where
 					"Failed to insert authentication key in the trie builder. Authentication leaf: {:#?}",
 					auth_leaf
 				);
-				DidMerkleProofError::Internal(5)
+				DidMerkleProofError::Internal
 			})?;
 		// Attestation key, if present
 		if let Some(att_key_id) = did_details.attestation_key {
 			let att_key_details = did_details.public_keys.get(&att_key_id).ok_or_else(|| {
 				log::error!("Attestation key should be part of the public keys.");
-				DidMerkleProofError::Internal(6)
+				DidMerkleProofError::Internal
 			})?;
 			let att_leaf = ProofLeafOf::<T>::DidKey(
 				(att_key_id, DidVerificationKeyRelationship::AssertionMethod.into()).into(),
@@ -147,14 +146,14 @@ where
 						"Failed to insert attestation key in the trie builder. Attestation leaf: {:#?}",
 						att_leaf
 					);
-					DidMerkleProofError::Internal(7)
+					DidMerkleProofError::Internal
 				})?;
 		};
 		// Delegation key, if present
 		if let Some(del_key_id) = did_details.delegation_key {
 			let del_key_details = did_details.public_keys.get(&del_key_id).ok_or_else(|| {
 				log::error!("Delegation key should be part of the public keys.");
-				DidMerkleProofError::Internal(8)
+				DidMerkleProofError::Internal
 			})?;
 			let del_leaf = ProofLeafOf::<T>::DidKey(
 				(del_key_id, DidVerificationKeyRelationship::CapabilityDelegation.into()).into(),
@@ -167,7 +166,7 @@ where
 						"Failed to insert delegation key in the trie builder. Delegation leaf: {:#?}",
 						del_leaf
 					);
-					DidMerkleProofError::Internal(9)
+					DidMerkleProofError::Internal
 				})?;
 		};
 		// Key agreement keys
@@ -177,7 +176,7 @@ where
 			.try_for_each(|id| -> Result<(), DidMerkleProofError> {
 				let key_agreement_details = did_details.public_keys.get(id).ok_or_else(|| {
 					log::error!("Key agreement key should be part of the public keys.");
-					DidMerkleProofError::Internal(10)
+					DidMerkleProofError::Internal
 				})?;
 				let enc_leaf = ProofLeafOf::<T>::DidKey(
 					(*id, DidKeyRelationship::Encryption).into(),
@@ -190,7 +189,7 @@ where
 							"Failed to insert key agreement key in the trie builder. Key agreement leaf: {:#?}",
 							enc_leaf
 						);
-						DidMerkleProofError::Internal(11)
+						DidMerkleProofError::Internal
 					})?;
 				Ok(())
 			})?;
@@ -211,7 +210,7 @@ where
 								"Failed to insert linked account in the trie builder. Linked account leaf: {:#?}",
 								linked_account_leaf
 							);
-							DidMerkleProofError::Internal(12)
+							DidMerkleProofError::Internal
 						})?;
 					Ok(())
 				})?;
@@ -233,7 +232,7 @@ where
 						"Failed to insert web3name in the trie builder. Web3name leaf: {:#?}",
 						web3_name_leaf
 					);
-					DidMerkleProofError::Internal(13)
+					DidMerkleProofError::Internal
 				})?;
 		}
 
@@ -282,7 +281,7 @@ where
 					Ok((*key_id, DidKeyRelationship::Encryption).into())
 				} else {
 					log::error!("Unknown key ID {:#?} retrieved from DID details.", key_id);
-					Err(DidMerkleProofError::Internal(14))
+					Err(DidMerkleProofError::Internal)
 				}?;
 				Ok(RevealedDidMerkleProofLeaf::DidKey(
 					did_key_merkle_key,
@@ -327,7 +326,7 @@ where
 				"Failed to generate a merkle proof for the encoded keys: {:#?}",
 				encoded_keys
 			);
-			DidMerkleProofError::Internal(15)
+			DidMerkleProofError::Internal
 		})?;
 		Ok(CompleteMerkleProof {
 			root,

--- a/runtimes/common/src/dip/merkle.rs
+++ b/runtimes/common/src/dip/merkle.rs
@@ -49,7 +49,7 @@ pub struct CompleteMerkleProof<Root, Proof> {
 	pub proof: Proof,
 }
 
-#[derive(Encode, Decode, TypeInfo)]
+#[derive(Clone, RuntimeDebug, Encode, Decode, TypeInfo, PartialEq)]
 pub enum DidMerkleProofError {
 	DidNotFound,
 	KeyNotFound,

--- a/runtimes/common/src/dip/merkle.rs
+++ b/runtimes/common/src/dip/merkle.rs
@@ -49,6 +49,15 @@ pub struct CompleteMerkleProof<Root, Proof> {
 	pub proof: Proof,
 }
 
+#[derive(Encode, Decode, TypeInfo)]
+pub enum DidMerkleProofError {
+	DidNotFound,
+	KeyNotFound,
+	LinkedAccountNotFound,
+	Web3NameNotFound,
+	InternalError,
+}
+
 pub struct DidMerkleRootGenerator<T>(PhantomData<T>);
 
 type ProofLeafOf<T> = RevealedDidMerkleProofLeaf<
@@ -74,20 +83,25 @@ where
 	// A valid proof will contain a leaf with the key details for each reference
 	// leaf, with multiple reference leaves potentially referring to the same
 	// details leaf, as we already do with out `DidDetails` type.
-	fn calculate_root_with_db(identity: &LinkedDidInfoOf<T>, db: &mut MemoryDB<T::Hashing>) -> Result<T::Hash, ()> {
+	fn calculate_root_with_db(
+		identity: &LinkedDidInfoOf<T>,
+		db: &mut MemoryDB<T::Hashing>,
+	) -> Result<T::Hash, DidMerkleProofError> {
 		// Fails if the DID details do not exist.
-		let (Some(did_details), web3_name, linked_accounts) = (&identity.a, &identity.b, &identity.c) else {
-			return Err(());
+		let (Some(did_details), web3_name, linked_accounts) = (&identity.a, &identity.b, &identity.c)  else {
+			return Err(DidMerkleProofError::DidNotFound);
 		};
 		let mut trie = TrieHash::<LayoutV1<T::Hashing>>::default();
 		let mut trie_builder = TrieDBMutBuilder::<LayoutV1<T::Hashing>>::new(db, &mut trie).build();
 
 		// Authentication key
-		// TODO: No panic
 		let auth_key_details = did_details
 			.public_keys
 			.get(&did_details.authentication_key)
-			.expect("Authentication key should be part of the public keys.");
+			.ok_or_else(|| {
+				log::error!("Authentication key should be part of the public keys.");
+				DidMerkleProofError::InternalError
+			})?;
 		let auth_leaf = ProofLeafOf::<T>::DidKey(
 			DidKeyMerkleKey(
 				did_details.authentication_key,
@@ -97,51 +111,75 @@ where
 		);
 		trie_builder
 			.insert(auth_leaf.encoded_key().as_slice(), auth_leaf.encoded_value().as_slice())
-			.map_err(|_| ())?;
+			.map_err(|_| {
+				log::error!(
+					"Failed to insert authentication key in the trie builder. Authentication leaf: {:#?}",
+					auth_leaf
+				);
+				DidMerkleProofError::InternalError
+			})?;
 		// Attestation key, if present
 		if let Some(att_key_id) = did_details.attestation_key {
-			let att_key_details = did_details
-				.public_keys
-				.get(&att_key_id)
-				.expect("Attestation key should be part of the public keys.");
+			let att_key_details = did_details.public_keys.get(&att_key_id).ok_or_else(|| {
+				log::error!("Attestation key should be part of the public keys.");
+				DidMerkleProofError::InternalError
+			})?;
 			let att_leaf = ProofLeafOf::<T>::DidKey(
 				(att_key_id, DidVerificationKeyRelationship::AssertionMethod.into()).into(),
 				att_key_details.clone().into(),
 			);
 			trie_builder
 				.insert(att_leaf.encoded_key().as_slice(), att_leaf.encoded_value().as_slice())
-				.map_err(|_| ())?;
+				.map_err(|_| {
+					log::error!(
+						"Failed to insert attestation key in the trie builder. Attestation leaf: {:#?}",
+						att_leaf
+					);
+					DidMerkleProofError::InternalError
+				})?;
 		};
 		// Delegation key, if present
 		if let Some(del_key_id) = did_details.delegation_key {
-			let del_key_details = did_details
-				.public_keys
-				.get(&del_key_id)
-				.expect("Delegation key should be part of the public keys.");
+			let del_key_details = did_details.public_keys.get(&del_key_id).ok_or_else(|| {
+				log::error!("Delegation key should be part of the public keys.");
+				DidMerkleProofError::InternalError
+			})?;
 			let del_leaf = ProofLeafOf::<T>::DidKey(
 				(del_key_id, DidVerificationKeyRelationship::CapabilityDelegation.into()).into(),
 				del_key_details.clone().into(),
 			);
 			trie_builder
 				.insert(del_leaf.encoded_key().as_slice(), del_leaf.encoded_value().as_slice())
-				.map_err(|_| ())?;
+				.map_err(|_| {
+					log::error!(
+						"Failed to insert delegation key in the trie builder. Delegation leaf: {:#?}",
+						del_leaf
+					);
+					DidMerkleProofError::InternalError
+				})?;
 		};
 		// Key agreement keys
 		did_details
 			.key_agreement_keys
 			.iter()
-			.try_for_each(|id| -> Result<(), ()> {
-				let key_agreement_details = did_details
-					.public_keys
-					.get(id)
-					.expect("Key agreement key should be part of the public keys.");
+			.try_for_each(|id| -> Result<(), DidMerkleProofError> {
+				let key_agreement_details = did_details.public_keys.get(id).ok_or_else(|| {
+					log::error!("Key agreement key should be part of the public keys.");
+					DidMerkleProofError::InternalError
+				})?;
 				let enc_leaf = ProofLeafOf::<T>::DidKey(
 					(*id, DidKeyRelationship::Encryption).into(),
 					key_agreement_details.clone().into(),
 				);
 				trie_builder
 					.insert(enc_leaf.encoded_key().as_slice(), enc_leaf.encoded_value().as_slice())
-					.map_err(|_| ())?;
+					.map_err(|_| {
+						log::error!(
+							"Failed to insert key agreement key in the trie builder. Key agreement leaf: {:#?}",
+							enc_leaf
+						);
+						DidMerkleProofError::InternalError
+					})?;
 				Ok(())
 			})?;
 
@@ -149,14 +187,20 @@ where
 		if let Some(linked_accounts) = linked_accounts {
 			linked_accounts
 				.iter()
-				.try_for_each(|linked_account| -> Result<(), ()> {
+				.try_for_each(|linked_account| -> Result<(), DidMerkleProofError> {
 					let linked_account_leaf = ProofLeafOf::<T>::LinkedAccount(linked_account.clone().into(), ().into());
 					trie_builder
 						.insert(
 							linked_account_leaf.encoded_key().as_slice(),
 							linked_account_leaf.encoded_value().as_slice(),
 						)
-						.map_err(|_| ())?;
+						.map_err(|_| {
+							log::error!(
+								"Failed to insert linked account in the trie builder. Linked account leaf: {:#?}",
+								linked_account_leaf
+							);
+							DidMerkleProofError::InternalError
+						})?;
 					Ok(())
 				})?;
 		}
@@ -172,14 +216,19 @@ where
 					web3_name_leaf.encoded_key().as_slice(),
 					web3_name_leaf.encoded_value().as_slice(),
 				)
-				.map_err(|_| ())?;
+				.map_err(|_| {
+					log::error!(
+						"Failed to insert web3name in the trie builder. Web3name leaf: {:#?}",
+						web3_name_leaf
+					);
+					DidMerkleProofError::InternalError
+				})?;
 		}
 
 		trie_builder.commit();
 		Ok(trie_builder.root().to_owned())
 	}
 
-	// TODO: Better error handling
 	// Only used for testing and as part of the features exposed by the runtime API
 	// of the provider. Given the provided `DidDetails` and a list of key IDs, it
 	// generates a merkle proof which only reveals the details of the provided key
@@ -190,22 +239,25 @@ where
 		key_ids: K,
 		should_include_web3_name: bool,
 		account_ids: A,
-	) -> Result<CompleteMerkleProof<T::Hash, DidMerkleProofOf<T>>, ()>
+	) -> Result<CompleteMerkleProof<T::Hash, DidMerkleProofOf<T>>, DidMerkleProofError>
 	where
 		K: Iterator<Item = &'a KeyIdOf<T>>,
 		A: Iterator<Item = &'a LinkableAccountId>,
 	{
 		// Fails if the DID details do not exist.
 		let (Some(did_details), linked_web3_name, linked_accounts) = (&identity.a, &identity.b, &identity.c) else {
-			return Err(());
+			return Err(DidMerkleProofError::DidNotFound);
 		};
 
 		let mut db = MemoryDB::default();
 		let root = Self::calculate_root_with_db(identity, &mut db)?;
 
 		let mut leaves = key_ids
-			.map(|key_id| -> Result<ProofLeafOf<T>, ()> {
-				let key_details = did_details.public_keys.get(key_id).ok_or(())?;
+			.map(|key_id| -> Result<_, DidMerkleProofError> {
+				let key_details = did_details
+					.public_keys
+					.get(key_id)
+					.ok_or(DidMerkleProofError::KeyNotFound)?;
 				// Create the merkle leaf key depending on the relationship of the key to the
 				// DID document.
 				let did_key_merkle_key: DidKeyMerkleKey<KeyIdOf<T>> = if *key_id == did_details.authentication_key {
@@ -217,16 +269,18 @@ where
 				} else if did_details.key_agreement_keys.contains(key_id) {
 					Ok((*key_id, DidKeyRelationship::Encryption).into())
 				} else {
-					Err(())
+					log::error!("Unknown key ID {:#?} retrieved from DID details.", key_id);
+					Err(DidMerkleProofError::InternalError)
 				}?;
 				Ok(RevealedDidMerkleProofLeaf::DidKey(
 					did_key_merkle_key,
 					key_details.clone().into(),
 				))
 			})
-			.chain(account_ids.map(|account_id| -> Result<ProofLeafOf<T>, ()> {
+			.chain(account_ids.map(|account_id| -> Result<_, DidMerkleProofError> {
 				let Some(linked_accounts) = linked_accounts else {
-					return Err(());
+					// Directly LinkedAccountNotFound since there's no linked accounts to check against.
+					return Err(DidMerkleProofError::LinkedAccountNotFound);
 				};
 				if linked_accounts.contains(account_id) {
 					Ok(RevealedDidMerkleProofLeaf::LinkedAccount(
@@ -234,7 +288,7 @@ where
 						().into(),
 					))
 				} else {
-					Err(())
+					Err(DidMerkleProofError::LinkedAccountNotFound)
 				}
 			}))
 			.collect::<Result<Vec<_>, _>>()?;
@@ -249,13 +303,19 @@ where
 				Ok(())
 			}
 			// ...else if web3name should be included and it DOES NOT exist...
-			(true, None) => Err(()),
-			// ...else if web3name should NOT be included.
+			(true, None) => Err(DidMerkleProofError::Web3NameNotFound),
+			// ...else (if web3name should NOT be included).
 			(false, _) => Ok(()),
 		}?;
 
 		let encoded_keys: Vec<Vec<u8>> = leaves.iter().map(|l| l.encoded_key()).collect();
-		let proof = generate_trie_proof::<LayoutV1<T::Hashing>, _, _, _>(&db, root, &encoded_keys).map_err(|_| ())?;
+		let proof = generate_trie_proof::<LayoutV1<T::Hashing>, _, _, _>(&db, root, &encoded_keys).map_err(|_| {
+			log::error!(
+				"Failed to generate a merkle proof for the encoded keys: {:#?}",
+				encoded_keys
+			);
+			DidMerkleProofError::InternalError
+		})?;
 		Ok(CompleteMerkleProof {
 			root,
 			proof: DidMerkleProofOf::<T> {
@@ -270,8 +330,7 @@ impl<T> IdentityCommitmentGenerator<DidIdentifier, LinkedDidInfoOf<T>> for DidMe
 where
 	T: did::Config + pallet_did_lookup::Config + pallet_web3_names::Config,
 {
-	// TODO: Proper error handling
-	type Error = ();
+	type Error = DidMerkleProofError;
 	type Output = T::Hash;
 
 	fn generate_commitment(_identifier: &DidIdentifier, identity: &LinkedDidInfoOf<T>) -> Result<T::Hash, Self::Error> {

--- a/runtimes/common/src/dip/merkle.rs
+++ b/runtimes/common/src/dip/merkle.rs
@@ -88,7 +88,7 @@ where
 		db: &mut MemoryDB<T::Hashing>,
 	) -> Result<T::Hash, DidMerkleProofError> {
 		// Fails if the DID details do not exist.
-		let (Some(did_details), web3_name, linked_accounts) = (&identity.a, &identity.b, &identity.c)  else {
+		let (Some(did_details), web3_name, linked_accounts) = (&identity.a, &identity.b, &identity.c) else {
 			return Err(DidMerkleProofError::DidNotFound);
 		};
 		let mut trie = TrieHash::<LayoutV1<T::Hashing>>::default();
@@ -279,7 +279,8 @@ where
 			})
 			.chain(account_ids.map(|account_id| -> Result<_, DidMerkleProofError> {
 				let Some(linked_accounts) = linked_accounts else {
-					// Directly LinkedAccountNotFound since there's no linked accounts to check against.
+					// Directly LinkedAccountNotFound since there's no linked accounts to check
+					// against.
 					return Err(DidMerkleProofError::LinkedAccountNotFound);
 				};
 				if linked_accounts.contains(account_id) {


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2552, by both removing all occurrences of `.expect()` and `.unwrap()` and replacing them with `Internal` errors, and by introducing error enums. The logic is that for both the provider and the consumer, a generic error is bubbled up from the runtime, and because of the constraints imposed by Substrate, the error reason is encoded as a `u16`, where each "class" of error is namespaced with a 255 value increment. A snippet of this is shown below:

```rust
fn from(
    value: DipSiblingProviderStateProofVerifierError<
        ParachainHeadMerkleProofVerificationError,
        IdentityCommitmentMerkleProofVerificationError,
        DipProofVerificationError,
        DidSignatureVerificationError
    >,
) -> Self {
    match value {
        DipSiblingProviderStateProofVerifierError::ParachainHeadMerkleProofVerificationError(error) => {
            error.into()
        }
        DipSiblingProviderStateProofVerifierError::IdentityCommitmentMerkleProofVerificationError(error) => {
            u8::MAX as u16 + error.into() as u16
        }
        DipSiblingProviderStateProofVerifierError::DipProofVerificationError(error) => {
            u8::MAX as u16 * 2 + error.into() as u16
        }
        DipSiblingProviderStateProofVerifierError::DidSignatureVerificationError(error) => {
            u8::MAX as u16 * 3 + error.into() as u16
        }
    }
}
```

The specific reason for the error can then be retrieved and decoded directly from the Polkadot Apps interface, as the example below shows, where the first byte `01` indicates the enum variant index, the second byte is the varint encoding of the SCALE-encoded u16, and the third and forth bytes `e000` represent the `u16` error reason. This can be decoded as decimal, where each value has a one-to-one link to a specific error from the runtime.

<img width="554" src="https://github.com/KILTprotocol/kilt-node/assets/6704504/f0985e17-7f3e-49f5-818c-6a7bc1ae1530">

The pallet consumer expects any other implementation of the DIP consumer protocol to expose the proof verification error reason as a `u16`, but of course developers are free to not give any meaning to it and treat everything as a generic `InvalidProof` error.