### PR TITLE
fix: properly handle dust from XCM execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,6 +7451,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "staging-xcm",
+ "staging-xcm-builder",
  "staging-xcm-executor",
 ]
 

--- a/pallets/pallet-asset-swap/Cargo.toml
+++ b/pallets/pallet-asset-swap/Cargo.toml
@@ -28,6 +28,7 @@ sp-io              = { workspace = true }
 sp-runtime         = { workspace = true }
 sp-std             = { workspace = true }
 xcm                = { workspace = true }
+xcm-builder        = { workspace = true }
 xcm-executor       = { workspace = true }
 
 [features]
@@ -41,6 +42,7 @@ std = [
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
+  "xcm-builder/std",
   "xcm-executor/std",
   "xcm/std",
 ]

--- a/pallets/pallet-asset-swap/README.md
+++ b/pallets/pallet-asset-swap/README.md
@@ -2,7 +2,6 @@ WIP.
 
 # TODO
 
-* [REQUIRED FOR V1] Implement `Drop` for XCM transactors.
 * [REQUIRED FOR V2] Add hook to check the swap parameters (restricting where remote assets can be sent to).
 * [REQUIRED FOR V2] Add constraints about which beneficiary people can send their tokens to.
 * [REQUIRED FOR V2] Make sure XCM fee asset can only be used for local XCM fees when transferring the asset itself, if possible.

