### PR TITLE
feat: increase service URL size limit

### DIFF
--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -385,7 +385,7 @@ pub mod did {
 	pub const MAX_SERVICE_ID_LENGTH: u32 = 50;
 	pub const MAX_SERVICE_TYPE_LENGTH: u32 = 50;
 	pub const MAX_NUMBER_OF_TYPES_PER_SERVICE: u32 = 1;
-	pub const MAX_SERVICE_URL_LENGTH: u32 = 200;
+	pub const MAX_SERVICE_URL_LENGTH: u32 = 2_000;
 	pub const MAX_NUMBER_OF_URLS_PER_SERVICE: u32 = 2;
 
 	parameter_types! {


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3131.

The ticket mentions that 500 would be a good new limit for the inbound request we had. Reading elsewhere online, such as [here](https://stackoverflow.com/a/417184) it seems that 2000 characters is a good upper bound limit for URLs. Since every change would require a runtime upgrade, I would rather make the value future proof and set it to 2000 directly.