### PR TITLE
docs: Document safe use of Twox64Concat

### DIFF
--- a/dip-template/pallets/pallet-postit/src/lib.rs
+++ b/dip-template/pallets/pallet-postit/src/lib.rs
@@ -57,10 +57,12 @@ pub mod pallet {
 		type Username: Encode + Decode + TypeInfo + MaxEncodedLen + Clone + PartialEq + Debug + Default;
 	}
 
+	// Safety: The hash is calculated on chain. The hashing algorithm provided by frame_system::Config must be cryptographically secure.
 	#[pallet::storage]
 	#[pallet::getter(fn posts)]
 	pub type Posts<T> = StorageMap<_, Twox64Concat, <T as frame_system::Config>::Hash, PostOf<T>>;
 
+	// Safety: The hash is calculated on chain. The hashing algorithm provided by frame_system::Config must be cryptographically secure.
 	#[pallet::storage]
 	#[pallet::getter(fn comments)]
 	pub type Comments<T> = StorageMap<_, Twox64Concat, <T as frame_system::Config>::Hash, CommentOf<T>>;

--- a/pallets/attestation/src/migrations.rs
+++ b/pallets/attestation/src/migrations.rs
@@ -37,6 +37,24 @@ where
 	)
 }
 
+pub mod v1 {
+	use frame_support::{pallet_prelude::*, storage_alias, Blake2_128Concat};
+
+	use crate::{AuthorizationIdOf, ClaimHashOf, Config, Pallet};
+
+	/// The old `PageIndex` storage item.
+	#[storage_alias]
+	pub(crate) type ExternalAttestations<T: Config> = StorageDoubleMap<
+		Pallet<T>,
+		Twox64Concat,
+		AuthorizationIdOf<T>,
+		Blake2_128Concat,
+		ClaimHashOf<T>,
+		bool,
+		ValueQuery,
+	>;
+}
+
 #[cfg(test)]
 pub mod test {
 	use ctype::mock::get_ctype_hash;

--- a/pallets/attestation/src/migrations.rs
+++ b/pallets/attestation/src/migrations.rs
@@ -42,7 +42,6 @@ pub mod v1 {
 
 	use crate::{AuthorizationIdOf, ClaimHashOf, Config, Pallet};
 
-	/// The old `PageIndex` storage item.
 	#[storage_alias]
 	pub(crate) type ExternalAttestations<T: Config> = StorageDoubleMap<
 		Pallet<T>,

--- a/pallets/pallet-deposit-storage/src/lib.rs
+++ b/pallets/pallet-deposit-storage/src/lib.rs
@@ -143,10 +143,11 @@ pub mod pallet {
 	/// Storage of all deposits. Its first key is a namespace, and the second
 	/// one the deposit key. Its value includes the details associated to a
 	/// deposit instance.
+	// SAFETY: The Namespace is not chosen by the user but by the pallet and therefore doesn't allow for arbitrary data.
 	#[pallet::storage]
 	#[pallet::getter(fn deposits)]
 	pub(crate) type Deposits<T> =
-		StorageDoubleMap<_, Twox64Concat, <T as Config>::Namespace, Twox64Concat, DepositKeyOf<T>, DepositEntryOf<T>>;
+		StorageDoubleMap<_, Twox64Concat, <T as Config>::Namespace, Blake2_128Concat, DepositKeyOf<T>, DepositEntryOf<T>>;
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/pallet-dip-consumer/src/lib.rs
+++ b/pallets/pallet-dip-consumer/src/lib.rs
@@ -41,7 +41,6 @@ pub mod pallet {
 		dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
 		pallet_prelude::*,
 		traits::{Contains, EnsureOriginWithArg},
-		Twox64Concat,
 	};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::{FullCodec, MaxEncodedLen};
@@ -108,7 +107,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn identity_proofs)]
 	pub(crate) type IdentityEntries<T> =
-		StorageMap<_, Twox64Concat, <T as Config>::Identifier, <T as Config>::LocalIdentityInfo>;
+		StorageMap<_, Blake2_128Concat, <T as Config>::Identifier, <T as Config>::LocalIdentityInfo>;
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/2529



## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>

```
```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
```

</details>

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