--- a/pallets/pallet-asset-swap/src/xcm/trade.rs
+++ b/pallets/pallet-asset-swap/src/xcm/trade.rs
@@ -18,13 +18,10 @@
 
 pub use xcm_fee_asset::UsingComponentsForXcmFeeAsset;
 mod xcm_fee_asset {
-	use frame_support::{traits::fungibles::Inspect, weights::WeightToFee as WeightToFeeT};
-	use sp_runtime::{
-		traits::{Saturating, Zero},
-		SaturatedConversion,
-	};
+	use frame_support::{ensure, weights::WeightToFee as WeightToFeeT};
+	use sp_runtime::traits::Zero;
 	use sp_std::marker::PhantomData;
-	use xcm::v3::{AssetId, Error, MultiAsset, Weight, XcmContext};
+	use xcm::v3::{AssetId, Error, MultiAsset, Weight, XcmContext, XcmHash};
 	use xcm_executor::{traits::WeightTrader, Assets};
 
 	use crate::{Config, SwapPair};
@@ -36,53 +33,87 @@ mod xcm_fee_asset {
 	///
 	/// This trader is required in case there is no other mechanism to pay for
 	/// fees when transferring such an asset to this chain.
-	pub struct UsingComponentsForXcmFeeAsset<T: frame_system::Config, WeightToFee, Fungibles: Inspect<T::AccountId>>(
-		Weight,
-		Fungibles::Balance,
-		PhantomData<(T, WeightToFee)>,
-	);
-
-	impl<T, WeightToFee, Fungibles> WeightTrader for UsingComponentsForXcmFeeAsset<T, WeightToFee, Fungibles>
+	pub struct UsingComponentsForXcmFeeAsset<T, WeightToFee>
 	where
 		T: Config,
-		WeightToFee: WeightToFeeT<Balance = Fungibles::Balance>,
-		Fungibles: Inspect<T::AccountId>,
+	{
+		remaining_weight: Weight,
+		remaining_fungible_balance: u128,
+		consumed_xcm_hash: Option<XcmHash>,
+		_phantom: PhantomData<(T, WeightToFee)>,
+	}
+
+	impl<T, WeightToFee> WeightTrader for UsingComponentsForXcmFeeAsset<T, WeightToFee>
+	where
+		T: Config,
+
+		WeightToFee: WeightToFeeT<Balance = u128>,
 	{
 		fn new() -> Self {
-			Self(Weight::zero(), Zero::zero(), PhantomData)
+			Self {
+				consumed_xcm_hash: None,
+				remaining_fungible_balance: Zero::zero(),
+				remaining_weight: Zero::zero(),
+				_phantom: PhantomData,
+			}
 		}
 
 		fn buy_weight(&mut self, weight: Weight, payment: Assets, context: &XcmContext) -> Result<Assets, Error> {
 			log::info!(target: LOG_TARGET, "buy_weight {:?}, {:?}, {:?}", weight, payment, context);
+
+			// Prevent re-using the same trader more than once.
+			ensure!(self.consumed_xcm_hash.is_none(), Error::NotWithdrawable);
+			// Asset not relevant if no swap pair is set.
 			let swap_pair = SwapPair::<T>::get().ok_or(Error::AssetNotFound)?;
+
 			let amount = WeightToFee::weight_to_fee(&weight);
-			let u128_amount: u128 = amount.try_into().map_err(|_| Error::Overflow)?;
+
 			let xcm_fee_asset_v3: MultiAsset = swap_pair.remote_fee.clone().try_into().map_err(|e| {
-				log::error!(target: "xcm::weight", "Failed to convert stored asset ID {:?} into v3 MultiAsset with error {:?}", swap_pair.remote_fee, e);
+				log::error!(target: LOG_TARGET, "Failed to convert stored asset ID {:?} into v3 MultiAsset with error {:?}", swap_pair.remote_fee, e);
 				Error::FailedToTransactAsset("Failed to convert swap pair asset ID into required version.")
 			})?;
-			let required: MultiAsset = (xcm_fee_asset_v3.id, u128_amount).into();
+
+			let required: MultiAsset = (xcm_fee_asset_v3.id, amount).into();
 			let unused = payment.checked_sub(required.clone()).map_err(|_| Error::TooExpensive)?;
-			log::trace!(target: LOG_TARGET, "required {:?} - unused {:?}", required, unused);
-			self.0 = self.0.saturating_add(weight);
-			self.1 = self.1.saturating_add(amount);
+
+			// Set link to XCM message ID only if this is the trader used.
+			log::trace!(target: LOG_TARGET, "Required {:?} - unused {:?}", required, unused);
+			self.consumed_xcm_hash = Some(context.message_id);
+			self.remaining_fungible_balance = self.remaining_fungible_balance.saturating_add(amount);
+			self.remaining_weight = self.remaining_weight.saturating_add(weight);
+
 			Ok(unused)
 		}
 
 		fn refund_weight(&mut self, weight: Weight, context: &XcmContext) -> Option<MultiAsset> {
 			log::info!(target: LOG_TARGET, "refund_weight weight: {:?} {:?}", weight, context);
-			let swap_pair = SwapPair::<T>::get()?;
+
+			// Ensure we refund in the same trader we took fees from.
+			if Some(context.message_id) != self.consumed_xcm_hash {
+				return None;
+			};
+
+			let Some(swap_pair) = SwapPair::<T>::get() else {
+				log::error!(target: LOG_TARGET, "Stored swap pair should not be None, but it is.");
+				return None;
+			};
+
 			let remote_asset_id_v3: AssetId = swap_pair.remote_asset_id.clone().try_into().map_err(|e| {
 				log::error!(target: LOG_TARGET, "Failed to convert stored asset ID {:?} into v3 AssetId with error {:?}", swap_pair.remote_asset_id, e);
 				e
 			}).ok()?;
-			let weight = weight.min(self.0);
+
+			let weight = weight.min(self.remaining_weight);
 			let amount = WeightToFee::weight_to_fee(&weight);
-			self.0 -= weight;
-			self.1 = self.1.saturating_sub(amount);
-			let amount: u128 = amount.saturated_into();
+
+			self.consumed_xcm_hash = None;
+			self.remaining_fungible_balance = self
+				.remaining_fungible_balance
+				.saturating_sub(self.remaining_fungible_balance);
+			self.remaining_weight = self.remaining_weight.saturating_sub(weight);
+
 			if amount > 0 {
-				log::trace!(target: LOG_TARGET, "refund amount {:?}", (remote_asset_id_v3, amount));
+				log::trace!(target: LOG_TARGET, "Refund amount {:?}", (remote_asset_id_v3, amount));
 				Some((remote_asset_id_v3, amount).into())
 			} else {
 				log::trace!(target: LOG_TARGET, "No refund");
@@ -90,17 +121,32 @@ mod xcm_fee_asset {
 			}
 		}
 	}
+
+	// We burn whatever surplus we have since we know we control it at destination.
+	impl<T, WeightToFee> Drop for UsingComponentsForXcmFeeAsset<T, WeightToFee>
+	where
+		T: Config,
+	{
+		fn drop(&mut self) {
+			log::trace!(target: LOG_TARGET, "Drop with remaining {:?}", (self.consumed_xcm_hash, self.remaining_fungible_balance, self.remaining_weight));
+		}
+	}
 }
 
 pub use swap_pair_remote_asset::UsingComponentsForSwapPairRemoteAsset;
 mod swap_pair_remote_asset {
-	use frame_support::weights::WeightToFee as WeightToFeeT;
-	use sp_runtime::{traits::Zero, SaturatedConversion};
+	use frame_support::{
+		ensure,
+		traits::{fungible::Mutate, tokens::Preservation},
+		weights::WeightToFee as WeightToFeeT,
+	};
+	use sp_core::Get;
+	use sp_runtime::traits::Zero;
 	use sp_std::marker::PhantomData;
-	use xcm::v3::{AssetId, Error, MultiAsset, Weight, XcmContext};
+	use xcm::v3::{AssetId, Error, MultiAsset, Weight, XcmContext, XcmHash};
 	use xcm_executor::{traits::WeightTrader, Assets};
 
-	use crate::{Config, SwapPair};
+	use crate::{Config, LocalCurrencyBalanceOf, SwapPair, SwapPairInfoOf};
 
 	const LOG_TARGET: &str = "xcm::pallet-asset-swap::UsingComponentsForSwapPairRemoteAsset";
 
@@ -109,55 +155,146 @@ mod swap_pair_remote_asset {
 	///
 	/// This trader is required in case there is no other mechanism to pay for
 	/// fees when transferring such an asset to this chain.
-	pub struct UsingComponentsForSwapPairRemoteAsset<T: frame_system::Config, WeightToFee>(
-		Weight,
-		u128,
-		PhantomData<(T, WeightToFee)>,
-	);
-
-	impl<T, WeightToFee> WeightTrader for UsingComponentsForSwapPairRemoteAsset<T, WeightToFee>
+	///
+	/// Any unused fee is transferred from the swap pair pool account to the
+	/// specified account.
+	#[derive(Default)]
+	pub struct UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
 	where
 		T: Config,
+		FeeDestinationAccount: Get<T::AccountId>,
+	{
+		remaining_weight: Weight,
+		remaining_fungible_balance: u128,
+		consumed_xcm_hash: Option<XcmHash>,
+		swap_pair: Option<SwapPairInfoOf<T>>,
+		_phantom: PhantomData<(WeightToFee, FeeDestinationAccount)>,
+	}
+
+	impl<T, WeightToFee, FeeDestinationAccount> WeightTrader
+		for UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
+	where
+		T: Config,
+		FeeDestinationAccount: Get<T::AccountId>,
+
 		WeightToFee: WeightToFeeT<Balance = u128>,
 	{
 		fn new() -> Self {
-			Self(Weight::zero(), Zero::zero(), PhantomData)
+			let swap_pair = SwapPair::<T>::get();
+			Self {
+				consumed_xcm_hash: None,
+				remaining_fungible_balance: Zero::zero(),
+				remaining_weight: Zero::zero(),
+				swap_pair,
+				_phantom: PhantomData,
+			}
 		}
 
 		fn buy_weight(&mut self, weight: Weight, payment: Assets, context: &XcmContext) -> Result<Assets, Error> {
 			log::info!(target: LOG_TARGET, "buy_weight {:?}, {:?}, {:?}", weight, payment, context);
-			let swap_pair = SwapPair::<T>::get().ok_or(Error::AssetNotFound)?;
+
+			// Prevent re-using the same trader more than once.
+			ensure!(self.consumed_xcm_hash.is_none(), Error::NotWithdrawable);
+			// Asset not relevant if no swap pair is set.
+			let swap_pair = self.swap_pair.as_ref().ok_or(Error::AssetNotFound)?;
+
 			let amount = WeightToFee::weight_to_fee(&weight);
+
 			let swap_pair_remote_asset_v3: AssetId = swap_pair.remote_asset_id.clone().try_into().map_err(|e| {
 				log::error!(target: LOG_TARGET, "Failed to convert stored asset ID {:?} into v3 AssetId with error {:?}", swap_pair.remote_asset_id, e);
 				Error::FailedToTransactAsset("Failed to convert swap pair asset ID into required version.")
 			})?;
+
 			let required: MultiAsset = (swap_pair_remote_asset_v3, amount).into();
 			let unused = payment.checked_sub(required.clone()).map_err(|_| Error::TooExpensive)?;
-			log::trace!(target: LOG_TARGET, "required {:?} - unused {:?}", required, unused);
-			self.0 = self.0.saturating_add(weight);
-			self.1 = self.1.saturating_add(amount);
+
+			// Set link to XCM message ID only if this is the trader used.
+			log::trace!(target: LOG_TARGET, "Required {:?} - unused {:?}", required, unused);
+			self.consumed_xcm_hash = Some(context.message_id);
+			self.remaining_fungible_balance = self.remaining_fungible_balance.saturating_add(amount);
+			self.remaining_weight = self.remaining_weight.saturating_add(weight);
+
 			Ok(unused)
 		}
 
 		fn refund_weight(&mut self, weight: Weight, context: &XcmContext) -> Option<MultiAsset> {
 			log::trace!(target: LOG_TARGET, "UsingComponents::refund_weight weight: {:?}, context: {:?}", weight, context);
-			let swap_pair = SwapPair::<T>::get()?;
+
+			// Ensure we refund in the same trader we took fees from.
+			if Some(context.message_id) != self.consumed_xcm_hash {
+				return None;
+			};
+
+			let Some(ref swap_pair) = self.swap_pair else {
+				log::error!(target: LOG_TARGET, "Stored swap pair should not be None, but it is.");
+				return None;
+			};
+
 			let swap_pair_remote_asset_v3: AssetId = swap_pair.remote_asset_id.clone().try_into().map_err(|e| {
 				log::error!(target: LOG_TARGET, "Failed to convert stored asset ID {:?} into v3 AssetId with error {:?}", swap_pair.remote_asset_id, e);
 				Error::FailedToTransactAsset("Failed to convert swap pair asset ID into required version.")
 			}).ok()?;
-			let weight = weight.min(self.0);
+
+			let weight = weight.min(self.remaining_weight);
 			let amount = WeightToFee::weight_to_fee(&weight);
-			self.0 -= weight;
-			self.1 = self.1.saturating_sub(amount);
-			let amount: u128 = amount.saturated_into();
+
+			self.consumed_xcm_hash = None;
+			self.remaining_fungible_balance = self
+				.remaining_fungible_balance
+				.saturating_sub(self.remaining_fungible_balance);
+			self.remaining_weight = self.remaining_weight.saturating_sub(weight);
+
 			if amount > 0 {
-				log::trace!(target: LOG_TARGET, "refund amount {:?}", (swap_pair_remote_asset_v3, amount));
+				log::trace!(target: LOG_TARGET, "Refund amount {:?}", (swap_pair_remote_asset_v3, amount));
 				Some((swap_pair_remote_asset_v3, amount).into())
 			} else {
 				log::trace!(target: LOG_TARGET, "No refund");
 				None
+			}
+		}
+	}
+
+	// Move any unused asset from the swap pool account to the specified account,
+	// and update the remote balance with the difference since we know we control
+	// the full amount on the remote location.
+	impl<T, WeightToFee, FeeDestinationAccount> Drop
+		for UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
+	where
+		T: Config,
+		FeeDestinationAccount: Get<T::AccountId>,
+	{
+		fn drop(&mut self) {
+			log::trace!(target: LOG_TARGET, "Drop with remaining {:?}", (self.consumed_xcm_hash, self.remaining_fungible_balance, self.remaining_weight, &self.swap_pair));
+			match (self.remaining_fungible_balance, &self.swap_pair) {
+				(remaining_balance, Some(swap_pair)) if remaining_balance > Zero::zero() => {
+					let Ok(remaining_balance_as_local_currency) = LocalCurrencyBalanceOf::<T>::try_from(remaining_balance).map_err(|e| {
+						log::error!(target: LOG_TARGET, "Failed to convert remaining balance {:?} to local currency balance", remaining_balance);
+						e
+					}) else { return; };
+
+					// No error should ever be thrown from inside this block.
+					let _ = <T::LocalCurrency as Mutate<T::AccountId>>::transfer(
+						&swap_pair.pool_account,
+						&FeeDestinationAccount::get(),
+						remaining_balance_as_local_currency,
+						Preservation::Expendable,
+					).map_err(|e| {
+						log::error!(target: LOG_TARGET, "Failed to transfer unused balance {:?} from swap pair pool account {:?} to specified account {:?}", remaining_balance_as_local_currency, swap_pair.pool_account, FeeDestinationAccount::get());
+						e
+					});
+
+					// No error should ever be thrown from inside this block.
+					SwapPair::<T>::mutate(|entry| {
+						let Some(entry) = entry.as_mut() else {
+							log::error!(target: LOG_TARGET, "Stored swap pair should not be None but it is.");
+							return;
+						};
+						entry.remote_asset_balance = entry
+							.remote_asset_balance
+							.saturating_add(self.remaining_fungible_balance);
+					});
+				}
+				_ => {}
 			}
 		}
 	}

--- a/pallets/pallet-asset-swap/src/xcm/trade.rs
+++ b/pallets/pallet-asset-swap/src/xcm/trade.rs
@@ -292,16 +292,9 @@ mod swap_pair_remote_asset {
 							log::error!(target: LOG_TARGET, "Stored swap pair should not be None but it is.");
 							return;
 						};
-						let new_remote_asset_balance = entry
+						entry.remote_asset_balance = entry
 							.remote_asset_balance
-							// If `add` overflows, log a warning and saturate to max.
-							.checked_add(self.remaining_fungible_balance).unwrap_or_else(|| {
-								log::warn!(target: LOG_TARGET, "Overflow found when adding {:?} to remote asset balance {:?}", self.remaining_fungible_balance, entry
-								.remote_asset_balance);
-								// Should always be `u128::MAX`, but we return a saturating `add` anyway.
-								entry.remote_asset_balance.saturating_add(self.remaining_fungible_balance)
-							});
-						entry.remote_asset_balance = new_remote_asset_balance
+							.saturating_add(self.remaining_fungible_balance);
 					});
 				}
 			}

