### PR TITLE
fix: include missing runtime migrations.

### DIFF
--- a/pallets/pallet-migration/src/lib.rs
+++ b/pallets/pallet-migration/src/lib.rs
@@ -103,7 +103,7 @@ pub mod pallet {
 		KeyParse,
 	}
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1110,6 +1110,7 @@ pub type Executive = frame_executive::Executive<
 	(
 		runtime_common::migrations::BumpStorageVersion<Runtime>,
 		parachain_staking::migrations::BalanceMigration<Runtime>,
+		pallet_xcm::migration::v1::MigrateToV1<Runtime>,
 	),
 >;
 

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -1095,6 +1095,7 @@ pub type Executive = frame_executive::Executive<
 	(
 		runtime_common::migrations::BumpStorageVersion<Runtime>,
 		parachain_staking::migrations::BalanceMigration<Runtime>,
+		pallet_xcm::migration::v1::MigrateToV1<Runtime>,
 	),
 >;
 


### PR DESCRIPTION
## Runtime Migrations

There are two pallets with missing runtime migrations. The command try-runtime on-runtime-upgrade revealed them. This PR aims to fix the issue and set the correct storage version for the pallet.
 

 