### PR TITLE
feat: support runtime-injected logic for swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9244,6 +9244,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "delegation",
  "did",
+ "enum-iterator",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/pallets/pallet-asset-swap/README.md
+++ b/pallets/pallet-asset-swap/README.md
@@ -2,8 +2,6 @@ WIP.
 
 # TODO
 
-* [REQUIRED FOR V2] Add hook to check the swap parameters (restricting where remote assets can be sent to).
-* [REQUIRED FOR V2] Add constraints about which beneficiary people can send their tokens to.
 * [REQUIRED FOR V2] Make sure XCM fee asset can only be used for local XCM fees when transferring the asset itself, if possible.
 * [REQUIRED FOR V2] Unit test the different XCM components.
 * [REQUIRED FOR V2] Add try-runtime support.

--- a/pallets/pallet-asset-swap/src/mock.rs
+++ b/pallets/pallet-asset-swap/src/mock.rs
@@ -183,6 +183,7 @@ impl crate::Config for MockRuntime {
 	type PauseOrigin = EnsureRoot<Self::AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type SubmitterOrigin = EnsureSigned<Self::AccountId>;
+	type SwapHooks = ();
 	type SwapOrigin = EnsureRoot<Self::AccountId>;
 	type XcmRouter = AlwaysSuccessfulXcmRouter;
 }

--- a/pallets/pallet-asset-swap/src/traits.rs
+++ b/pallets/pallet-asset-swap/src/traits.rs
@@ -37,6 +37,10 @@ where
 		to: &VersionedMultiLocation,
 		amount: LocalCurrencyBalanceOf<T>,
 	) -> Result<(), Self::Error>;
+
+	fn pre_remote_to_local_swap(to: &T::AccountId, amount: u128) -> Result<(), Self::Error>;
+
+	fn post_remote_to_local_swap(to: &T::AccountId, amount: u128) -> Result<(), Self::Error>;
 }
 
 impl<T> SwapHooks<T> for ()
@@ -58,6 +62,14 @@ where
 		_to: &VersionedMultiLocation,
 		_amount: LocalCurrencyBalanceOf<T>,
 	) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn pre_remote_to_local_swap(_to: &<T>::AccountId, _amount: u128) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn post_remote_to_local_swap(_to: &<T>::AccountId, _amount: u128) -> Result<(), Self::Error> {
 		Ok(())
 	}
 }

--- a/pallets/pallet-asset-swap/src/traits.rs
+++ b/pallets/pallet-asset-swap/src/traits.rs
@@ -1,0 +1,63 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use xcm::VersionedMultiLocation;
+
+use crate::{Config, LocalCurrencyBalanceOf};
+
+pub trait SwapHooks<T>
+where
+	T: Config,
+{
+	type Error: Into<u8>;
+
+	fn pre_local_to_remote_swap(
+		from: &T::AccountId,
+		to: &VersionedMultiLocation,
+		amount: LocalCurrencyBalanceOf<T>,
+	) -> Result<(), Self::Error>;
+
+	fn post_local_to_remote_swap(
+		from: &T::AccountId,
+		to: &VersionedMultiLocation,
+		amount: LocalCurrencyBalanceOf<T>,
+	) -> Result<(), Self::Error>;
+}
+
+impl<T> SwapHooks<T> for ()
+where
+	T: Config,
+{
+	type Error = u8;
+
+	fn pre_local_to_remote_swap(
+		_from: &T::AccountId,
+		_to: &VersionedMultiLocation,
+		_amount: LocalCurrencyBalanceOf<T>,
+	) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn post_local_to_remote_swap(
+		_from: &T::AccountId,
+		_to: &VersionedMultiLocation,
+		_amount: LocalCurrencyBalanceOf<T>,
+	) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -14,7 +14,8 @@ version       = { workspace = true }
 substrate-wasm-builder = { workspace = true }
 
 [dev-dependencies]
-sp-io = { workspace = true }
+enum-iterator = { workspace = true }
+sp-io         = { workspace = true }
 
 [dependencies]
 # External dependencies

--- a/runtimes/peregrine/src/asset_swap/mod.rs
+++ b/runtimes/peregrine/src/asset_swap/mod.rs
@@ -65,6 +65,14 @@ impl SwapHooks<Runtime> for RestrictSwapDestinationToSelf {
 	) -> Result<(), Self::Error> {
 		Ok(())
 	}
+
+	fn pre_remote_to_local_swap(_to: &AccountId, _amount: u128) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn post_remote_to_local_swap(_to: &AccountId, _amount: u128) -> Result<(), Self::Error> {
+		Ok(())
+	}
 }
 
 #[cfg_attr(test, derive(enum_iterator::Sequence))]