--- a/pallets/pallet-asset-swap/src/xcm/trade.rs
+++ b/pallets/pallet-asset-swap/src/xcm/trade.rs
@@ -292,9 +292,16 @@ mod swap_pair_remote_asset {
 							log::error!(target: LOG_TARGET, "Stored swap pair should not be None but it is.");
 							return;
 						};
-						entry.remote_asset_balance = entry
+						let new_remote_asset_balance = entry
 							.remote_asset_balance
-							.saturating_add(self.remaining_fungible_balance);
+							// If `add` overflows, log a warning and saturate to max.
+							.checked_add(self.remaining_fungible_balance).unwrap_or_else(|| {
+								log::warn!(target: LOG_TARGET, "Overflow found when adding {:?} to remote asset balance {:?}", self.remaining_fungible_balance, entry
+								.remote_asset_balance);
+								// Should always be `u128::MAX`, but we return a saturating `add` anyway.
+								entry.remote_asset_balance.saturating_add(self.remaining_fungible_balance)
+							});
+						entry.remote_asset_balance = new_remote_asset_balance
 					});
 				}
 			}

--- a/pallets/pallet-asset-swap/src/xcm/transfer.rs
+++ b/pallets/pallet-asset-swap/src/xcm/transfer.rs
@@ -77,7 +77,7 @@ mod swap_pair_remote_asset {
 
 	use crate::{Config, SwapPair};
 
-	const LOG_TARGET: &str = "xcm::pallet-asset-swap::AllowSwapPairRemoteAsset";
+	const LOG_TARGET: &str = "xcm::barriers::pallet-asset-swap::AllowSwapPairRemoteAsset";
 
 	/// Type implementing `ContainsPair<MultiAsset, MultiLocation>` and returns
 	/// `true` if the specified asset matches the swap pair remote asset, which


### PR DESCRIPTION
The numbers did not match up between what the swap pallet thought the remote balance was, and what the actual remote balance is. This is because there was some dust in the trader `drop()` function we did not handle. That is fixed now, so that whenever a eKILT -> KILT swap happens, the following two things also happen:

1. The amount of remote balance is increased not only by the amount of eKILTs (after XCM fees are taken) being swapped, but also by the amount of fees taken as part of the XCM operation. Now, the real value and the tracked value in the swap pallet always stay consistent.
2. The same corresponding amount of KILTs that are now not swappable because some eKILTs have been used to pay for XCM fees are sent to a configurable account ID (which in the [Peregrine configuration](https://github.com/KILTprotocol/kilt-node/pull/659) is the treasury account). So now the balance of the pool account matches exactly the number of eKILTs that have been swapped back to KILTs.

Based on top of https://github.com/KILTprotocol/kilt-node/pull/660.