### PR TITLE
fix: CLI 

### DIFF
--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -158,14 +158,14 @@ pub(crate) fn run() -> sc_cli::Result<()> {
 		Some(Subcommand::Benchmark(cmd)) => {
 
 			let shared_params = match cmd {
-				BenchmarkCmd::Block(c) => &c.shared_params,  
-				BenchmarkCmd::Pallet(c) => &c.shared_params,  
+				BenchmarkCmd::Block(c) => &c.shared_params,
+				BenchmarkCmd::Pallet(c) => &c.shared_params,
 				BenchmarkCmd::Extrinsic(c) => &c.shared_params,
-				BenchmarkCmd::Machine(c) => &c.shared_params, 
-				BenchmarkCmd::Overhead(c) => &c.shared_params,  
+				BenchmarkCmd::Machine(c) => &c.shared_params,
+				BenchmarkCmd::Overhead(c) => &c.shared_params,
 				BenchmarkCmd::Storage(c) => &c.shared_params,
 			};
- 
+
 			let (_, runtime) = get_selected_chainspec(shared_params)?;
 
 			let runner = cli.create_runner(cmd)?;

--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -35,7 +35,7 @@ use crate::{
 
 // Returns the provided (`--chain`, <selected_runtime>) given only a reference
 // to the global `Cli` object.
- 
+
 fn get_selected_chainspec(params: &sc_cli::SharedParams) -> Result<(String, ParachainRuntime), sc_cli::Error> {
 	let chain_id = params.chain_id(params.is_dev());
 	let runtime = chain_id.parse::<ParachainRuntime>().map_err(sc_cli::Error::Input)?;
@@ -167,8 +167,6 @@ pub(crate) fn run() -> sc_cli::Result<()> {
 			};
  
 			let (_, runtime) = get_selected_chainspec(shared_params)?;
-
-			println!("Benchmarking runtime: {runtime}."	);
 
 			let runner = cli.create_runner(cmd)?;
 


### PR DESCRIPTION
`cli.run.base` is used to run the node (providing no CLI argument), which is not the case for benchmarking, exporting WASM, or other tools. The `SharedParameter` struct was empty, even if the flags were set in the CLI.

By using the `SharedParameters` from the subcommands, CLI flags are taken into account.

