### PR TITLE
chore: convert errors into warning for `cargo doc`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ clippy-and-docs:
   stage: test
   script:
     - cargo clippy --all-features --all-targets --locked -- -D warnings
-    - cargo doc --all-features --no-deps --locked
+    - RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps --locked
 
 fmt:
   image: paritytech/ci-unified:bullseye-1.70.0


### PR DESCRIPTION
Taken from https://github.com/rust-lang/cargo/issues/8424#issuecomment-1070988443. Otherwise CI would not highlight the issue.