### PR TITLE
chore: remove unnecessary try-runtime execution

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,9 +49,6 @@ test-try-runtime:
     - ./try-runtime --version
     - cargo build --locked --release -p ${RUNTIME}-runtime --features try-runtime
     - ./try-runtime --runtime ./target/release/wbuild/${RUNTIME}-runtime/${RUNTIME}_runtime.compact.compressed.wasm on-runtime-upgrade --disable-spec-version-check --checks=all live --uri=${ENDPOINT}
-    - echo "try-runtime with all checks exited successfully."
-    - ./try-runtime --runtime ./target/release/wbuild/${RUNTIME}-runtime/${RUNTIME}_runtime.compact.compressed.wasm on-runtime-upgrade --disable-spec-version-check live --uri=${ENDPOINT}
-    - echo "try-runtime with pre and post checks exited successfully."
 
 build:
   timeout: 2 hours


### PR DESCRIPTION
Output of a `try-runtime` execution with `--checks all`:

<details>
<summary>stdout</summary>

```
antonio@rust-2:~/Developer/kilt-node\ $ try-runtime --runtime target/debug/wbuild/spiritnet-runtime/spiritnet_runtime.compact.compressed.wasm on-runtime-upgrade --checks all live --uri wss://spiritnet.kilt.io:443
[2024-04-17T06:14:46Z INFO  remote-ext] replacing wss:// in uri with https://: "https://spiritnet.kilt.io:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-04-17T06:14:46Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0xef1391b41c362cd4175c25a5ea456a6e07200d6f82842d4b6ba79c648ac8fb38
[2024-04-17T06:14:46Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-04-17T06:14:46Z INFO  remote-ext] scraping key-pairs from remote at block height 0xef1391b41c362cd4175c25a5ea456a6e07200d6f82842d4b6ba79c648ac8fb38
✅ Found 629821 keys (2.55s)
[00:00:20] ✅ Downloaded key values 30,749.4766/s [==============================================] 629821/629821 (0s)
✅ Inserted keys into DB (1.54s)
[2024-04-17T06:15:11Z INFO  remote-ext] adding data for hashed prefix: , took 24.88s
[2024-04-17T06:15:11Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-04-17T06:15:11Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-04-17T06:15:11Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-04-17T06:15:11Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-04-17T06:15:11Z INFO  remote-ext] initialized state externalities with storage root 0xc81286809bc836dc6b615d11dbd164caf1657a763243a2dc4f96999b670f9d87 and state_version V0
[2024-04-17T06:15:11Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("kilt-spiritnet")] [Version: 11210] [Code hash: 0xe680...7107]
[2024-04-17T06:15:11Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("kilt-spiritnet")] [Version: 11300] [Code hash: 0xdb55...0f08]
[2024-04-17T06:15:11Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-04-17T06:15:11Z INFO  try_runtime_core::misc] -----------------------------------------------------------
    
    
[2024-04-17T06:15:11Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: All
    
    
[2024-04-17T06:15:11Z INFO  try_runtime_core::misc] -----------------------------------------------------------
    
    
[2024-04-17T06:15:12Z INFO  spiritnet_runtime] try-runtime::on_runtime_upgrade spiritnet.
[2024-04-17T06:15:15Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-04-17T06:15:19Z INFO  spiritnet_runtime] try-runtime::on_runtime_upgrade spiritnet.
[2024-04-17T06:15:19Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] --------------------------------------------------------------------------
    
    
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: All
    
    
[2024-04-17T06:15:19Z INFO  try_runtime_core::misc] --------------------------------------------------------------------------
    
    
[2024-04-17T06:15:19Z INFO  spiritnet_runtime] try-runtime::on_runtime_upgrade spiritnet.
[2024-04-17T06:15:23Z INFO  runtime::frame-support] ⚠️ PolkadotXcm declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`
[2024-04-17T06:15:27Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 608 B. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-04-17T06:15:27Z INFO  try-runtime::cli] Consumed ref_time: 0s (0.00% of max 0.5s)
[2024-04-17T06:15:27Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```
</details>

Hence, we can remove the execution that does not use any checks, since the first one includes also checks for weights and idempotent operations.