### PR TITLE
fix: origin checks for provider and consumer pallets

### DIFF
--- a/pallets/pallet-dip-provider/src/lib.rs
+++ b/pallets/pallet-dip-provider/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
 pub mod pallet {
 	use super::*;
 
-	use frame_support::{pallet_prelude::*, traits::EnsureOrigin};
+	use frame_support::{pallet_prelude::*, traits::EnsureOriginWithArg};
 	use frame_system::pallet_prelude::*;
 
 	use crate::traits::{IdentityCommitmentGenerator, IdentityProvider, ProviderHooks, SubmitterInfo};
@@ -47,7 +47,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		type CommitOriginCheck: EnsureOrigin<Self::RuntimeOrigin, Success = Self::CommitOrigin>;
+		type CommitOriginCheck: EnsureOriginWithArg<Self::RuntimeOrigin, Self::Identifier, Success = Self::CommitOrigin>;
 		type CommitOrigin: SubmitterInfo<Submitter = Self::AccountId>;
 		type Identifier: Parameter + MaxEncodedLen;
 		type IdentityCommitmentGenerator: IdentityCommitmentGenerator<Self>;
@@ -103,8 +103,8 @@ pub mod pallet {
 			identifier: T::Identifier,
 			version: Option<IdentityCommitmentVersion>,
 		) -> DispatchResult {
-			let dispatcher =
-				T::CommitOriginCheck::ensure_origin(origin).map(|e: <T as Config>::CommitOrigin| e.submitter())?;
+			let dispatcher = T::CommitOriginCheck::ensure_origin(origin, &identifier)
+				.map(|e: <T as Config>::CommitOrigin| e.submitter())?;
 
 			let commitment_version = version.unwrap_or(LATEST_COMMITMENT_VERSION);
 			let identity = T::IdentityProvider::retrieve(&identifier)
@@ -148,8 +148,8 @@ pub mod pallet {
 			identifier: T::Identifier,
 			version: Option<IdentityCommitmentVersion>,
 		) -> DispatchResult {
-			let dispatcher =
-				T::CommitOriginCheck::ensure_origin(origin).map(|e: <T as Config>::CommitOrigin| e.submitter())?;
+			let dispatcher = T::CommitOriginCheck::ensure_origin(origin, &identifier)
+				.map(|e: <T as Config>::CommitOrigin| e.submitter())?;
 
 			let commitment_version = version.unwrap_or(LATEST_COMMITMENT_VERSION);
 			let commitment = Self::delete_identity_commitment_storage_entry(&identifier, commitment_version)?;


### PR DESCRIPTION
Ensuring the origin is a DID origin for the implementor of the provider pallet might not be enough. They need to check that the origin indeed matches the identifier being acted upon. Replacing `EnsureOrigin` with `EnsureOriginWithArg` gives access to that information.

Tests will ALL be implemented in a different PR 😄