### PR TITLE
feat: instantiatable swap pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,6 +7461,7 @@ version = "1.14.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
+ "sp-std",
 ]
 
 [[package]]

--- a/pallets/pallet-asset-swap/README.md
+++ b/pallets/pallet-asset-swap/README.md
@@ -1,9 +1,1 @@
 WIP.
-
-# TODO
-
-* [REQUIRED FOR V2] Make sure XCM fee asset can only be used for local XCM fees when transferring the asset itself, if possible.
-* [REQUIRED FOR V2] Unit test the different XCM components.
-* [REQUIRED FOR V2] Add try-runtime support.
-* [REQUIRED FOR V2] Add benchmarks.
-* [OPTIONAL] Add configurable ratio for local/remote swaps.

--- a/pallets/pallet-asset-swap/README.md
+++ b/pallets/pallet-asset-swap/README.md
@@ -6,5 +6,4 @@ WIP.
 * [REQUIRED FOR V2] Unit test the different XCM components.
 * [REQUIRED FOR V2] Add try-runtime support.
 * [REQUIRED FOR V2] Add benchmarks.
-* [OPTIONAL] Make pallet possible to deploy multiple times within the same runtime.
 * [OPTIONAL] Add configurable ratio for local/remote swaps.

--- a/pallets/pallet-asset-swap/src/lib.rs
+++ b/pallets/pallet-asset-swap/src/lib.rs
@@ -151,7 +151,6 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> Pallet<T, I>
 	where
 		LocalCurrencyBalanceOf<T, I>: Into<u128>,
-		I: Encode,
 	{
 		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
@@ -472,7 +471,7 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config<I>, I: 'static + Encode> Pallet<T, I> {
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn set_swap_pair_bypass_checks(
 		reserve_location: VersionedMultiLocation,
 		remote_asset_id: VersionedAssetId,
@@ -543,7 +542,7 @@ impl<T: Config<I>, I: 'static + Encode> Pallet<T, I> {
 	}
 }
 
