### PR TITLE
chore: add DIP templates Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,8 @@ build:
   variables:
     DOCKER_HUB_PARACHAIN: "kiltprotocol/kilt-node"
     DOCKER_HUB_STANDALONE: "kiltprotocol/standalone-node"
+    DOCKER_HUB_DIP_PROVIDER_TEMPLATE: "kiltprotocol/dip-provider-node-template"
+    DOCKER_HUB_DIP_CONSUMER_TEMPLATE: "kiltprotocol/dip-consumer-node-template"
   before_script:
     - aws --version
     - docker --version

--- a/.maintain/build-image.sh
+++ b/.maintain/build-image.sh
@@ -27,14 +27,14 @@ docker build \
 PROVIDER_BIN_NAME="dip-provider-node-template"
 docker build \
 	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
-	--cache-from $AWS_REGISTRY/kilt-parachain/collator:$target_tag \
+	--cache-from $AWS_REGISTRY/dip-provider-node-template:$target_tag \
 	--build-arg NODE_TYPE=$PROVIDER_BIN_NAME \
 	-t local/$PROVIDER_BIN_NAME:$target_tag \
 	.
 CONSUMER_BIN_NAME="dip-consumer-node-template"
 docker build \
 	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
-	--cache-from $AWS_REGISTRY/kilt-parachain/collator:$target_tag \
+	--cache-from $AWS_REGISTRY/dip-consumer-node-template:$target_tag \
 	--build-arg NODE_TYPE=$CONSUMER_BIN_NAME \
 	-t local/$CONSUMER_BIN_NAME:$target_tag \
 	.

--- a/.maintain/build-image.sh
+++ b/.maintain/build-image.sh
@@ -27,14 +27,14 @@ docker build \
 PROVIDER_BIN_NAME="dip-provider-node-template"
 docker build \
 	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
-	--cache-from $AWS_REGISTRY/dip-provider-node-template:$target_tag \
+	--cache-from $AWS_REGISTRY/$PROVIDER_BIN_NAME:$target_tag \
 	--build-arg NODE_TYPE=$PROVIDER_BIN_NAME \
 	-t local/$PROVIDER_BIN_NAME:$target_tag \
 	.
 CONSUMER_BIN_NAME="dip-consumer-node-template"
 docker build \
 	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
-	--cache-from $AWS_REGISTRY/dip-consumer-node-template:$target_tag \
+	--cache-from $AWS_REGISTRY/$CONSUMER_BIN_NAME:$target_tag \
 	--build-arg NODE_TYPE=$CONSUMER_BIN_NAME \
 	-t local/$CONSUMER_BIN_NAME:$target_tag \
 	.

--- a/.maintain/build-image.sh
+++ b/.maintain/build-image.sh
@@ -22,3 +22,19 @@ docker build \
     --build-arg NODE_TYPE=standalone-node \
     -t local/standalone-node:$target_tag \
     .
+
+# build DIP provider and consumer templates
+PROVIDER_BIN_NAME="dip-provider-node-template"
+docker build \
+	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
+	--cache-from $AWS_REGISTRY/kilt-parachain/collator:$target_tag \
+	--build-arg NODE_TYPE=$PROVIDER_BIN_NAME \
+	-t local/$PROVIDER_BIN_NAME:$target_tag \
+	.
+CONSUMER_BIN_NAME="dip-consumer-node-template"
+docker build \
+	--cache-from $AWS_REGISTRY/kilt-parachain/collator:builder \
+	--cache-from $AWS_REGISTRY/kilt-parachain/collator:$target_tag \
+	--build-arg NODE_TYPE=$CONSUMER_BIN_NAME \
+	-t local/$CONSUMER_BIN_NAME:$target_tag \
+	.

--- a/.maintain/push-image.sh
+++ b/.maintain/push-image.sh
@@ -3,11 +3,14 @@
 source_tag=$1
 target_tag=$2
 
+PROVIDER_BIN_NAME="dip-provider-node-template"
+CONSUMER_BIN_NAME="dip-consumer-node-template"
+
 # publish to docker hub
 docker tag local/standalone-node:$source_tag ${DOCKER_HUB_STANDALONE}:$target_tag
 docker tag local/kilt-node:$source_tag ${DOCKER_HUB_PARACHAIN}:$target_tag
