### PR TITLE
fix: check events

### DIFF
--- a/pallets/attestation/src/authorized_by.rs
+++ b/pallets/attestation/src/authorized_by.rs
@@ -1,0 +1,34 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2023 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+/// Describes who authorized the associated action.
+///
+/// This can either be the attester that issued this attestation, another
+/// attester who is authorized by the `authorization_id` or the deposit owner.
+#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+pub enum AuthorizedBy<Account, Attester> {
+	/// Authorized by the deposit owner.
+	DepositOwner(Account),
+	/// Authorized by who issued the attestation.
+	Attester(Attester),
+	/// Authorized by the authorization_id.
+	Authorization(Attester),
+}

--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -18,8 +18,7 @@
 
 use frame_benchmarking::{account, benchmarks};
 use frame_support::traits::{fungible::Mutate, Get};
-use frame_system::pallet_prelude::BlockNumberFor;
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::traits::Hash;
 
 use ctype::CtypeEntryOf;

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -219,6 +219,8 @@ pub mod pallet {
 			authorized_by: AuthorizedByOf<T>,
 			/// The attester who initially created the attestation.
 			attester: AttesterOf<T>,
+			/// The ctype of the attested credential.
+			ctype_hash: CtypeHashOf<T>,
 			/// The claim hash of the credential that is revoked.
 			claim_hash: ClaimHashOf<T>,
 		},
@@ -228,6 +230,8 @@ pub mod pallet {
 			authorized_by: AuthorizedByOf<T>,
 			/// The attester who initially created the attestation.
 			attester: AttesterOf<T>,
+			/// The ctype of the attested credential.
+			ctype_hash: CtypeHashOf<T>,
 			/// The claim hash of the credential for which the attestation entry
 			/// was deleted.
 			claim_hash: ClaimHashOf<T>,
@@ -384,6 +388,7 @@ pub mod pallet {
 			Self::deposit_event(Event::AttestationRevoked {
 				attester,
 				authorized_by,
+				ctype_hash: attestation.ctype_hash,
 				claim_hash,
 			});
 
@@ -521,12 +526,14 @@ pub mod pallet {
 					attester: attestation.attester.clone(),
 					authorized_by: authorized_by.clone(),
 					claim_hash,
+					ctype_hash: attestation.ctype_hash,
 				});
 			}
 			Self::deposit_event(Event::AttestationRemoved {
 				attester: attestation.attester,
 				authorized_by,
 				claim_hash,
+				ctype_hash: attestation.ctype_hash,
 			});
 			Ok(())
 		}

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -210,10 +210,7 @@ pub mod pallet {
 		AttestationRevoked(AttesterOf<T>, ClaimHashOf<T>),
 		/// An attestation has been removed.
 		/// \[account id, claim hash\]
-		AttestationRemoved(AttesterOf<T>, ClaimHashOf<T>),
-		/// The deposit owner reclaimed a deposit by removing an attestation.
-		/// \[account id, claim hash\]
-		DepositReclaimed(AccountIdOf<T>, ClaimHashOf<T>),
+		AttestationRemoved(ClaimHashOf<T>),
 	}
 
 	#[pallet::error]
@@ -420,14 +417,13 @@ pub mod pallet {
 			log::debug!("removing Attestation");
 
 			Self::remove_attestation(attestation, claim_hash)?;
-			Self::deposit_event(Event::AttestationRemoved(who, claim_hash));
 
 			Ok(Some(<T as pallet::Config>::WeightInfo::remove()).into())
 		}
 
 		/// Reclaim a storage deposit by removing an attestation
 		///
-		/// Emits `DepositReclaimed`.
+		/// Emits `AttestationRemoved`.
 		///
 		/// # <weight>
 		/// Weight: O(1)
@@ -445,7 +441,6 @@ pub mod pallet {
 			log::debug!("removing Attestation");
 
 			Self::remove_attestation(attestation, claim_hash)?;
-			Self::deposit_event(Event::DepositReclaimed(who, claim_hash));
 
 			Ok(())
 		}
