### PR TITLE
feat: update templates and Dockerfile to support Zombienet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,21 @@ FROM paritytech/ci-unified:bullseye-1.70.0 as builder
 
 WORKDIR /build
 
-ARG FEATURES=default
+ARG BINARY=kilt-parachain
 
 COPY . .
 
-RUN cargo build --locked --release --features $FEATURES
+RUN cargo build --locked --release -p $BINARY
 
 # ===== SECOND STAGE ======
 
 FROM docker.io/library/ubuntu:20.04
-LABEL description="This is the 2nd stage: a very small image where we copy the kilt-parachain binary."
 
-ARG NODE_TYPE=kilt-parachain
+ARG BINARY=kilt-parachain
 
-COPY --from=builder /build/target/release/$NODE_TYPE /usr/local/bin/node-executable
+LABEL description="This is the 2nd stage: a very small image where we copy the ${BINARY} binary."
+
+COPY --from=builder /build/target/release/$BINARY /usr/local/bin/node-executable
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node node && \
 	mkdir -p /node/.local/share/node && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ FROM paritytech/ci-unified:bullseye-1.70.0 as builder
 
 WORKDIR /build
 
+ARG FEATURES=default
 ARG BINARY=kilt-parachain
 
 COPY . .
 
-RUN cargo build --locked --release -p $BINARY
+RUN cargo build --locked --release --features $FEATURES -p $BINARY
 
 # ===== SECOND STAGE ======
 

--- a/dip-template/nodes/dip-consumer/Cargo.toml
+++ b/dip-template/nodes/dip-consumer/Cargo.toml
@@ -68,3 +68,6 @@ cumulus-relay-chain-interface.workspace = true
 
 [build-dependencies]
 substrate-build-script-utils.workspace = true
+
+[features]
+default = []

--- a/dip-template/nodes/dip-consumer/src/command.rs
+++ b/dip-template/nodes/dip-consumer/src/command.rs
@@ -21,8 +21,8 @@ use std::{fs::create_dir_all, net::SocketAddr};
 use cumulus_primitives_core::ParaId;
 use log::{info, warn};
 use sc_cli::{
-	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams, LoggerBuilder,
-	NetworkParams, Result, SharedParams, SubstrateCli,
+	ChainSpec as ChainSpecTrait, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
+	LoggerBuilder, NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::{
 	config::{BasePath, PrometheusConfig},
@@ -33,15 +33,15 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
-	chain_spec::{development_config, Extensions},
+	chain_spec::{development_config, ChainSpec, Extensions},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, start_parachain_node},
 };
 
-fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 	match id {
-		"dev" => Ok(Box::new(development_config())),
-		_ => Err("Unrecognized spec ID.".into()),
+		"dev" | "" => Ok(Box::new(development_config())),
+		path => Ok(Box::new(ChainSpec::from_json_file(std::path::PathBuf::from(path))?)),
 	}
 }
 
@@ -76,7 +76,7 @@ impl SubstrateCli for Cli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 		load_spec(id)
 	}
 }
@@ -112,7 +112,7 @@ impl SubstrateCli for RelayChainCli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
 	}
 }
@@ -289,7 +289,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 	fn prometheus_config(
 		&self,
 		default_listen_port: u16,
-		chain_spec: &Box<dyn ChainSpec>,
+		chain_spec: &Box<dyn ChainSpecTrait>,
 	) -> Result<Option<PrometheusConfig>> {
 		self.base.base.prometheus_config(default_listen_port, chain_spec)
 	}
@@ -361,7 +361,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.announce_block()
 	}
 
-	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpec>) -> Result<Option<TelemetryEndpoints>> {
+	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpecTrait>) -> Result<Option<TelemetryEndpoints>> {
 		self.base.base.telemetry_endpoints(chain_spec)
 	}
 }

--- a/dip-template/nodes/dip-provider/Cargo.toml
+++ b/dip-template/nodes/dip-provider/Cargo.toml
@@ -68,3 +68,6 @@ cumulus-relay-chain-interface.workspace = true
 
 [build-dependencies]
 substrate-build-script-utils.workspace = true
+
+[features]
+default = []

