### PR TITLE
chore: add new intermediate profile for unoptimized releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,16 @@ members = [
 ]
 
 [profile.release]
+codegen-units = 1
 lto = "fat"
 panic = "unwind"
+
+# Defaults for `release` profiles as specified in https://doc.rust-lang.org/cargo/reference/profiles.html#release
+[profile.release-unoptimized]
+inherits = "release"
+codegen-units = 16
+incremental = true
+lto = false
 
 [workspace.dependencies]
 # Build deps


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3401.

The `lto = "fat"` settings results in much longer compilation times which are often not required for quick testing or prototyping where the default `debug` profile is too slow. This PR adds a new build profile called `release-unoptimized` which can be called with `cargo build --profile release-unoptimized` and puts build artifacts in the `target/release-unoptimized` folder. The default `--release` profile has one more flag `codegen-units = 1` which, according to the [documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units) reduces compilation times but increases performance of the compiled binary. Parity also [uses this](https://github.com/paritytech/polkadot-sdk/blob/313fe0f9a277f27a4228634f0fb15a1c3fa21271/Cargo.toml#L588) for their production profile.