@@ -509,6 +504,7 @@ pub mod pallet {
 			if let Some(authorization_id) = &attestation.authorization_id {
 				ExternalAttestations::<T>::remove(authorization_id, claim_hash);
 			}
+			Self::deposit_event(Event::AttestationRemoved(claim_hash));
 			Ok(())
 		}
 	}

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -192,7 +192,7 @@ pub(crate) mod runtime {
 	use ctype::{CtypeCreatorOf, CtypeEntryOf};
 	use kilt_support::mock::{mock_origin, SubjectId};
 
-	use crate::{self as attestation};
+	use crate::{self as attestation, Event};
 
 	type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -204,6 +204,20 @@ pub(crate) mod runtime {
 	pub const UNIT: Balance = 10u128.pow(15);
 	pub const MILLI_UNIT: Balance = 10u128.pow(12);
 	pub const ATTESTATION_DEPOSIT: Balance = 10 * MILLI_UNIT;
+
+	pub(crate) fn events() -> Vec<Event<Test>> {
+		System::events()
+			.into_iter()
+			.map(|r| r.event)
+			.filter_map(|e| {
+				if let RuntimeEvent::Attestation(e) = e {
+					Some(e)
+				} else {
+					None
+				}
+			})
+			.collect::<Vec<_>>()
+	}
 
 	frame_support::construct_runtime!(
 		pub enum Test
@@ -230,7 +244,7 @@ pub(crate) mod runtime {
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Block = Block;
 		type Nonce = u64;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type BlockHashCount = BlockHashCount;
 		type DbWeight = RocksDbWeight;
 		type Version = ();
@@ -263,7 +277,7 @@ pub(crate) mod runtime {
 		type MaxHolds = MaxHolds;
 		type Balance = Balance;
 		type DustRemoval = ();
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
 		type WeightInfo = ();
@@ -281,7 +295,7 @@ pub(crate) mod runtime {
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OverarchingOrigin = EnsureSigned<AccountId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type WeightInfo = ();
 
 		type Currency = Balances;
@@ -303,7 +317,7 @@ pub(crate) mod runtime {
 	impl Config for Test {
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, AttesterOf<Self>>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, AttesterOf<Self>>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type WeightInfo = ();
 		type RuntimeHoldReason = RuntimeHoldReason;
 		type Currency = Balances;
@@ -370,6 +384,9 @@ pub(crate) mod runtime {
 			let mut ext = sp_io::TestExternalities::new(storage);
 
 			ext.execute_with(|| {
+				// ensure that we are not at the genesis block. Events are not registered for the genesis block.
+				System::set_block_number(System::block_number() + 1);
+
 				for ctype in self.ctypes {
 					ctype::Ctypes::<Test>::insert(
 						ctype.0,

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -384,7 +384,8 @@ pub(crate) mod runtime {
 			let mut ext = sp_io::TestExternalities::new(storage);
 
 			ext.execute_with(|| {
-				// ensure that we are not at the genesis block. Events are not registered for the genesis block.
+				// ensure that we are not at the genesis block. Events are not registered for
+				// the genesis block.
 				System::set_block_number(System::block_number() + 1);
 
 				for ctype in self.ctypes {

--- a/pallets/attestation/src/tests/claim.rs
+++ b/pallets/attestation/src/tests/claim.rs
@@ -21,35 +21,44 @@ use frame_support::{assert_noop, assert_ok};
 use kilt_support::mock::mock_origin::DoubleOrigin;
 use sp_runtime::DispatchError;
 
-use crate::{self as attestation, mock::*, AttestationAccessControl, AttesterOf, Config};
+use crate::{self as attestation, mock::*, AttestationAccessControl, AttesterOf, Config, Event};
 
 #[test]
 fn test_attest_without_authorization() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
-	let ctype_hash = get_ctype_hash::<Test>(true);
+	let ctype = get_ctype_hash::<Test>(true);
 	let authorization_info = None;
 
 	ExtBuilder::default()
-		.with_ctypes(vec![(ctype_hash, attester.clone())])
+		.with_ctypes(vec![(ctype, attester.clone())])
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.build_and_execute_with_sanity_tests(|| {
 			assert_ok!(Attestation::add(
 				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
 				claim_hash,
-				ctype_hash,
+				ctype,
 				authorization_info.clone()
 			));
 			let stored_attestation =
 				Attestation::attestations(claim_hash).expect("Attestation should be present on chain.");
 
-			assert_eq!(stored_attestation.ctype_hash, ctype_hash);
+			assert_eq!(stored_attestation.ctype_hash, ctype);
 			assert_eq!(stored_attestation.attester, attester);
 			assert_eq!(
 				stored_attestation.authorization_id,
 				authorization_info.map(|ac| ac.authorization_id())
 			);
 			assert!(!stored_attestation.revoked);
+			assert_eq!(
+				events(),
+				vec![Event::AttestationCreated {
+					attester: attester.clone(),
+					claim_hash,
+					ctype_hash: ctype,
+					authorization: None
+				}]
+			);
 		});
 }
 
@@ -81,6 +90,15 @@ fn test_attest_authorized() {
 				authorization_info.map(|ac| ac.authorization_id())
 			);
 			assert!(!stored_attestation.revoked);
+			assert_eq!(
+				events(),
+				vec![Event::AttestationCreated {
+					attester: attester.clone(),
+					claim_hash,
+					ctype_hash: ctype,
+					authorization: Some(attester)
+				}]
+			);
 		});
 }
 
@@ -96,14 +114,14 @@ fn test_attest_unauthorized() {
 		.with_ctypes(vec![(ctype, attester.clone())])
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.build_and_execute_with_sanity_tests(|| {
-			assert_eq!(
+			assert_noop!(
 				Attestation::add(
 					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
 					claim_hash,
 					ctype,
 					authorization_info
 				),
-				Err(DispatchError::Other("Unauthorized"))
+				DispatchError::Other("Unauthorized")
 			);
 		});
 }

--- a/pallets/attestation/src/tests/delete.rs
+++ b/pallets/attestation/src/tests/delete.rs
@@ -20,14 +20,13 @@ use frame_support::{assert_noop, assert_ok, traits::fungible::InspectHold};
 use kilt_support::mock::mock_origin::DoubleOrigin;
 use sp_runtime::traits::Zero;
 
-use crate::{self as attestation, mock::*, AttesterOf, Config, HoldReason};
+use crate::{self as attestation, mock::*, AttesterOf, Config, Event, HoldReason};
 
 #[test]
 fn test_remove() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	let authorization_info = None;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -37,9 +36,55 @@ fn test_remove() {
 			assert_ok!(Attestation::remove(
 				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
 				claim_hash,
-				authorization_info
+				None
 			));
 			assert!(Attestation::attestations(claim_hash).is_none());
+			assert_eq!(
+				events(),
+				vec![
+					Event::AttestationRevoked {
+						attester: attester.clone(),
+						claim_hash,
+						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+					},
+					Event::AttestationRemoved {
+						attester: attester.clone(),
+						claim_hash,
+						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+					}
+				]
+			);
+		});
+}
+
+#[test]
+fn test_remove_revoked() {
+	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
+	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
+	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
+	attestation.revoked = true;
+
+	ExtBuilder::default()
+		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
+		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
+		.with_attestations(vec![(claim_hash, attestation)])
+		.build_and_execute_with_sanity_tests(|| {
+			assert_ok!(Attestation::remove(
+				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
+				claim_hash,
+				None
+			));
+			assert!(Attestation::attestations(claim_hash).is_none());
+			assert_eq!(
+				events(),
+				vec![
+					Event::AttestationRemoved {
+						attester: attester.clone(),
+						claim_hash,
+						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+					}
+				]
+			);
 		});
 }
 
@@ -48,7 +93,7 @@ fn test_remove_authorized() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
 	let revoker: AttesterOf<Test> = sr25519_did_from_public_key(&BOB_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
-	let mut attestation = generate_base_attestation::<Test>(attester, ACCOUNT_00);
+	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.authorization_id = Some(revoker.clone());
 	let authorization_info = Some(MockAccessControl(revoker.clone()));
 
@@ -64,6 +109,21 @@ fn test_remove_authorized() {
 			));
 			assert!(Attestation::attestations(claim_hash).is_none());
 			assert!(!Attestation::external_attestations(revoker.clone(), claim_hash));
+			assert_eq!(
+				events(),
+				vec![
+					Event::AttestationRevoked {
+						attester: attester.clone(),
+						claim_hash,
+						authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
+					},
+					Event::AttestationRemoved {
+						attester: attester.clone(),
+						claim_hash,
+						authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
+					}
+				]
+			);
 		});
 }
 

--- a/pallets/attestation/src/tests/delete.rs
+++ b/pallets/attestation/src/tests/delete.rs
@@ -27,6 +27,7 @@ fn test_remove() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -45,12 +46,14 @@ fn test_remove() {
 					Event::AttestationRevoked {
 						attester: attester.clone(),
 						claim_hash,
-						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone()),
+						ctype_hash,
 					},
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
-						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone()),
+						ctype_hash,
 					}
 				]
 			);
@@ -63,6 +66,7 @@ fn test_remove_revoked() {
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.revoked = true;
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -81,6 +85,7 @@ fn test_remove_revoked() {
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
 					}
 				]
@@ -96,6 +101,7 @@ fn test_remove_authorized() {
 	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.authorization_id = Some(revoker.clone());
 	let authorization_info = Some(MockAccessControl(revoker.clone()));
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -115,11 +121,13 @@ fn test_remove_authorized() {
 					Event::AttestationRevoked {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
 					},
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
 					}
 				]

--- a/pallets/attestation/src/tests/delete.rs
+++ b/pallets/attestation/src/tests/delete.rs
@@ -81,14 +81,12 @@ fn test_remove_revoked() {
 			assert!(Attestation::attestations(claim_hash).is_none());
 			assert_eq!(
 				events(),
-				vec![
-					Event::AttestationRemoved {
-						attester: attester.clone(),
-						claim_hash,
-						ctype_hash,
-						authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
-					}
-				]
+				vec![Event::AttestationRemoved {
+					attester: attester.clone(),
+					claim_hash,
+					ctype_hash,
+					authorized_by: attestation::authorized_by::AuthorizedBy::Attester(attester.clone())
+				}]
 			);
 		});
 }

--- a/pallets/attestation/src/tests/deposit.rs
+++ b/pallets/attestation/src/tests/deposit.rs
@@ -20,7 +20,7 @@ use frame_support::{assert_noop, assert_ok, traits::fungible::InspectHold};
 use kilt_support::{mock::mock_origin::DoubleOrigin, Deposit};
 use sp_runtime::{traits::Zero, TokenError};
 
-use crate::{self as attestation, mock::*, AttesterOf, Config, Error, HoldReason, Event};
+use crate::{self as attestation, mock::*, AttesterOf, Config, Error, Event, HoldReason};
 
 #[test]
 fn test_reclaim_deposit_not_found() {
@@ -300,7 +300,6 @@ fn test_reclaim_deposit() {
 		});
 }
 
-
 #[test]
 fn test_reclaim_deposit_revoked() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&BOB_SEED);
@@ -327,14 +326,12 @@ fn test_reclaim_deposit_revoked() {
 
 			assert_eq!(
 				events(),
-				vec![
-					Event::AttestationRemoved {
-						attester: attester.clone(),
-						claim_hash,
-						ctype_hash,
-						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
-					}
-				]
+				vec![Event::AttestationRemoved {
+					attester: attester.clone(),
+					claim_hash,
+					ctype_hash,
+					authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
+				}]
 			);
 		});
 }

