### PR TITLE
fix: outdated integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,22 +30,22 @@ test-features:
   script:
     - cargo test --all --all-features --all-targets --locked
 
-# integration-tests:
-#   timeout: 30 minutes
-#   image: paritytech/ci-unified:bullseye-1.70.0
-#   stage: test
-#   variables:
-#     CI: "true"
-#   script:
-#     - cd ./integration-tests/chopsticks
-#     - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-#     - export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" --no-use
-#     - eval "[ -f .nvmrc ] && nvm install" && nvm use
-#     - yarn --immutable
-#     - yarn ts-check
-#     - yarn lint
-#     - cargo build -p spiritnet-runtime
-#     - yarn test:CI
+integration-tests:
+  timeout: 30 minutes
+  image: paritytech/ci-unified:bullseye-1.70.0
+  stage: test
+  variables:
+    CI: "true"
+  script:
+    - cd ./integration-tests/chopsticks
+    - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+    - export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" --no-use
+    - eval "[ -f .nvmrc ] && nvm install" && nvm use
+    - yarn --immutable
+    - yarn ts-check
+    - yarn lint
+    - cargo build -p spiritnet-runtime
+    - yarn test:CI
 
 # TODO: The try-runtime-cli executable could be built as part of the Docker image directly, saving some time.
 test-try-runtime:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,10 @@ integration-tests:
     - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
     - export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" --no-use
     - eval "[ -f .nvmrc ] && nvm install" && nvm use
-    - cargo build -p spiritnet-runtime
     - yarn --immutable
+    - yarn ts-check
     - yarn lint
+    - cargo build -p spiritnet-runtime
     - yarn test:CI
 
 # TODO: The try-runtime-cli executable could be built as part of the Docker image directly, saving some time.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,6 @@ integration-tests:
     - yarn --immutable
     - yarn ts-check
     - yarn lint
-    - cargo build -p spiritnet-runtime
     - yarn test:CI
 
 # TODO: The try-runtime-cli executable could be built as part of the Docker image directly, saving some time.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,22 +30,22 @@ test-features:
   script:
     - cargo test --all --all-features --all-targets --locked
 
-integration-tests:
-  timeout: 30 minutes
-  image: paritytech/ci-unified:bullseye-1.70.0
-  stage: test
-  variables:
-    CI: "true"
-  script:
-    - cd ./integration-tests/chopsticks
-    - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-    - export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" --no-use
-    - eval "[ -f .nvmrc ] && nvm install" && nvm use
-    - yarn --immutable
-    - yarn ts-check
-    - yarn lint
-    - cargo build -p spiritnet-runtime
-    - yarn test:CI
+# integration-tests:
+#   timeout: 30 minutes
+#   image: paritytech/ci-unified:bullseye-1.70.0
+#   stage: test
+#   variables:
+#     CI: "true"
+#   script:
+#     - cd ./integration-tests/chopsticks
+#     - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+#     - export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" --no-use
+#     - eval "[ -f .nvmrc ] && nvm install" && nvm use
+#     - yarn --immutable
+#     - yarn ts-check
+#     - yarn lint
+#     - cargo build -p spiritnet-runtime
+#     - yarn test:CI
 
 # TODO: The try-runtime-cli executable could be built as part of the Docker image directly, saving some time.
 test-try-runtime:

--- a/integration-tests/chopsticks/package.json
+++ b/integration-tests/chopsticks/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0"
   },
   "scripts": {
+    "ts-check": "tsc --noEmit",
     "lint": "eslint src && prettier --check src",
     "lint:fix": "eslint --fix src && prettier --write src",
     "clean": "rm -rf ./db && cargo build -p spiritnet-runtime",

--- a/integration-tests/chopsticks/package.json
+++ b/integration-tests/chopsticks/package.json
@@ -33,7 +33,7 @@
     "ts-check": "tsc --noEmit",
     "lint": "eslint src && prettier --check src",
     "lint:fix": "eslint --fix src && prettier --write src",
-    "clean": "rm -rf ./db && cargo build -p spiritnet-runtime",
+    "clean": "rm -rf ./db",
     "test": "LOG_LEVEL=error vitest",
     "test:CI": "vitest --bail 0  --no-file-parallelism"
   }

