### PR TITLE
fix: unit tests

### DIFF
--- a/pallets/pallet-asset-switch/README.md
+++ b/pallets/pallet-asset-switch/README.md
@@ -50,7 +50,7 @@ impl pallet_asset_switch::Config<SwitchPool2> for Runtime {
 
 If a single instance is required, then use the default instance:
 
-```rust
+```rust,ignore
 impl pallet_asset_switch::Config for Runtime {
     // Config
 }

--- a/pallets/pallet-asset-switch/src/xcm/transact/mock.rs
+++ b/pallets/pallet-asset-switch/src/xcm/transact/mock.rs
@@ -178,7 +178,6 @@ impl ExtBuilder {
 				);
 				Pallet::<MockRuntime>::set_switch_pair_status(switch_pair_info.status).unwrap();
 			}
-			println!("self.1: {:?} ICH BIN HIER DU WIXA", self.1);
 			for (account, free, held, frozen) in self.1 {
 				<Balances as MutateFungible<AccountId32>>::mint_into(&account, free).unwrap();
 				<Balances as MutateHold<AccountId32>>::hold(&MockRuntimeHoldReason {}, &account, held).unwrap();


### PR DESCRIPTION
To create holds, a hold reason has to be specified. 