### PR TITLE
fix: try-runtime support in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ build-wasm-try-runtime:
       - RUNTIME: "peregrine"
       - RUNTIME: "spiritnet"
   image:
-    image: paritytech/ci-unified:bullseye-1.70.0
+    name: paritytech/ci-unified:bullseye-1.70.0
     entrypoint: [""]
   stage: build
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ build-wasm-try-runtime:
       - RUNTIME: "peregrine"
       - RUNTIME: "spiritnet"
   image:
-    name: paritytech/srtool:1.70.0
+    image: paritytech/ci-unified:bullseye-1.70.0
     entrypoint: [""]
   stage: build
   only:
@@ -131,14 +131,9 @@ build-wasm-try-runtime:
     - master
     - /^[0-9]+(?:\.[0-9]+){2}(?:-(rc)*([0-9])+)?$/
   script:
-    - export PACKAGE=${RUNTIME}-runtime
-    - export RUNTIME_DIR=runtimes/${RUNTIME}
-    - export PARACHAIN_PALLET_ID=0x50
-    - export AUTHORIZE_UPGRADE_PREFIX=0x02
-    - cp -r * /build
-    - /srtool/build build --default-features try-runtime
+    - cargo build -p ${RUNTIME}-runtime --features try-runtime
     - mkdir ./out
-    - mv /out/${RUNTIME}_runtime.compact.compressed.wasm ./dangerous_${RUNTIME}.try-runtime.wasm
+    - mv target/release/wbuild/${RUNTIME}-runtime/${RUNTIME}_runtime.compact.compressed.wasm ./dangerous_${RUNTIME}.try-runtime.wasm
   artifacts:
     name: ${RUNTIME}_try-runtime
     paths:


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3300.

Currently srtool does not really support features (https://github.com/chevdor/srtool-cli/issues/32), so we need a workaround until features are supported in srtool. Since this is what we do anyway now, I decided to go with using the same build infrastructure we use for tests.