--- a/dip-template/nodes/dip-provider/src/command.rs
+++ b/dip-template/nodes/dip-provider/src/command.rs
@@ -21,8 +21,8 @@ use std::{fs::create_dir_all, net::SocketAddr};
 use cumulus_primitives_core::ParaId;
 use log::{info, warn};
 use sc_cli::{
-	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams, LoggerBuilder,
-	NetworkParams, Result, SharedParams, SubstrateCli,
+	ChainSpec as ChainSpecTrait, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
+	LoggerBuilder, NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::{
 	config::{BasePath, PrometheusConfig},
@@ -33,15 +33,15 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
-	chain_spec::{development_config, Extensions},
+	chain_spec::{development_config, ChainSpec, Extensions},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, start_parachain_node},
 };
 
-fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 	match id {
-		"dev" => Ok(Box::new(development_config())),
-		_ => Err("Unrecognized spec ID.".into()),
+		"dev" | "" => Ok(Box::new(development_config())),
+		path => Ok(Box::new(ChainSpec::from_json_file(std::path::PathBuf::from(path))?)),
 	}
 }
 
@@ -76,7 +76,7 @@ impl SubstrateCli for Cli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 		load_spec(id)
 	}
 }
@@ -112,7 +112,7 @@ impl SubstrateCli for RelayChainCli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
 		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
 	}
 }
@@ -289,7 +289,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 	fn prometheus_config(
 		&self,
 		default_listen_port: u16,
-		chain_spec: &Box<dyn ChainSpec>,
+		chain_spec: &Box<dyn ChainSpecTrait>,
 	) -> Result<Option<PrometheusConfig>> {
 		self.base.base.prometheus_config(default_listen_port, chain_spec)
 	}
@@ -361,7 +361,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.announce_block()
 	}
 
-	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpec>) -> Result<Option<TelemetryEndpoints>> {
+	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpecTrait>) -> Result<Option<TelemetryEndpoints>> {
 		self.base.base.telemetry_endpoints(chain_spec)
 	}
 }

--- a/dip-template/nodes/dip-provider/src/command.rs
+++ b/dip-template/nodes/dip-provider/src/command.rs
@@ -21,8 +21,8 @@ use std::{fs::create_dir_all, net::SocketAddr};
 use cumulus_primitives_core::ParaId;
 use log::{info, warn};
 use sc_cli::{
-	ChainSpec as ChainSpecTrait, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
-	LoggerBuilder, NetworkParams, Result, SharedParams, SubstrateCli,
+	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams, LoggerBuilder,
+	NetworkParams, Result, SharedParams, SubstrateCli,
 };
 use sc_service::{
 	config::{BasePath, PrometheusConfig},
@@ -33,15 +33,17 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
-	chain_spec::{development_config, ChainSpec, Extensions},
+	chain_spec::{development_config, ChainSpec as ProviderChainSpec, Extensions},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, start_parachain_node},
 };
 
-fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	match id {
 		"dev" | "" => Ok(Box::new(development_config())),
-		path => Ok(Box::new(ChainSpec::from_json_file(std::path::PathBuf::from(path))?)),
+		path => Ok(Box::new(ProviderChainSpec::from_json_file(std::path::PathBuf::from(
+			path,
+		))?)),
 	}
 }
 
@@ -76,7 +78,7 @@ impl SubstrateCli for Cli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		load_spec(id)
 	}
 }
@@ -112,7 +114,7 @@ impl SubstrateCli for RelayChainCli {
 		2023
 	}
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpecTrait>, String> {
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
 	}
 }
@@ -289,7 +291,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 	fn prometheus_config(
 		&self,
 		default_listen_port: u16,
-		chain_spec: &Box<dyn ChainSpecTrait>,
+		chain_spec: &Box<dyn ChainSpec>,
 	) -> Result<Option<PrometheusConfig>> {
 		self.base.base.prometheus_config(default_listen_port, chain_spec)
 	}
@@ -361,7 +363,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.announce_block()
 	}
 
-	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpecTrait>) -> Result<Option<TelemetryEndpoints>> {
+	fn telemetry_endpoints(&self, chain_spec: &Box<dyn ChainSpec>) -> Result<Option<TelemetryEndpoints>> {
 		self.base.base.telemetry_endpoints(chain_spec)
 	}
 }


### PR DESCRIPTION
Zombienet uses the empty chainspec for a parachain, and that was not supported by the node templates. Also, the Dockerfile assumes the `kilt-parachain` is being run, but this is different now, and could also be different in the future, so the binary target should be parametrized: anyway, it is not necessary to compile the whole workspace if only a specific binary is required.