### PR TITLE
chore: fix benchmark logic

### DIFF
--- a/pallets/pallet-asset-switch/src/benchmarking.rs
+++ b/pallets/pallet-asset-switch/src/benchmarking.rs
@@ -59,7 +59,7 @@ mod benchmarks {
 	use sp_runtime::traits::{TryConvert, Zero};
 	use sp_std::boxed::Box;
 	use xcm::{
-		v4::{Asset, AssetId, Fungibility, Junction, Junctions, Location, XcmContext},
+		v4::{Asset, AssetId, Fungibility, Junction, Junctions, Location},
 		VersionedAsset, VersionedAssetId, VersionedInteriorLocation, VersionedLocation,
 	};
 	use xcm_executor::traits::TransactAsset;

--- a/runtimes/common/src/asset_switch/mod.rs
+++ b/runtimes/common/src/asset_switch/mod.rs
@@ -24,11 +24,11 @@ use sp_std::marker::PhantomData;
 pub struct NoopBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
-impl pallet_assets::BenchmarkHelper<xcm::v3::MultiLocation> for NoopBenchmarkHelper {
-	fn create_asset_id_parameter(_id: u32) -> xcm::v3::MultiLocation {
-		xcm::v3::MultiLocation {
+impl pallet_assets::BenchmarkHelper<xcm::v4::Location> for NoopBenchmarkHelper {
+	fn create_asset_id_parameter(_id: u32) -> xcm::v4::Location {
+		xcm::v4::Location {
 			parents: 0,
-			interior: xcm::v3::Junctions::Here,
+			interior: xcm::v4::Junctions::Here,
 		}
 	}
 }

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1270,28 +1270,33 @@ mod benches {
 		fn setup() -> Option<PartialBenchmarkInfo> {
 			const DESTINATION_PARA_ID: u32 = 1_000;
 
-			let asset_location: MultiLocation = Junctions::Here.into();
+			let asset_location: Location = Junctions::Here.into();
 			Fungibles::create(
 				RawOrigin::Root.into(),
-				asset_location,
+				asset_location.clone(),
 				AccountId::from([0; 32]).into(),
 				1u32.into(),
 			)
 			.unwrap();
-			let beneficiary = Junctions::X1(Junction::AccountId32 {
-				network: None,
-				id: [0; 32],
-			})
+			let beneficiary = Junctions::X1(
+				[Junction::AccountId32 {
+					network: None,
+					id: [0; 32],
+				}]
+				.into(),
+			)
 			.into();
-			let destination =
-				MultiLocation::from(ParentThen(Junctions::X1(Junction::Parachain(DESTINATION_PARA_ID)))).into();
-			let remote_xcm_fee = MultiAsset {
-				id: AssetId::Concrete(asset_location),
+			let destination = Location::from(ParentThen(Junctions::X1(
+				[Junction::Parachain(DESTINATION_PARA_ID)].into(),
+			)))
+			.into();
+			let remote_xcm_fee = Asset {
+				id: AssetId(asset_location),
 				fun: Fungibility::Fungible(1_000),
 			}
 			.into();
 
-			ParachainSystem::open_outbound_hrmp_channel_for_benchmarks(DESTINATION_PARA_ID.into());
+			ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(DESTINATION_PARA_ID.into());
 
 			Some(PartialBenchmarkInfo {
 				beneficiary: Some(beneficiary),

--- a/runtimes/peregrine/src/weights/pallet_xcm.rs
+++ b/runtimes/peregrine/src/weights/pallet_xcm.rs
@@ -107,15 +107,33 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
-	/// Storage: `Benchmark::Override` (r:0 w:0)
-	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `AssetSwitchPool1::SwitchPair` (r:1 w:0)
+	/// Proof: `AssetSwitchPool1::SwitchPair` (`max_values`: Some(1), `max_size`: Some(1939), added: 2434, mode: `MaxEncodedLen`)
+	/// Storage: `ParachainInfo::ParachainId` (r:1 w:0)
+	/// Proof: `ParachainInfo::ParachainId` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(132), added: 2607, mode: `MaxEncodedLen`)
+	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)
+	/// Proof: `PolkadotXcm::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `PolkadotXcm::VersionDiscoveryQueue` (r:1 w:1)
+	/// Proof: `PolkadotXcm::VersionDiscoveryQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `PolkadotXcm::SafeXcmVersion` (r:1 w:0)
+	/// Proof: `PolkadotXcm::SafeXcmVersion` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `ParachainSystem::RelevantMessagingState` (r:1 w:0)
+	/// Proof: `ParachainSystem::RelevantMessagingState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `XcmpQueue::OutboundXcmpStatus` (r:1 w:1)
+	/// Proof: `XcmpQueue::OutboundXcmpStatus` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `XcmpQueue::OutboundXcmpMessages` (r:0 w:1)
+	/// Proof: `XcmpQueue::OutboundXcmpMessages` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn transfer_assets() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 18_446_744_073_709_551_000 picoseconds.
-		Weight::from_parts(18_446_744_073_709_551_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
+		//  Measured:  `346`
+		//  Estimated: `3811`
+		// Minimum execution time: 1_048_341_000 picoseconds.
+		Weight::from_parts(1_058_740_000, 0)
+			.saturating_add(Weight::from_parts(0, 3811))
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(4))
 	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -384,6 +402,18 @@ mod tests {
 				.unwrap_or_else(<sp_weights::Weight as sp_runtime::traits::Bounded>::max_value)
 				.proof_size()
 				> 3774
+		);
+	}
+	#[test]
+	fn test_transfer_assets() {
+		assert!(
+			<crate::Runtime as frame_system::Config>::BlockWeights::get()
+				.per_class
+				.get(frame_support::dispatch::DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(<sp_weights::Weight as sp_runtime::traits::Bounded>::max_value)
+				.proof_size()
+				> 3811
 		);
 	}
 	#[test]


### PR DESCRIPTION
## fixes [#3563](https://github.com/KILTprotocol/ticket/issues/3563)

This PR fixes some old XCM versions used in benchmarks. Additionally, the set_up_complex_asset_transfer function is implemented to benchmark the transfer_assets transaction, allowing users to send back their DOTs.
 
