### PR TITLE
chore: fix docs and add check step in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,11 +2,12 @@ stages:
   - test
   - build
 
-clippy:
+clippy-and-docs:
   image: paritytech/ci-unified:bullseye-1.70.0
   stage: test
   script:
     - cargo clippy --all-features --all-targets --locked -- -D warnings
+    - cargo doc --all-features --no-deps --locked
 
 fmt:
   image: paritytech/ci-unified:bullseye-1.70.0

--- a/nodes/parachain/src/chain_spec.rs
+++ b/nodes/parachain/src/chain_spec.rs
@@ -43,7 +43,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 		.public()
 }
 
-/// The extensions for the [`ChainSpec`].
+/// The extensions for the `ChainSpec`.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
 #[serde(deny_unknown_fields)]
 pub struct Extensions {

--- a/pallets/delegation/src/access_control.rs
+++ b/pallets/delegation/src/access_control.rs
@@ -42,7 +42,7 @@ use crate::{
 ///    * sender delegation node is equal to OR parent of the delegation node
 ///      stored in the attestation
 ///
-/// Can remove attestations if <the same as revoke>
+/// Can remove attestations if (the same as revoke)
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct DelegationAc<T: Config> {
 	pub(crate) subject_node_id: DelegationNodeIdOf<T>,

--- a/pallets/did/src/errors.rs
+++ b/pallets/did/src/errors.rs
@@ -24,15 +24,15 @@ use crate::did_details::DidVerificationKeyRelationship;
 /// All the errors that can be generated when validating a DID operation.
 #[derive(Debug, Eq, PartialEq, TypeInfo)]
 pub enum DidError {
-	/// See [Storage].
+	/// See [`StorageError`].
 	Storage(StorageError),
-	/// See [Signature].
+	/// See [`SignatureError`].
 	Signature(SignatureError),
-	/// See [Input].
+	/// See [`InputError`].
 	Input(InputError),
 	/// An error that is not supposed to take place, yet it happened.
 	Internal,
-	/// An error that is related to updating the deposit
+	/// An error that is related to updating the deposit.
 	Deposit(DispatchError),
 }
 

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -74,8 +74,8 @@
 //!   creation or update operation is bounded by `MaxNewKeyAgreementKeys`.
 //! - After it is generated and signed by a client, a DID-authorised operation
 //!   can be submitted for evaluation anytime between the time the operation is
-//!   created and [MaxBlocksTxValidity] blocks after that. After this time has
-//!   elapsed, the operation is considered invalid.
+//!   created and [`Config::MaxBlocksTxValidity`] blocks after that. After this
+//!   time has elapsed, the operation is considered invalid.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
@@ -1241,7 +1241,7 @@ pub mod pallet {
 		///   error.
 		/// * When the DID already exists, this function returns a
 		///   `AlreadyExists` error.
-		/// * When the [sender] doesn't have enough free balance, this function
+		/// * When the `sender` doesn't have enough free balance, this function
 		///   returns a `UnableToPayFees` error.
 		pub fn try_insert_did(
 			did_identifier: DidIdentifierOf<T>,
@@ -1375,8 +1375,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Verify that [account] is authorized to dispatch DID calls on behave
-		/// of [did_identifier].
+		/// Verify that `account` is authorized to dispatch DID calls on behave
+		/// of `did_identifier`.
 		///
 		/// # Errors
 		///

--- a/pallets/pallet-inflation/src/lib.rs
+++ b/pallets/pallet-inflation/src/lib.rs
@@ -24,8 +24,8 @@
 //!
 //! ## Assumptions
 //!
-//! - The minting of rewards after [InitialPeriodLength] many blocks is handled
-//!   by another pallet, e.g., ParachainStaking.
+//! - The minting of rewards after [`Config::InitialPeriodLength`] many blocks
+//!   is handled by another pallet, e.g., ParachainStaking.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -143,7 +143,6 @@ pub mod pallet {
 	pub use crate::inflation::{InflationInfo, RewardRate, StakingInfo};
 
 	use core::cmp::Ordering;
-	use frame_support::traits::BuildGenesisConfig;
 	use frame_support::{
 		pallet_prelude::*,
 		storage::bounded_btree_map::BoundedBTreeMap,
@@ -153,7 +152,7 @@ pub mod pallet {
 				fungible::{Inspect, MutateFreeze, Unbalanced},
 				Fortitude, Precision, Preservation,
 			},
-			EstimateNextSessionRotation, Get, OnUnbalanced, StorageVersion,
+			BuildGenesisConfig, EstimateNextSessionRotation, Get, OnUnbalanced, StorageVersion,
 		},
 		BoundedVec,
 	};
@@ -584,7 +583,7 @@ pub mod pallet {
 	/// The sum of all collator and their delegator stakes.
 	///
 	/// Note: There are more funds locked by this pallet, since the backing for
-	/// non collating candidates is not included in [TotalCollatorStake].
+	/// non collating candidates is not included in `TotalCollatorStake`.
 	#[pallet::storage]
 	#[pallet::getter(fn total_collator_stake)]
 	pub(crate) type TotalCollatorStake<T: Config> = StorageValue<_, TotalStake<BalanceOf<T>>, ValueQuery>;
@@ -594,9 +593,9 @@ pub mod pallet {
 	/// Each time the stake of a collator is increased, it is checked whether
 	/// this pushes another candidate out of the list. When the stake is
 	/// reduced however, it is not checked if another candidate has more stake,
-	/// since this would require iterating over the entire [CandidatePool].
+	/// since this would require iterating over the entire `CandidatePool`.
 	///
-	/// There must always be more candidates than [MaxSelectedCandidates] so
+	/// There must always be more candidates than `MaxSelectedCandidates` so
 	/// that a collator can drop out of the collator set by reducing their
 	/// stake.
 	#[pallet::storage]
@@ -1628,13 +1627,6 @@ pub mod pallet {
 		/// Unlock all previously staked funds that are now available for
 		/// unlocking by the origin account after `StakeDuration` blocks have
 		/// elapsed.
-		///
-		/// Weight: O(U) where U is the number of locked unstaking requests
-		/// bounded by `MaxUnstakeRequests`.
-		/// - Reads: [Origin Account], Unstaking, Freezes
-		/// - Writes: Unstaking, Freezes
-		/// - Kills: Unstaking & Freezes if no balance is locked anymore
-		/// # </weight>
 		#[pallet::call_index(16)]
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::unlock_unstaked(
 			T::MaxUnstakeRequests::get().saturated_into::<u32>()
@@ -2513,8 +2505,8 @@ pub mod pallet {
 		/// 2. In hook new_session: Read the current top n candidates from the
 		///    TopCandidates and assign this set to author blocks for the next
 		///    session.
-		/// 3. AuRa queries the authorities from the session pallet for
-		///    this session and picks authors on round-robin-basis from list of
+		/// 3. AuRa queries the authorities from the session pallet for this
+		///    session and picks authors on round-robin-basis from list of
 		///    authorities.
 		fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 			log::debug!(

--- a/pallets/public-credentials/src/lib.rs
+++ b/pallets/public-credentials/src/lib.rs
@@ -88,8 +88,8 @@ pub mod pallet {
 	pub(crate) type CurrencyOf<T> = <T as Config>::Currency;
 
 	/// The type of the credential subject input. It is bound in max length.
-	/// It is transformed inside the `add` operation into a [<T as
-	/// Config>::SubjectId].
+	/// It is transformed inside the `add` operation into a
+	/// [`Config::SubjectId`].
 	pub type InputSubjectIdOf<T> = BoundedVec<u8, <T as Config>::MaxSubjectIdLength>;
 	/// The type of the credential subject input. It is bound in max length.
 	pub type InputClaimsContentOf<T> = BoundedVec<u8, <T as Config>::MaxEncodedClaimsLength>;

--- a/runtimes/common/src/assets.rs
+++ b/runtimes/common/src/assets.rs
@@ -32,7 +32,7 @@ use crate::{authorization::AuthorizationId, AccountId, Balance, BlockNumber, Has
 pub use benchmarks::*;
 
 /// Thin wrapper around the `AssetDid` type, that implements the required
-/// TryFrom<Vec<u8>> trait.
+/// `TryFrom<Vec<u8>>` trait.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
 pub struct AssetDid(AssetIdentifier);
 

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -165,7 +165,7 @@ parameter_types! {
 pub type FeeSplit<R, B1, B2> = SplitFeesByRatio<R, FeeSplitRatio, B1, B2>;
 
 /// Parameterized slow adjusting fee updated based on
-/// https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html#-2.-slow-adjusting-mechanism
+/// <https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html#-2.-slow-adjusting-mechanism>
 pub type SlowAdjustingFeeUpdate<R> =
 	TargetedFeeAdjustment<R, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier, MaximumMultiplier>;
 

--- a/runtimes/common/src/migrations.rs
+++ b/runtimes/common/src/migrations.rs
@@ -26,7 +26,7 @@ use sp_core::Get;
 use sp_std::marker::PhantomData;
 
 /// There are some pallets without a storage version.
-/// Based on the changes in the PR (https://github.com/paritytech/substrate/pull/13417),
+/// Based on the changes in the PR <https://github.com/paritytech/substrate/pull/13417>,
 /// pallets without a storage version or with a wrong version throw an error
 /// in the try state tests.
 pub struct BumpStorageVersion<T>(PhantomData<T>);

--- a/runtimes/common/src/xcm_config.rs
+++ b/runtimes/common/src/xcm_config.rs
@@ -61,8 +61,8 @@ where
 	}
 }
 
-/// Reserved funds to the relay chain can't return. See https://github.com/paritytech/polkadot/issues/5233
-/// Usage of the new xcm matcher. See https://github.com/paritytech/polkadot/pull/7098
+/// Reserved funds to the relay chain can't return. See <https://github.com/paritytech/polkadot/issues/5233>
+/// Usage of the new xcm matcher. See <https://github.com/paritytech/polkadot/pull/7098>
 pub struct DenyReserveTransferToRelayChain;
 impl ShouldExecute for DenyReserveTransferToRelayChain {
 	fn should_execute<RuntimeCall>(


### PR DESCRIPTION
Running `cargo doc` produces a bunch of warnings. Although we don't do much with them yet, it is nice that we make sure they are correct. Our test step already includes any snippets (we don't have any), but we don't check that the docs themselves are correct.