--- a/integration-tests/chopsticks/src/network/hydraDx.ts
+++ b/integration-tests/chopsticks/src/network/hydraDx.ts
@@ -40,7 +40,7 @@ export function assignKiltTokensToAccounts(addr: string[], balance: bigint = ini
 /// HydraDX ParaId
 export const paraId = 2034
 
-/// OmniPool account
+/// Omnipool account
 export const omnipoolAccount = '7L53bUTBbfuj14UpdCNPwmgzzHSsrsTWBHX5pys32mVWM3C1'
 
 export async function getContext(): Promise<Config> {

--- a/integration-tests/chopsticks/src/network/hydraDx.ts
+++ b/integration-tests/chopsticks/src/network/hydraDx.ts
@@ -1,6 +1,5 @@
 import { setupContext, SetupOption } from '@acala-network/chopsticks-testing'
 import type { Config } from './types.js'
-import * as SpiritnetConfig from './spiritnet.js'
 import { initialBalanceHDX, initialBalanceKILT, toNumber } from '../utils.js'
 
 /// Options used to create the HydraDx context
@@ -10,7 +9,7 @@ export const options: SetupOption = {
 	port: toNumber(process.env.HYDRADX_PORT) || 9001,
 }
 
-export const kiltTokenId = 60
+export const kiltTokenId = 28
 
 /// Sets the [TechnicalCommittee] and [Council] governance to the given accounts
 export function setGovernance(addr: string[]) {
@@ -34,34 +33,6 @@ export function assignKiltTokensToAccounts(addr: string[], balance: bigint = ini
 	return {
 		Tokens: {
 			Accounts: addr.map((address) => [[address, kiltTokenId], { free: balance }]),
-		},
-	}
-}
-
-/// Register KILT into HydraDX and allow KILT as payment
-export function registerKilt() {
-	return {
-		assetRegistry: {
-			assetLocations: [[[kiltTokenId], { parents: 1, interior: { X1: { Parachain: SpiritnetConfig.paraId } } }]],
-			assetIds: [[['KILT'], kiltTokenId]],
-			locationAssets: [[[{ parents: 1, interior: { X1: { Parachain: SpiritnetConfig.paraId } } }], kiltTokenId]],
-			assets: [
-				[
-					[kiltTokenId],
-					{
-						name: 'KILT',
-						assetType: 'Token',
-						existentialDeposit: 500,
-						symbol: 'KILT',
-						decimals: 18,
-						xcmRateLimit: null,
-						isSufficient: true,
-					},
-				],
-			],
-		},
-		multiTransactionPayment: {
-			acceptedCurrencies: [[[kiltTokenId], 100_000]],
 		},
 	}
 }

--- a/integration-tests/chopsticks/src/network/spiritnet.ts
+++ b/integration-tests/chopsticks/src/network/spiritnet.ts
@@ -7,9 +7,6 @@ const options: SetupOption = {
 	endpoint: process.env.SPIRITNET_WS || 'wss://kilt-rpc.dwellir.com',
 	db: './db/spiritnet.db.sqlite',
 	port: toNumber(process.env.SPIRITNET_PORT) || 9002,
-	wasmOverride: '../../target/debug/wbuild/spiritnet-runtime/spiritnet_runtime.wasm',
-	// Whether to allow WASM unresolved imports when using a WASM to build the parachain. This Flag is needed otherwise, the runtime can not be built from the WASM. Chopsticks throws an error when it encounters an unresolved import.
-	allowUnresolvedImports: true,
 }
 
 /// Assigns the native tokens to an accounts
@@ -26,15 +23,6 @@ export function setGovernance(addr: string[]) {
 	return {
 		technicalCommittee: { Members: addr },
 		council: { Members: addr },
-	}
-}
-
-/// Sets the [safeXcmVersion] to the given version
-export function setSafeXcmVersion(version: number) {
-	return {
-		polkadotXcm: {
-			safeXcmVersion: version,
-		},
 	}
 }
 

--- a/integration-tests/chopsticks/src/tests/index.ts
+++ b/integration-tests/chopsticks/src/tests/index.ts
@@ -6,7 +6,6 @@ import * as SpiritnetConfig from '../network/spiritnet.js'
 import * as PolkadotConfig from '../network/polkadot.js'
 import * as HydraDxConfig from '../network/hydraDx.js'
 import type { Config } from '../network/types.js'
-import { setStorage } from './utils.js'
 
 export let spiritnetContext: Config
 export let hydradxContext: Config

--- a/integration-tests/chopsticks/src/tests/index.ts
+++ b/integration-tests/chopsticks/src/tests/index.ts
@@ -18,8 +18,11 @@ beforeAll(async () => {
 	polkadotContext = await PolkadotConfig.getContext()
 
 	// Setup network
+	//@ts-expect-error Something weird in the exported types
 	await connectVertical(polkadotContext.chain, spiritnetContext.chain)
+	//@ts-expect-error Something weird in the exported types
 	await connectVertical(polkadotContext.chain, hydradxContext.chain)
+	//@ts-expect-error Something weird in the exported types
 	await connectParachains([spiritnetContext.chain, hydradxContext.chain])
 
 	const newBlockConfig = { count: 2 }
@@ -31,14 +34,6 @@ beforeAll(async () => {
 		spiritnetContext.dev.newBlock(newBlockConfig),
 		hydradxContext.dev.newBlock(newBlockConfig),
 	])
-
-	console.info('Runtime Upgrade completed')
-
-	// set SafeXcmVersion to 3
-	await setStorage(spiritnetContext, SpiritnetConfig.setSafeXcmVersion(3))
-
-	// register Kilt in HydraDX
-	await setStorage(hydradxContext, HydraDxConfig.registerKilt())
 }, 300_000)
 
 afterAll(async () => {

--- a/integration-tests/chopsticks/src/tests/utils.ts
+++ b/integration-tests/chopsticks/src/tests/utils.ts
@@ -30,6 +30,18 @@ export async function checkBalance(
 	expect(balance).eq(BigInt(expectedAmount))
 }
 
+/// checks the balance of an account and expects it to be in the given range
+export async function checkBalanceInRange(
+	getFreeBalanceFunction: (account: string) => Promise<bigint>,
+	account: string,
+	expect: ExpectStatic,
+	expectedRange: [bigint, bigint]
+) {
+	const balance = await getFreeBalanceFunction(account)
+	expect(balance >= expectedRange[0])
+	expect(balance <= expectedRange[1])
+}
+
 export function hexAddress(addr: string) {
 	return u8aToHex(decodeAddress(addr))
 }

--- a/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV2.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV2.test.ts.snap
@@ -72,3 +72,85 @@ exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > 
   },
 ]
 `;
+
+exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > receiver events currencies 1`] = `
+[
+  {
+    "data": {
+      "amount": "(rounded 1000000000000000)",
+      "currencyId": 28,
+      "who": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
+    },
+    "method": "Deposited",
+    "section": "currencies",
+  },
+  {
+    "data": {
+      "amount": "(rounded 3700000000000)",
+      "currencyId": 28,
+      "who": "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh",
+    },
+    "method": "Deposited",
+    "section": "currencies",
+  },
+]
+`;
+
+exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > receiver events xcmpQueue 1`] = `
+[
+  {
+    "data": {
+      "messageHash": "(hash)",
+      "messageId": "(hash)",
+      "weight": {
+        "proofSize": 0,
+        "refTime": 400000000,
+      },
+    },
+    "method": "Success",
+    "section": "xcmpQueue",
+  },
+]
+`;
+
+exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events Balances 1`] = `
+[
+  {
+    "data": {
+      "amount": "(rounded 170000000000)",
+      "who": "4seWojfEHrk5YKPahdErazQ3CWEHZYi6NV4gKz5AaejWbRPJ",
+    },
+    "method": "Withdraw",
+    "section": "balances",
+  },
+]
+`;
+
+exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events xcm pallet 1`] = `
+[
+  {
+    "data": {
+      "outcome": {
+        "Complete": {
+          "proofSize": 0,
+          "refTime": 400000000,
+        },
+      },
+    },
+    "method": "Attempted",
+    "section": "polkadotXcm",
+  },
+]
+`;
+
+exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events xcm queue pallet 1`] = `
+[
+  {
+    "data": {
+      "messageHash": "(hash)",
+    },
+    "method": "XcmpMessageSent",
+    "section": "xcmpQueue",
+  },
+]
+`;