--- a/runtimes/peregrine/src/asset_swap/mod.rs
+++ b/runtimes/peregrine/src/asset_swap/mod.rs
@@ -1,0 +1,99 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use frame_support::ensure;
+use pallet_asset_swap::traits::SwapHooks;
+use runtime_common::{AccountId, Balance};
+use xcm::{
+	v3::{Junction, MultiLocation},
+	VersionedMultiLocation,
+};
+
+use crate::Runtime;
+
+const LOG_TARGET: &str = "runtime::peregrine::asset-swap::RestrictTransfersToSameUser";
+
+/// Check requiring the beneficiary be a single `AccountId32` junction
+/// containing the same account ID as the account on this chain initiating the
+/// swap.
+pub struct RestrictTransfersToSameUser;
+
+impl SwapHooks<Runtime> for RestrictTransfersToSameUser {
+	type Error = Error;
+
+	fn pre_local_to_remote_swap(
+		from: &AccountId,
+		to: &VersionedMultiLocation,
+		_amount: Balance,
+	) -> Result<(), Self::Error> {
+		let to_as_v3: MultiLocation = to.clone().try_into().map_err(|e| {
+			log::error!(target: LOG_TARGET, "Failed to convert beneficiary Multilocation {:?} to v3 with error {:?}", to, e);
+			Error::Internal
+		})?;
+		ensure!(
+			to_as_v3.interior
+				== Junction::AccountId32 {
+					network: None,
+					id: from.clone().into()
+				}
+				.into(),
+			Error::NotToSelf
+		);
+		Ok(())
+	}
+
+	// We don't need to take any actions after the swap is executed
+	fn post_local_to_remote_swap(
+		_from: &AccountId,
+		_to: &VersionedMultiLocation,
+		_amount: Balance,
+	) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}
+
+#[cfg_attr(test, derive(enum_iterator::Sequence))]
+pub enum Error {
+	NotToSelf,
+	Internal,
+}
+
+impl From<Error> for u8 {
+	fn from(value: Error) -> Self {
+		match value {
+			Error::NotToSelf => 0,
+			Error::Internal => Self::MAX,
+		}
+	}
+}
+
+#[test]
+fn error_value_not_duplicated() {
+	enum_iterator::all::<Error>().fold(
+		sp_std::collections::btree_set::BTreeSet::<u8>::new(),
+		|mut values, new_value| {
+			let new_encoded_value = u8::from(new_value);
+			assert!(
+				values.insert(new_encoded_value),
+				"Failed to add unique value {:#?} for error variant",
+				new_encoded_value
+			);
+			values
+		},
+	);
+}

--- a/runtimes/peregrine/src/asset_swap/mod.rs
+++ b/runtimes/peregrine/src/asset_swap/mod.rs
@@ -31,9 +31,9 @@ const LOG_TARGET: &str = "runtime::peregrine::asset-swap::RestrictTransfersToSam
 /// Check requiring the beneficiary be a single `AccountId32` junction
 /// containing the same account ID as the account on this chain initiating the
 /// swap.
-pub struct RestrictTransfersToSameUser;
+pub struct RestrictSwapDestinationToSelf;
 
-impl SwapHooks<Runtime> for RestrictTransfersToSameUser {
+impl SwapHooks<Runtime> for RestrictSwapDestinationToSelf {
 	type Error = Error;
 
 	fn pre_local_to_remote_swap(

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -84,6 +84,7 @@ use frame_try_runtime::UpgradeCheckSelect;
 #[cfg(test)]
 mod tests;
 
+mod asset_swap;
 mod dip;
 mod weights;
 pub mod xcm_config;
@@ -963,6 +964,7 @@ impl pallet_asset_swap::Config for Runtime {
 	type PauseOrigin = EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type SubmitterOrigin = EnsureSigned<AccountId>;
+	type SwapHooks = asset_swap::RestrictTransfersToSameUser;
 	type SwapOrigin = EnsureRoot<AccountId>;
 	type XcmRouter = XcmRouter;
 }

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -964,7 +964,7 @@ impl pallet_asset_swap::Config for Runtime {
 	type PauseOrigin = EnsureRoot<AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type SubmitterOrigin = EnsureSigned<AccountId>;
-	type SwapHooks = asset_swap::RestrictTransfersToSameUser;
+	type SwapHooks = asset_swap::RestrictSwapDestinationToSelf;
 	type SwapOrigin = EnsureRoot<AccountId>;
 	type XcmRouter = XcmRouter;
 }


### PR DESCRIPTION
WIP.

Based on top of https://github.com/KILTprotocol/kilt-node/pull/659.

## Checklist

- [x] Add hook to disallow swaps to a different remote beneficiary

Given the current XCM executor logic, specifically the appending of a `ClearOrigin` instruction right after a reserve-based transfer, it is not possible to make any judgments about the origin funds are coming from to our chain, hence it is not possible to apply any restrictions to those.