-impl<T: Config<I>, I: 'static + Encode> Pallet<T, I> {
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	pub fn pool_account_id_for_remote_asset(remote_asset_id: &VersionedAssetId) -> Result<T::AccountId, Error<T, I>> {
 		let pallet_name = <Pallet<T, I> as PalletInfoAccess>::name();
 		let pallet_name_hashed = sp_io::hashing::blake2_256(pallet_name.as_bytes());

--- a/pallets/pallet-asset-swap/src/mock.rs
+++ b/pallets/pallet-asset-swap/src/mock.rs
@@ -174,8 +174,6 @@ impl SendXcm for AlwaysSuccessfulXcmRouter {
 }
 
 impl crate::Config for MockRuntime {
-	const POOL_ADDRESS_GENERATION_ENTROPY: [u8; 8] = *b"eKILT/AH";
-
 	type AccountIdConverter = AccountId32ToAccountId32JunctionConverter;
 	type AssetTransactor = MockFungibleAssetTransactor;
 	type FeeOrigin = EnsureRoot<Self::AccountId>;

--- a/pallets/pallet-asset-swap/src/traits.rs
+++ b/pallets/pallet-asset-swap/src/traits.rs
@@ -20,22 +20,23 @@ use xcm::VersionedMultiLocation;
 
 use crate::{Config, LocalCurrencyBalanceOf};
 
-pub trait SwapHooks<T>
+pub trait SwapHooks<T, I>
 where
-	T: Config,
+	T: Config<I>,
+	I: 'static,
 {
 	type Error: Into<u8>;
 
 	fn pre_local_to_remote_swap(
 		from: &T::AccountId,
 		to: &VersionedMultiLocation,
-		amount: LocalCurrencyBalanceOf<T>,
+		amount: LocalCurrencyBalanceOf<T, I>,
 	) -> Result<(), Self::Error>;
 
 	fn post_local_to_remote_swap(
 		from: &T::AccountId,
 		to: &VersionedMultiLocation,
-		amount: LocalCurrencyBalanceOf<T>,
+		amount: LocalCurrencyBalanceOf<T, I>,
 	) -> Result<(), Self::Error>;
 
 	fn pre_remote_to_local_swap(to: &T::AccountId, amount: u128) -> Result<(), Self::Error>;
@@ -43,16 +44,17 @@ where
 	fn post_remote_to_local_swap(to: &T::AccountId, amount: u128) -> Result<(), Self::Error>;
 }
 
-impl<T> SwapHooks<T> for ()
+impl<T, I> SwapHooks<T, I> for ()
 where
-	T: Config,
+	T: Config<I>,
+	I: 'static,
 {
 	type Error = u8;
 
 	fn pre_local_to_remote_swap(
 		_from: &T::AccountId,
 		_to: &VersionedMultiLocation,
-		_amount: LocalCurrencyBalanceOf<T>,
+		_amount: LocalCurrencyBalanceOf<T, I>,
 	) -> Result<(), Self::Error> {
 		Ok(())
 	}
@@ -60,7 +62,7 @@ where
 	fn post_local_to_remote_swap(
 		_from: &T::AccountId,
 		_to: &VersionedMultiLocation,
-		_amount: LocalCurrencyBalanceOf<T>,
+		_amount: LocalCurrencyBalanceOf<T, I>,
 	) -> Result<(), Self::Error> {
 		Ok(())
 	}

--- a/pallets/pallet-asset-swap/src/xcm/trade.rs
+++ b/pallets/pallet-asset-swap/src/xcm/trade.rs
@@ -33,19 +33,21 @@ mod xcm_fee_asset {
 	///
 	/// This trader is required in case there is no other mechanism to pay for
 	/// fees when transferring such an asset to this chain.
-	pub struct UsingComponentsForXcmFeeAsset<T, WeightToFee>
+	pub struct UsingComponentsForXcmFeeAsset<T, I, WeightToFee>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 	{
 		remaining_weight: Weight,
 		remaining_fungible_balance: u128,
 		consumed_xcm_hash: Option<XcmHash>,
-		_phantom: PhantomData<(T, WeightToFee)>,
+		_phantom: PhantomData<(T, I, WeightToFee)>,
 	}
 
-	impl<T, WeightToFee> WeightTrader for UsingComponentsForXcmFeeAsset<T, WeightToFee>
+	impl<T, I, WeightToFee> WeightTrader for UsingComponentsForXcmFeeAsset<T, I, WeightToFee>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 
 		WeightToFee: WeightToFeeT<Balance = u128>,
 	{
@@ -64,7 +66,7 @@ mod xcm_fee_asset {
 			// Prevent re-using the same trader more than once.
 			ensure!(self.consumed_xcm_hash.is_none(), Error::NotWithdrawable);
 			// Asset not relevant if no swap pair is set.
-			let swap_pair = SwapPair::<T>::get().ok_or(Error::AssetNotFound)?;
+			let swap_pair = SwapPair::<T, I>::get().ok_or(Error::AssetNotFound)?;
 
 			let amount = WeightToFee::weight_to_fee(&weight);
 
@@ -93,7 +95,7 @@ mod xcm_fee_asset {
 				return None;
 			};
 
-			let Some(swap_pair) = SwapPair::<T>::get() else {
+			let Some(swap_pair) = SwapPair::<T, I>::get() else {
 				log::error!(target: LOG_TARGET, "Stored swap pair should not be None, but it is.");
 				return None;
 			};
@@ -123,9 +125,10 @@ mod xcm_fee_asset {
 	}
 
 	// We burn whatever surplus we have since we know we control it at destination.
-	impl<T, WeightToFee> Drop for UsingComponentsForXcmFeeAsset<T, WeightToFee>
+	impl<T, I, WeightToFee> Drop for UsingComponentsForXcmFeeAsset<T, I, WeightToFee>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 	{
 		fn drop(&mut self) {
 			log::trace!(target: LOG_TARGET, "Drop with remaining {:?}", (self.consumed_xcm_hash, self.remaining_fungible_balance, self.remaining_weight));
@@ -159,28 +162,30 @@ mod swap_pair_remote_asset {
 	/// Any unused fee is transferred from the swap pair pool account to the
 	/// specified account.
 	#[derive(Default)]
-	pub struct UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
+	pub struct UsingComponentsForSwapPairRemoteAsset<T, I, WeightToFee, FeeDestinationAccount>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 		FeeDestinationAccount: Get<T::AccountId>,
 	{
 		remaining_weight: Weight,
 		remaining_fungible_balance: u128,
 		consumed_xcm_hash: Option<XcmHash>,
 		swap_pair: Option<SwapPairInfoOf<T>>,
-		_phantom: PhantomData<(WeightToFee, FeeDestinationAccount)>,
+		_phantom: PhantomData<(WeightToFee, I, FeeDestinationAccount)>,
 	}
 
-	impl<T, WeightToFee, FeeDestinationAccount> WeightTrader
-		for UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
+	impl<T, I, WeightToFee, FeeDestinationAccount> WeightTrader
+		for UsingComponentsForSwapPairRemoteAsset<T, I, WeightToFee, FeeDestinationAccount>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 		FeeDestinationAccount: Get<T::AccountId>,
 
 		WeightToFee: WeightToFeeT<Balance = u128>,
 	{
 		fn new() -> Self {
-			let swap_pair = SwapPair::<T>::get();
+			let swap_pair = SwapPair::<T, I>::get();
 			Self {
 				consumed_xcm_hash: None,
 				remaining_fungible_balance: Zero::zero(),
@@ -257,10 +262,11 @@ mod swap_pair_remote_asset {
 	// Move any unused asset from the swap pool account to the specified account,
 	// and update the remote balance with the difference since we know we control
 	// the full amount on the remote location.
-	impl<T, WeightToFee, FeeDestinationAccount> Drop
-		for UsingComponentsForSwapPairRemoteAsset<T, WeightToFee, FeeDestinationAccount>
+	impl<T, I, WeightToFee, FeeDestinationAccount> Drop
+		for UsingComponentsForSwapPairRemoteAsset<T, I, WeightToFee, FeeDestinationAccount>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 		FeeDestinationAccount: Get<T::AccountId>,
 	{
 		fn drop(&mut self) {
@@ -270,7 +276,7 @@ mod swap_pair_remote_asset {
 			// zero.
 			if let Some(swap_pair) = &self.swap_pair {
 				if self.remaining_fungible_balance > Zero::zero() {
-					let Ok(remaining_balance_as_local_currency) = LocalCurrencyBalanceOf::<T>::try_from(self.remaining_fungible_balance).map_err(|e| {
+					let Ok(remaining_balance_as_local_currency) = LocalCurrencyBalanceOf::<T, I>::try_from(self.remaining_fungible_balance).map_err(|e| {
 						log::error!(target: LOG_TARGET, "Failed to convert remaining balance {:?} to local currency balance", self.remaining_fungible_balance);
 						e
 					}) else { return; };
@@ -287,7 +293,7 @@ mod swap_pair_remote_asset {
 					});
 
 					// No error should ever be thrown from inside this block.
-					SwapPair::<T>::mutate(|entry| {
+					SwapPair::<T, I>::mutate(|entry| {
 						let Some(entry) = entry.as_mut() else {
 							log::error!(target: LOG_TARGET, "Stored swap pair should not be None but it is.");
 							return;

--- a/pallets/pallet-asset-swap/src/xcm/transfer.rs
+++ b/pallets/pallet-asset-swap/src/xcm/transfer.rs
@@ -30,16 +30,17 @@ mod xcm_fee_asset {
 	/// `true` if the specified asset matches the swap pair remote XCM fee
 	/// asset, which must be reserve transferred to this chain in order to be
 	/// withdrawn from the user's balance to pay for XCM fees at destination.
-	pub struct IsSwapPairXcmFeeAsset<T>(PhantomData<T>);
+	pub struct IsSwapPairXcmFeeAsset<T, I>(PhantomData<(T, I)>);
 
-	impl<T> ContainsPair<MultiAsset, MultiLocation> for IsSwapPairXcmFeeAsset<T>
+	impl<T, I> ContainsPair<MultiAsset, MultiLocation> for IsSwapPairXcmFeeAsset<T, I>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 	{
 		fn contains(a: &MultiAsset, b: &MultiLocation) -> bool {
 			log::info!(target: LOG_TARGET, "contains {:?}, {:?}", a, b);
 			// 1. Verify a swap pair has been set.
-			let Some(swap_pair) = SwapPair::<T>::get() else {
+			let Some(swap_pair) = SwapPair::<T, I>::get() else {
 				return false;
 			};
 
@@ -83,16 +84,17 @@ mod swap_pair_remote_asset {
 	/// `true` if the specified asset matches the swap pair remote asset, which
 	/// must be reserve transferred to this chain to be traded back for the
 	/// local token.
-	pub struct IsSwapPairRemoteAsset<T>(PhantomData<T>);
+	pub struct IsSwapPairRemoteAsset<T, I>(PhantomData<(T, I)>);
 
-	impl<T> ContainsPair<MultiAsset, MultiLocation> for IsSwapPairRemoteAsset<T>
+	impl<T, I> ContainsPair<MultiAsset, MultiLocation> for IsSwapPairRemoteAsset<T, I>
 	where
-		T: Config,
+		T: Config<I>,
+		I: 'static,
 	{
 		fn contains(a: &MultiAsset, b: &MultiLocation) -> bool {
 			log::info!(target: LOG_TARGET, "contains {:?}, {:?}", a, b);
 			// 1. Verify a swap pair has been set.
-			let Some(swap_pair) = SwapPair::<T>::get() else {
+			let Some(swap_pair) = SwapPair::<T, I>::get() else {
 				return false;
 			};
 

--- a/runtime-api/asset-swap/Cargo.toml
+++ b/runtime-api/asset-swap/Cargo.toml
@@ -16,7 +16,8 @@ parity-scale-codec = { workspace = true }
 
 # Substrate dependencies
 sp-api = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]
-std     = ["parity-scale-codec/std", "sp-api/std"]
+std     = ["parity-scale-codec/std", "sp-api/std", "sp-std/std"]

--- a/runtime-api/asset-swap/src/lib.rs
+++ b/runtime-api/asset-swap/src/lib.rs
@@ -22,11 +22,11 @@ use parity_scale_codec::Codec;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-	/// Runtime API to compute the pool account for a given pool ID and remote asset.
+	/// Runtime API to compute the pool account for a given swap pair ID and remote asset.
 	pub trait AssetSwap<AssetId, AccountId> where
 		AssetId: Codec,
 		AccountId: Codec,
 		{
-			fn pool_account_id(pool_id: Vec<u8>, asset_id: AssetId) -> AccountId;
+			fn pool_account_id(pair_id: Vec<u8>, asset_id: AssetId) -> AccountId;
 		}
 }

--- a/runtime-api/asset-swap/src/lib.rs
+++ b/runtime-api/asset-swap/src/lib.rs
@@ -19,13 +19,14 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use parity_scale_codec::Codec;
+use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-	/// Runtime API to compute the pool account for a given remote asset.
+	/// Runtime API to compute the pool account for a given pool ID and remote asset.
 	pub trait AssetSwap<AssetId, AccountId> where
 		AssetId: Codec,
 		AccountId: Codec,
 		{
-			fn pool_account_id(asset_id: AssetId) -> AccountId;
+			fn pool_account_id(pool_id: Vec<u8>, asset_id: AssetId) -> AccountId;
 		}
 }

--- a/runtimes/peregrine/src/asset_swap/mod.rs
+++ b/runtimes/peregrine/src/asset_swap/mod.rs
@@ -24,7 +24,7 @@ use xcm::{
 	VersionedMultiLocation,
 };
 
-use crate::Runtime;
+use crate::{KiltToEKiltSwapPallet, Runtime};
 
 const LOG_TARGET: &str = "runtime::peregrine::asset-swap::RestrictTransfersToSameUser";
 
@@ -33,7 +33,7 @@ const LOG_TARGET: &str = "runtime::peregrine::asset-swap::RestrictTransfersToSam
 /// swap.
 pub struct RestrictSwapDestinationToSelf;
 
-impl SwapHooks<Runtime> for RestrictSwapDestinationToSelf {
+impl SwapHooks<Runtime, KiltToEKiltSwapPallet> for RestrictSwapDestinationToSelf {
 	type Error = Error;
 
 	fn pre_local_to_remote_swap(

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1486,18 +1486,17 @@ impl_runtime_apis! {
 
 		// TODO: I think it's fine to panic in runtime APIs, but should double check that.
 		impl pallet_asset_swap_runtime_api::AssetSwap<Block, VersionedAssetId, AccountId> for Runtime {
-			fn pool_account_id(pool_id: Vec<u8>, asset_id: VersionedAssetId) -> AccountId {
+			fn pool_account_id(pair_id: Vec<u8>, asset_id: VersionedAssetId) -> AccountId {
 				use core::str;
 				use frame_support::traits::PalletInfoAccess;
 
-				let pool_id_as_string = str::from_utf8(pool_id.as_slice()).expect("Provided pool ID is not a valid UTF-8 string.");
-				match pool_id_as_string {
+				let pair_id_as_string = str::from_utf8(pair_id.as_slice()).expect("Provided swap pair ID is not a valid UTF-8 string.");
+				match pair_id_as_string {
 					kilt_to_ekilt if kilt_to_ekilt == AssetSwap::name() => {
 						AssetSwap::pool_account_id_for_remote_asset(&asset_id).expect("Should never fail to generate a pool account for a given asset.")
 					},
-					_ => panic!("No pool with specified pool ID found")
+					_ => panic!("No swap pair with specified pool ID found")
 				}
-				// pallet_asset_swap::Pallet::<Runtime>::pool_account_id_for_remote_asset(&remote_asset_id).expect("Should never fail to generate a pool account for a given asset.")
 			}
 		}
 

--- a/runtimes/peregrine/src/xcm_config.rs
+++ b/runtimes/peregrine/src/xcm_config.rs
@@ -17,8 +17,8 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use crate::{
-	AccountId, AllPalletsWithSystem, Balances, CheckingAccount, Fungibles, ParachainInfo, ParachainSystem, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, WeightToFee, XcmpQueue,
+	AccountId, AllPalletsWithSystem, Balances, CheckingAccount, Fungibles, KiltToEKiltSwapPallet, ParachainInfo,
+	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury, WeightToFee, XcmpQueue,
 };
 
 use frame_support::{
@@ -179,11 +179,11 @@ impl xcm_executor::Config for XcmConfig {
 	// transactors.
 	type AssetTransactor = (
 		// Allow the asset from the other side of the pool to be "deposited" into the current system.
-		SwapPairRemoteAssetTransactor<LocationToAccountIdConverter, Runtime>,
+		SwapPairRemoteAssetTransactor<LocationToAccountIdConverter, Runtime, KiltToEKiltSwapPallet>,
 		// Allow the asset to pay for remote XCM fees to be deposited into the current system.
 		FungiblesAdapter<
 			Fungibles,
-			MatchesSwapPairXcmFeeFungibleAsset<Runtime>,
+			MatchesSwapPairXcmFeeFungibleAsset<Runtime, KiltToEKiltSwapPallet>,
 			LocationToAccountIdConverter,
 			AccountId,
 			NoChecking,
@@ -195,8 +195,8 @@ impl xcm_executor::Config for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = (
 		NativeAsset,
-		IsSwapPairRemoteAsset<Runtime>,
-		IsSwapPairXcmFeeAsset<Runtime>,
+		IsSwapPairRemoteAsset<Runtime, KiltToEKiltSwapPallet>,
+		IsSwapPairXcmFeeAsset<Runtime, KiltToEKiltSwapPallet>,
 	);
 	// Teleporting is disabled.
 	type IsTeleporter = ();
@@ -211,9 +211,9 @@ impl xcm_executor::Config for XcmConfig {
 	// used. In that case they are put into the treasury.
 	type Trader = (
 		// Can pay for fees with the remote XCM asset fee (when sending it into this system).
-		UsingComponentsForXcmFeeAsset<Runtime, WeightToFee<Runtime>>,
+		UsingComponentsForXcmFeeAsset<Runtime, KiltToEKiltSwapPallet, WeightToFee<Runtime>>,
 		// Can pay for the remote asset of the swap pair (when "depositing" it into this system).
-		UsingComponentsForSwapPairRemoteAsset<Runtime, WeightToFee<Runtime>, TreasuryAccountId>,
+		UsingComponentsForSwapPairRemoteAsset<Runtime, KiltToEKiltSwapPallet, WeightToFee<Runtime>, TreasuryAccountId>,
 		// Can pay with the fungible that matches the "Here" location.
 		UsingComponents<WeightToFee<Runtime>, HereLocation, AccountId, Balances, Treasury>,
 	);


### PR DESCRIPTION
Based on top of https://github.com/KILTprotocol/kilt-node/pull/663.

This PR makes it possible for multiple instances of the swap pallet asset to co-exist within the runtime, so that we can implement N:N swaps by deploying multiple pallets (easier solution).

The runtime API has also been updated to take an extra `pair_id` parameter which must match the name of one of the deployed pallets.