--- a/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV2.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV2.test.ts.snap
@@ -1,83 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > receiver events currencies 1`] = `
-[
-  {
-    "data": {
-      "amount": 1000000000000000,
-      "currencyId": 60,
-      "who": "7L53bUTBbfuj14UpdCNPwmgzzHSsrsTWBHX5pys32mVWM3C1",
-    },
-    "method": "Deposited",
-    "section": "currencies",
-  },
-]
-`;
-
-exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > receiver events xcmpQueue 1`] = `
-[
-  {
-    "data": {
-      "messageHash": "(hash)",
-      "messageId": "(hash)",
-      "weight": {
-        "proofSize": 0,
-        "refTime": 400000000,
-      },
-    },
-    "method": "Success",
-    "section": "xcmpQueue",
-  },
-]
-`;
-
-exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > sender events Balances 1`] = `
-[
-  {
-    "data": {
-      "amount": "(rounded 170000000000)",
-      "who": "4seWojfEHrk5YKPahdErazQ3CWEHZYi6NV4gKz5AaejWbRPJ",
-    },
-    "method": "Withdraw",
-    "section": "balances",
-  },
-]
-`;
-
-exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > sender events xcm pallet 1`] = `
-[
-  {
-    "data": {
-      "outcome": {
-        "Complete": {
-          "proofSize": 0,
-          "refTime": 400000000,
-        },
-      },
-    },
-    "method": "Attempted",
-    "section": "polkadotXcm",
-  },
-]
-`;
-
-exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx > sender events xcm queue pallet 1`] = `
-[
-  {
-    "data": {
-      "messageHash": "(hash)",
-    },
-    "method": "XcmpMessageSent",
-    "section": "xcmpQueue",
-  },
-]
-`;
-
 exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > receiver events currencies 1`] = `
 [
   {
     "data": {
-      "amount": "(rounded 1000000000000000)",
+      "amount": "(rounded 990000000000000)",
       "currencyId": 28,
       "who": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
     },
@@ -86,7 +13,7 @@ exports[`Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Ac
   },
   {
     "data": {
-      "amount": "(rounded 3700000000000)",
+      "amount": "(rounded 5000000000000)",
       "currencyId": 28,
       "who": "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh",
     },

--- a/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV3.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReserveTransferSpiritnetHydraDxV3.test.ts.snap
@@ -1,12 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > receiver events currencies 1`] = `
+exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > receiver events currencies 1`] = `
 [
   {
     "data": {
-      "amount": 1000000000000000,
-      "currencyId": 60,
-      "who": "7L53bUTBbfuj14UpdCNPwmgzzHSsrsTWBHX5pys32mVWM3C1",
+      "amount": "(rounded 990000000000000)",
+      "currencyId": 28,
+      "who": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
+    },
+    "method": "Deposited",
+    "section": "currencies",
+  },
+  {
+    "data": {
+      "amount": "(rounded 5000000000000)",
+      "currencyId": 28,
+      "who": "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh",
     },
     "method": "Deposited",
     "section": "currencies",
@@ -14,7 +23,7 @@ exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > 
 ]
 `;
 
-exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > receiver events xcmpQueue 1`] = `
+exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > receiver events xcmpQueue 1`] = `
 [
   {
     "data": {
@@ -31,7 +40,7 @@ exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > 
 ]
 `;
 
-exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > sender events Balances 1`] = `
+exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events Balances 1`] = `
 [
   {
     "data": {
@@ -44,7 +53,7 @@ exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > 
 ]
 `;
 
-exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > sender events xcm pallet 1`] = `
+exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events xcm pallet 1`] = `
 [
   {
     "data": {
@@ -61,7 +70,7 @@ exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > 
 ]
 `;
 
-exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx > sender events xcm queue pallet 1`] = `
+exports[`Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice > sender events xcm queue pallet 1`] = `
 [
   {
     "data": {

--- a/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReseveTransferHydraDxSpiritnet.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/xcm/__snapshots__/limitedReseveTransferHydraDxSpiritnet.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > receiver events Balances 1`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > receiver events Balances 1`] = `
 [
   {
     "data": {
@@ -13,7 +13,7 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > recei
 ]
 `;
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > receiver events Balances 2`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > receiver events Balances 2`] = `
 [
   {
     "data": {
@@ -26,7 +26,7 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > recei
 ]
 `;
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > receiver events xcmpQueue 1`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > receiver events xcmpQueue 1`] = `
 [
   {
     "data": {
@@ -43,13 +43,13 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > recei
 ]
 `;
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sender events currencies 1`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > sender events currencies 1`] = `
 [
   {
     "data": {
       "amount": "(rounded 440000000000)",
       "currencyId": 0,
-      "who": "7MZG43idRmdg8VSt5BS9mVJeBhhxxt5y55hCsMpoKp5xFQX2",
+      "who": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
     },
     "method": "Withdrawn",
     "section": "currencies",
@@ -57,8 +57,8 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sende
   {
     "data": {
       "amount": 1000000000000000,
-      "currencyId": 60,
-      "who": "7MZG43idRmdg8VSt5BS9mVJeBhhxxt5y55hCsMpoKp5xFQX2",
+      "currencyId": 28,
+      "who": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
     },
     "method": "Withdrawn",
     "section": "currencies",
@@ -66,7 +66,7 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sende
 ]
 `;
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sender events currencies 2`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > sender events currencies 2`] = `
 [
   {
     "data": {
@@ -118,7 +118,7 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sende
           },
         },
       },
-      "sender": "7MZG43idRmdg8VSt5BS9mVJeBhhxxt5y55hCsMpoKp5xFQX2",
+      "sender": "7NL1GYCJu8cFSnWBLwET2X3fMdodw8T75zuxi59hA2bhdjQq",
     },
     "method": "TransferredMultiAssets",
     "section": "xTokens",
@@ -126,7 +126,7 @@ exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sende
 ]
 `;
 
-exports[`Limited Reserve Transfers from HydraDx Account Bob -> Spiritnet > sender events xcm queue pallet 1`] = `
+exports[`Limited Reserve Transfers from HydraDx Account Alice -> Spiritnet Account Alice > sender events xcm queue pallet 1`] = `
 [
   {
     "data": {

--- a/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV2.test.ts
+++ b/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV2.test.ts
@@ -13,12 +13,22 @@ const KILT_ASSET_V2 = { V2: [getNativeAssetIdLocation(KILT)] }
 test('Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Account Alice', async ({ expect }) => {
 	const { checkEvents, checkSystemEvents } = withExpect(expect)
 
-	// Set storage
-	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address], initialBalanceKILT))
-	const hydraDxSovereignAccountBalanceBeforeTransfer = await getFreeBalanceSpiritnet(SpiritnetConfig.hydraDxSovereignAccount)
+	// Assign alice some KILT tokens
+	await setStorage(
+		spiritnetContext,
+		SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address], initialBalanceKILT)
+	)
 
-	// check initial balance
+	// Balance of the hydraDx sovereign account before the transfer
+	const hydraDxSovereignAccountBalanceBeforeTransfer = await getFreeBalanceSpiritnet(
+		SpiritnetConfig.hydraDxSovereignAccount
+	)
+
+	// check initial balance of Alice on Spiritnet
 	await checkBalance(getFreeBalanceSpiritnet, keysAlice.address, expect, initialBalanceKILT)
+
+	// Alice should have NO KILT on HydraDx
+	await checkBalance(getFreeBalanceHydraDxKilt, keysAlice.address, expect, BigInt(0))
 
 	const aliceAddress = hexAddress(keysAlice.address)
 	const hydraDxDestination = { V2: getSiblingLocation(HydraDxConfig.paraId) }
@@ -38,10 +48,20 @@ test('Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Accou
 	checkEvents(events, 'polkadotXcm').toMatchSnapshot('sender events xcm pallet')
 	checkEvents(events, { section: 'balances', method: 'Withdraw' }).toMatchSnapshot('sender events Balances')
 
-	// check balance
-	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect, hydraDxSovereignAccountBalanceBeforeTransfer + KILT)
+	// check balance. The sovereign account should hold one additional KILT.
+	await checkBalance(
+		getFreeBalanceSpiritnet,
+		SpiritnetConfig.hydraDxSovereignAccount,
+		expect,
+		hydraDxSovereignAccountBalanceBeforeTransfer + KILT
+	)
+
+	// check balance sender
 	// Equal to `initialBalanceKILT - KILT` - tx fees
-	await checkBalanceInRange(getFreeBalanceSpiritnet, keysAlice.address, expect, [BigInt(98999830999996320), BigInt(98999830999996321)])
+	await checkBalanceInRange(getFreeBalanceSpiritnet, keysAlice.address, expect, [
+		BigInt('98999830999996320'),
+		BigInt('98999830999996321'),
+	])
 
 	// Check receiver state
 	await createBlock(hydradxContext)
@@ -52,6 +72,10 @@ test('Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx Accou
 	)
 	checkSystemEvents(hydradxContext, 'xcmpQueue').toMatchSnapshot('receiver events xcmpQueue')
 
-	// check balance
-	await checkBalanceInRange(getFreeBalanceHydraDxKilt, aliceAddress, expect, [BigInt(996349465529793), BigInt(996349465529796)])
+	// check balance receiver
+	// check balance. Equal to `KILT` - tx fees
+	await checkBalanceInRange(getFreeBalanceHydraDxKilt, aliceAddress, expect, [
+		BigInt(996349465529793),
+		BigInt(996349465529796),
+	])
 }, 20_000)

--- a/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV2.test.ts
+++ b/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV2.test.ts
@@ -16,14 +16,18 @@ test('Limited Reserve V2 Transfers from Spiritnet Account Alice -> HydraDx', asy
 	// Set storage
 	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address]))
 	await setStorage(hydradxContext, HydraDxConfig.assignNativeTokensToAccounts([keysAlice.address]))
+	// Set balance to 0 for HydraDX sovereign account on Spiritnet
+	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([SpiritnetConfig.hydraDxSovereignAccount], BigInt(0)))
+	// Set KILT balance to 0 for Omnipool account on HydraDx
+	await setStorage(hydradxContext, HydraDxConfig.assignKiltTokensToAccounts([HydraDxConfig.omnipoolAccount], BigInt(0)))
 
 	// check initial balance
-	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect)
-	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect)
+	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect, BigInt(0))
+	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect, BigInt(0))
 
-	const omniPoolAddress = hexAddress(HydraDxConfig.omnipoolAccount)
+	const omnipoolAddress = hexAddress(HydraDxConfig.omnipoolAccount)
 	const hydraDxDestination = { V2: getSiblingLocation(HydraDxConfig.paraId) }
-	const beneficiary = getAccountLocationV2(omniPoolAddress)
+	const beneficiary = getAccountLocationV2(omnipoolAddress)
 
 	const signedTx = spiritnetContext.api.tx.polkadotXcm
 		.limitedReserveTransferAssets(hydraDxDestination, beneficiary, KILT_ASSET_V2, 0, 'Unlimited')

--- a/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV3.test.ts
+++ b/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV3.test.ts
@@ -16,14 +16,18 @@ test('Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx', asy
 	// set storage
 	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address]))
 	await setStorage(hydradxContext, HydraDxConfig.assignNativeTokensToAccounts([keysAlice.address]))
+	// Set balance to 0 for HydraDX sovereign account on Spiritnet
+	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([SpiritnetConfig.hydraDxSovereignAccount], BigInt(0)))
+	// Set KILT balance to 0 for Omnipool account on HydraDx
+	await setStorage(hydradxContext, HydraDxConfig.assignKiltTokensToAccounts([HydraDxConfig.omnipoolAccount], BigInt(0)))
 
 	// check initial balance
-	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect)
-	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect)
+	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect, BigInt(0))
+	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect, BigInt(0))
 
-	const omniPoolAddress = hexAddress(HydraDxConfig.omnipoolAccount)
+	const omnipoolAddress = hexAddress(HydraDxConfig.omnipoolAccount)
 	const hydraDxDestination = { V3: getSiblingLocation(HydraDxConfig.paraId) }
-	const beneficiary = getAccountLocationV3(omniPoolAddress)
+	const beneficiary = getAccountLocationV3(omnipoolAddress)
 
 	const signedTx = spiritnetContext.api.tx.polkadotXcm
 		.limitedReserveTransferAssets(hydraDxDestination, beneficiary, KILT_ASSET_V3, 0, 'Unlimited')

--- a/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV3.test.ts
+++ b/integration-tests/chopsticks/src/tests/xcm/limitedReserveTransferSpiritnetHydraDxV3.test.ts
@@ -3,31 +3,35 @@ import { sendTransaction, withExpect } from '@acala-network/chopsticks-testing'
 
 import * as SpiritnetConfig from '../../network/spiritnet.js'
 import * as HydraDxConfig from '../../network/hydraDx.js'
-import { KILT, keysAlice } from '../../utils.js'
+import { KILT, initialBalanceKILT, keysAlice } from '../../utils.js'
 import { spiritnetContext, hydradxContext, getFreeBalanceSpiritnet, getFreeBalanceHydraDxKilt } from '../index.js'
 import { getAccountLocationV3, getNativeAssetIdLocation, getSiblingLocation } from '../../network/utils.js'
-import { checkBalance, createBlock, hexAddress, setStorage } from '../utils.js'
+import { checkBalance, checkBalanceInRange, createBlock, hexAddress, setStorage } from '../utils.js'
 
 const KILT_ASSET_V3 = { V3: [getNativeAssetIdLocation(KILT)] }
 
-test('Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx', async ({ expect }) => {
+test('Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx Account Alice', async ({ expect }) => {
 	const { checkEvents, checkSystemEvents } = withExpect(expect)
 
-	// set storage
-	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address]))
-	await setStorage(hydradxContext, HydraDxConfig.assignNativeTokensToAccounts([keysAlice.address]))
-	// Set balance to 0 for HydraDX sovereign account on Spiritnet
-	await setStorage(spiritnetContext, SpiritnetConfig.assignNativeTokensToAccounts([SpiritnetConfig.hydraDxSovereignAccount], BigInt(0)))
-	// Set KILT balance to 0 for Omnipool account on HydraDx
-	await setStorage(hydradxContext, HydraDxConfig.assignKiltTokensToAccounts([HydraDxConfig.omnipoolAccount], BigInt(0)))
+	// Assign alice some KILT tokens
+	await setStorage(
+		spiritnetContext,
+		SpiritnetConfig.assignNativeTokensToAccounts([keysAlice.address], initialBalanceKILT)
+	)
 
-	// check initial balance
-	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect, BigInt(0))
-	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect, BigInt(0))
+	// Balance of the hydraDx sovereign account before the transfer
+	const hydraDxSovereignAccountBalanceBeforeTransfer = await getFreeBalanceSpiritnet(
+		SpiritnetConfig.hydraDxSovereignAccount
+	)
 
-	const omnipoolAddress = hexAddress(HydraDxConfig.omnipoolAccount)
+	// check initial balance of Alice on Spiritnet
+	await checkBalance(getFreeBalanceSpiritnet, keysAlice.address, expect, initialBalanceKILT)
+	// Alice should have NO KILT on HydraDx
+	await checkBalance(getFreeBalanceHydraDxKilt, keysAlice.address, expect, BigInt(0))
+
+	const aliceAddress = hexAddress(keysAlice.address)
 	const hydraDxDestination = { V3: getSiblingLocation(HydraDxConfig.paraId) }
-	const beneficiary = getAccountLocationV3(omnipoolAddress)
+	const beneficiary = getAccountLocationV3(aliceAddress)
 
 	const signedTx = spiritnetContext.api.tx.polkadotXcm
 		.limitedReserveTransferAssets(hydraDxDestination, beneficiary, KILT_ASSET_V3, 0, 'Unlimited')
@@ -43,8 +47,20 @@ test('Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx', asy
 	checkEvents(events, 'polkadotXcm').toMatchSnapshot('sender events xcm pallet')
 	checkEvents(events, { section: 'balances', method: 'Withdraw' }).toMatchSnapshot('sender events Balances')
 
+	// check balance. The sovereign account should hold one additional KILT.
+	await checkBalance(
+		getFreeBalanceSpiritnet,
+		SpiritnetConfig.hydraDxSovereignAccount,
+		expect,
+		hydraDxSovereignAccountBalanceBeforeTransfer + KILT
+	)
+
 	// check balance sender
-	await checkBalance(getFreeBalanceSpiritnet, SpiritnetConfig.hydraDxSovereignAccount, expect, KILT)
+	// Equal to `initialBalanceKILT - KILT` - tx fees
+	await checkBalanceInRange(getFreeBalanceSpiritnet, keysAlice.address, expect, [
+		BigInt('98999830999996320'),
+		BigInt('98999830999996321'),
+	])
 
 	// Check receiver state
 	await createBlock(hydradxContext)
@@ -56,5 +72,9 @@ test('Limited Reserve V3 Transfers from Spiritnet Account Alice -> HydraDx', asy
 	checkSystemEvents(hydradxContext, 'xcmpQueue').toMatchSnapshot('receiver events xcmpQueue')
 
 	// check balance receiver
-	await checkBalance(getFreeBalanceHydraDxKilt, HydraDxConfig.omnipoolAccount, expect, KILT)
+	// check balance. Equal to `KILT` - tx fees
+	await checkBalanceInRange(getFreeBalanceHydraDxKilt, aliceAddress, expect, [
+		BigInt(996349465529793),
+		BigInt(996349465529796),
+	])
 }, 20_000)


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3344.

Integration tests are outdated. Since KILT is now listed on HydraDX, any tokens sent to the Omnipool account is automatically transferred to the treasury, which makes the test cases fail. The integration test logic must be updated to test the following:

1. Send KILT tokens from a KILT account to **its own** sovereign account on HydraDX (implementation started in this PR for the V2 tests)
2. Send KILT tokens from HydraDX back to KILT (to implement in this PR)