--- a/pallets/attestation/src/tests/deposit.rs
+++ b/pallets/attestation/src/tests/deposit.rs
@@ -216,6 +216,7 @@ fn test_reclaim_deposit_authorization() {
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.authorization_id = Some(other_authorized.clone());
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -242,11 +243,13 @@ fn test_reclaim_deposit_authorization() {
 					Event::AttestationRevoked {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
 					},
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
 					}
 				]
@@ -259,6 +262,7 @@ fn test_reclaim_deposit() {
 	let attester: AttesterOf<Test> = sr25519_did_from_public_key(&BOB_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -282,11 +286,13 @@ fn test_reclaim_deposit() {
 					Event::AttestationRevoked {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
 					},
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
 					}
 				]
@@ -301,6 +307,7 @@ fn test_reclaim_deposit_revoked() {
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.revoked = true;
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -324,6 +331,7 @@ fn test_reclaim_deposit_revoked() {
 					Event::AttestationRemoved {
 						attester: attester.clone(),
 						claim_hash,
+						ctype_hash,
 						authorized_by: attestation::authorized_by::AuthorizedBy::DepositOwner(ACCOUNT_00)
 					}
 				]

--- a/pallets/attestation/src/tests/revoke.rs
+++ b/pallets/attestation/src/tests/revoke.rs
@@ -20,7 +20,7 @@ use frame_support::{assert_noop, assert_ok, traits::fungible::InspectHold};
 use kilt_support::mock::mock_origin::DoubleOrigin;
 use sp_runtime::{traits::Zero, DispatchError};
 
-use crate::{self as attestation, mock::*, AttesterOf, Config, HoldReason};
+use crate::{self as attestation, mock::*, AttesterOf, Config, Event, HoldReason};
 
 #[test]
 fn test_revoke_remove() {
@@ -46,6 +46,16 @@ fn test_revoke_remove() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_00),
 				<Test as Config>::Deposit::get()
 			);
+			assert_eq!(
+				events(),
+				vec![Event::AttestationRevoked {
+					attester: revoker.clone(),
+					claim_hash,
+					authorized_by: attestation::authorized_by::AuthorizedBy::Attester(revoker.clone())
+				}]
+			);
+
+			System::reset_events();
 
 			assert_ok!(Attestation::remove(
 				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
@@ -54,6 +64,14 @@ fn test_revoke_remove() {
 			));
 			assert!(Attestation::attestations(claim_hash).is_none());
 			assert!(Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_00).is_zero());
+			assert_eq!(
+				events(),
+				vec![Event::AttestationRemoved {
+					attester: revoker.clone(),
+					claim_hash,
+					authorized_by: attestation::authorized_by::AuthorizedBy::Attester(revoker.clone())
+				}]
+			);
 		});
 }
 