-docker tag local/dip-provider-node-template:$source_tag ${DOCKER_HUB_DIP_PROVIDER_TEMPLATE}:$target_tag
-docker tag local/dip-consumer-node-template:$source_tag ${DOCKER_HUB_DIP_CONSUMER_TEMPLATE}:$target_tag
+docker tag local/$PROVIDER_BIN_NAME:$source_tag ${DOCKER_HUB_DIP_PROVIDER_TEMPLATE}:$target_tag
+docker tag local/$CONSUMER_BIN_NAME:$source_tag ${DOCKER_HUB_DIP_CONSUMER_TEMPLATE}:$target_tag
 
 docker push ${DOCKER_HUB_STANDALONE}:$target_tag
 docker push ${DOCKER_HUB_PARACHAIN}:$target_tag
@@ -17,10 +20,10 @@ docker push ${DOCKER_HUB_DIP_CONSUMER_TEMPLATE}:$target_tag
 # publish to AWS
 docker tag local/standalone-node:$source_tag $AWS_REGISTRY/kilt/prototype-chain:$target_tag
 docker tag local/kilt-node:$source_tag $AWS_REGISTRY/kilt-parachain/collator:$target_tag
-docker tag local/dip-provider-node-template:$source_tag $AWS_REGISTRY/dip-provider-node-template:$target_tag
-docker tag local/dip-consumer-node-template:$source_tag $AWS_REGISTRY/dip-consumer-node-template:$target_tag
+docker tag local/$PROVIDER_BIN_NAME:$source_tag $AWS_REGISTRY/$PROVIDER_BIN_NAME:$target_tag
+docker tag local/$CONSUMER_BIN_NAME:$source_tag $AWS_REGISTRY/$CONSUMER_BIN_NAME:$target_tag
 
 docker push $AWS_REGISTRY/kilt/prototype-chain:$target_tag
 docker push $AWS_REGISTRY/kilt-parachain/collator:$target_tag
-docker push $AWS_REGISTRY/dip-provider-node-template:$target_tag
-docker push $AWS_REGISTRY/dip-consumer-node-template:$target_tag
+docker push $AWS_REGISTRY/$PROVIDER_BIN_NAME:$target_tag
+docker push $AWS_REGISTRY/$CONSUMER_BIN_NAME:$target_tag

--- a/.maintain/push-image.sh
+++ b/.maintain/push-image.sh
@@ -6,13 +6,21 @@ target_tag=$2
 # publish to docker hub
 docker tag local/standalone-node:$source_tag ${DOCKER_HUB_STANDALONE}:$target_tag
 docker tag local/kilt-node:$source_tag ${DOCKER_HUB_PARACHAIN}:$target_tag
+docker tag local/dip-provider-node-template:$source_tag ${DOCKER_HUB_DIP_PROVIDER_TEMPLATE}:$target_tag
+docker tag local/dip-consumer-node-template:$source_tag ${DOCKER_HUB_DIP_CONSUMER_TEMPLATE}:$target_tag
 
 docker push ${DOCKER_HUB_STANDALONE}:$target_tag
 docker push ${DOCKER_HUB_PARACHAIN}:$target_tag
+docker push ${DOCKER_HUB_DIP_PROVIDER_TEMPLATE}:$target_tag
+docker push ${DOCKER_HUB_DIP_CONSUMER_TEMPLATE}:$target_tag
 
 # publish to AWS
 docker tag local/standalone-node:$source_tag $AWS_REGISTRY/kilt/prototype-chain:$target_tag
 docker tag local/kilt-node:$source_tag $AWS_REGISTRY/kilt-parachain/collator:$target_tag
+docker tag local/dip-provider-node-template:$source_tag $AWS_REGISTRY/dip-provider-node-template:$target_tag
+docker tag local/dip-consumer-node-template:$source_tag $AWS_REGISTRY/dip-consumer-node-template:$target_tag
 
 docker push $AWS_REGISTRY/kilt/prototype-chain:$target_tag
 docker push $AWS_REGISTRY/kilt-parachain/collator:$target_tag
+docker push $AWS_REGISTRY/dip-provider-node-template:$target_tag
+docker push $AWS_REGISTRY/dip-consumer-node-template:$target_tag


### PR DESCRIPTION
Partially fixes https://github.com/KILTprotocol/ticket/issues/3051. Needed for easier DIP-SDK integration tests. Binaries will have to be compiled and exported in a different PR.