@@ -68,7 +86,7 @@ fn test_authorized_revoke() {
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(attestation.ctype_hash, attester)])
+		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
 		.with_attestations(vec![(claim_hash, attestation)])
 		.build_and_execute_with_sanity_tests(|| {
 			assert_ok!(Attestation::revoke(
@@ -84,6 +102,14 @@ fn test_authorized_revoke() {
 			assert_eq!(
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_00),
 				<Test as Config>::Deposit::get()
+			);
+			assert_eq!(
+				events(),
+				vec![Event::AttestationRevoked {
+					attester: attester.clone(),
+					claim_hash,
+					authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
+				}]
 			);
 		});
 }

--- a/pallets/attestation/src/tests/revoke.rs
+++ b/pallets/attestation/src/tests/revoke.rs
@@ -27,6 +27,7 @@ fn test_revoke_remove() {
 	let revoker: AttesterOf<Test> = sr25519_did_from_public_key(&ALICE_SEED);
 	let claim_hash = claim_hash_from_seed(CLAIM_HASH_SEED_01);
 	let attestation = generate_base_attestation::<Test>(revoker.clone(), ACCOUNT_00);
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -51,6 +52,7 @@ fn test_revoke_remove() {
 				vec![Event::AttestationRevoked {
 					attester: revoker.clone(),
 					claim_hash,
+					ctype_hash,
 					authorized_by: attestation::authorized_by::AuthorizedBy::Attester(revoker.clone())
 				}]
 			);
@@ -69,6 +71,7 @@ fn test_revoke_remove() {
 				vec![Event::AttestationRemoved {
 					attester: revoker.clone(),
 					claim_hash,
+					ctype_hash,
 					authorized_by: attestation::authorized_by::AuthorizedBy::Attester(revoker.clone())
 				}]
 			);
@@ -83,6 +86,7 @@ fn test_authorized_revoke() {
 	let authorization_info = Some(MockAccessControl(revoker.clone()));
 	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 	attestation.authorization_id = Some(revoker.clone());
+	let ctype_hash = attestation.ctype_hash;
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -108,6 +112,7 @@ fn test_authorized_revoke() {
 				vec![Event::AttestationRevoked {
 					attester: attester.clone(),
 					claim_hash,
+					ctype_hash,
 					authorized_by: attestation::authorized_by::AuthorizedBy::Authorization(revoker.clone())
 				}]
 			);

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! - **Delegation:**: An attestation which is not issued by the attester
 //!   directly but via a (chain of) delegations which entitle the delegated
-//!   attester. This could be an employe of a company which is authorized to
+//!   attester. This could be an employee of a company which is authorized to
 //!   sign documents for their superiors.
 //!
 //! ## Assumptions
@@ -248,9 +248,6 @@ pub mod pallet {
 		/// A delegation has been removed.
 		/// \[remover ID, delegation node ID\]
 		DelegationRemoved(AccountIdOf<T>, DelegationNodeIdOf<T>),
-		/// The deposit owner reclaimed a deposit by removing a delegation
-		/// subtree. \[revoker ID, delegation node ID\]
-		DepositReclaimed(AccountIdOf<T>, DelegationNodeIdOf<T>),
 	}
 
 	#[pallet::error]

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -314,7 +314,11 @@ pub mod pallet {
 			let (decoded_name, is_claimed) = Self::check_banning_preconditions(name)?;
 
 			if is_claimed {
-				Self::unregister_name(&decoded_name)?;
+				let owner = Self::unregister_name(&decoded_name)?.owner;
+				Self::deposit_event(Event::<T>::Web3NameReleased {
+					owner,
+					name: decoded_name.clone(),
+				});
 			}
 
 			Self::ban_name(&decoded_name);

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -224,7 +224,7 @@ pub mod pallet {
 
 			let decoded_name = Self::check_claiming_preconditions(name, &owner, &payer)?;
 
-			Self::register_name(decoded_name.clone(), owner.clone(), payer)?;
+			Self::register_name(decoded_name, owner, payer)?;
 
 			Ok(())
 		}

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -225,10 +225,6 @@ pub mod pallet {
 			let decoded_name = Self::check_claiming_preconditions(name, &owner, &payer)?;
 
 			Self::register_name(decoded_name.clone(), owner.clone(), payer)?;
-			Self::deposit_event(Event::<T>::Web3NameClaimed {
-				owner,
-				name: decoded_name,
-			});
 
 			Ok(())
 		}
@@ -254,10 +250,6 @@ pub mod pallet {
 			let owned_name = Self::check_releasing_preconditions(&owner)?;
 
 			Self::unregister_name(&owned_name)?;
-			Self::deposit_event(Event::<T>::Web3NameReleased {
-				owner,
-				name: owned_name,
-			});
 
 			Ok(())
 		}
@@ -281,11 +273,7 @@ pub mod pallet {
 
 			let decoded_name = Self::check_reclaim_deposit_preconditions(name, &caller)?;
 
-			let Web3OwnershipOf::<T> { owner, .. } = Self::unregister_name(&decoded_name)?;
-			Self::deposit_event(Event::<T>::Web3NameReleased {
-				owner,
-				name: decoded_name,
-			});
+			Self::unregister_name(&decoded_name)?;
 
 			Ok(())
 		}
@@ -314,11 +302,7 @@ pub mod pallet {
 			let (decoded_name, is_claimed) = Self::check_banning_preconditions(name)?;
 
 			if is_claimed {
-				let owner = Self::unregister_name(&decoded_name)?.owner;
-				Self::deposit_event(Event::<T>::Web3NameReleased {
-					owner,
-					name: decoded_name.clone(),
-				});
+				Self::unregister_name(&decoded_name)?;
 			}
 
 			Self::ban_name(&decoded_name);
@@ -440,11 +424,13 @@ pub mod pallet {
 			Owner::<T>::insert(
 				&name,
 				Web3OwnershipOf::<T> {
-					owner,
+					owner: owner.clone(),
 					claimed_at: block_number,
 					deposit,
 				},
 			);
+
+			Self::deposit_event(Event::<T>::Web3NameClaimed { owner, name });
 			Ok(())
 		}
 
@@ -494,7 +480,10 @@ pub mod pallet {
 				)
 			}
 
-			// Should never fail since we checked in the preconditions
+			Self::deposit_event(Event::<T>::Web3NameReleased {
+				owner: name_ownership.owner.clone(),
+				name: name.clone(),
+			});
 
 			Ok(name_ownership)
 		}


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3023

Not sure about removing the `Attester` from the `AttestationRemoved` event. We could also consider to have an enum `Remover` with the variants `DepositOwner` and `AuthorizedAttester`. This could make sense since not only the original attester can remove an attestation but also any attester who is authorized via the `AuthorizationId`.

### changed

* moved the `deposit_event(Event::AttestationRemoved)` to the `remove_attestation` so that the event shall never be forgotten to be deposited.
* restructured Attestation event
  * added authorized_by to revoked and removed, added ctype
* test attestation events
* removed unused `DepositReclaimed` events
* deposit `W3nReleased` event when governance bans an already used w3n

## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>

```
!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
[≠] pallet 62: Attestation -> 4 change(s)
  - events changes:
    [≠]  0: AttestationCreated ( : AttesterOf<T>, : ClaimHashOf<T>, : CtypeHashOf<T>, : Option<AuthorizationIdOf<T>>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "attester"))]), Changed(1, [Name(StringChange("", "claim_hash"))]), Changed(2, [Name(StringChange("", "ctype_hash"))]), Changed(3, [Name(StringChange("", "authorization"))])] })]
    [≠]  1: AttestationRevoked ( : AttesterOf<T>, : ClaimHashOf<T>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "authorized_by")), Ty(StringChange("AttesterOf<T>", "AuthorizedByOf<T>"))]), Changed(1, [Name(StringChange("", "attester")), Ty(StringChange("ClaimHashOf<T>", "AttesterOf<T>"))]), Added(2, ArgDesc { name: "claim_hash", ty: "ClaimHashOf<T>" })] })]
    [≠]  2: AttestationRemoved ( : AttesterOf<T>, : ClaimHashOf<T>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "authorized_by")), Ty(StringChange("AttesterOf<T>", "AuthorizedByOf<T>"))]), Changed(1, [Name(StringChange("", "attester")), Ty(StringChange("ClaimHashOf<T>", "AttesterOf<T>"))]), Added(2, ArgDesc { name: "claim_hash", ty: "ClaimHashOf<T>" })] })]
    [-] "DepositReclaimed"

[≠] pallet 63: Delegation -> 1 change(s)
  - events changes:
    [-] "DepositReclaimed"

SUMMARY:
- Compatible.......................: true
- Require transaction_version bump.: false

!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
[≠] pallet 62: Attestation -> 4 change(s)
  - events changes:
    [≠]  0: AttestationCreated ( : AttesterOf<T>, : ClaimHashOf<T>, : CtypeHashOf<T>, : Option<AuthorizationIdOf<T>>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "attester"))]), Changed(1, [Name(StringChange("", "claim_hash"))]), Changed(2, [Name(StringChange("", "ctype_hash"))]), Changed(3, [Name(StringChange("", "authorization"))])] })]
    [≠]  1: AttestationRevoked ( : AttesterOf<T>, : ClaimHashOf<T>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "authorized_by")), Ty(StringChange("AttesterOf<T>", "AuthorizedByOf<T>"))]), Changed(1, [Name(StringChange("", "attester")), Ty(StringChange("ClaimHashOf<T>", "AttesterOf<T>"))]), Added(2, ArgDesc { name: "claim_hash", ty: "ClaimHashOf<T>" })] })]
    [≠]  2: AttestationRemoved ( : AttesterOf<T>, : ClaimHashOf<T>, )  )
        [Signature(SignatureChange { args: [Changed(0, [Name(StringChange("", "authorized_by")), Ty(StringChange("AttesterOf<T>", "AuthorizedByOf<T>"))]), Changed(1, [Name(StringChange("", "attester")), Ty(StringChange("ClaimHashOf<T>", "AttesterOf<T>"))]), Added(2, ArgDesc { name: "claim_hash", ty: "ClaimHashOf<T>" })] })]
    [-] "DepositReclaimed"

[≠] pallet 63: Delegation -> 1 change(s)
  - events changes:
    [-] "DepositReclaimed"

SUMMARY:
- Compatible.......................: true
- Require transaction_version bump.: false

!!! THE SUBWASM REDUCED DIFFER IS EXPERIMENTAL, DOUBLE CHECK THE RESULTS !!!
```

</details>

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
