### PR TITLE
fix: IsReserve implementation to allow assets regardless of pool status

### DIFF
--- a/pallets/pallet-asset-switch/src/xcm/transfer/switch_pair_remote_asset/mod.rs
+++ b/pallets/pallet-asset-switch/src/xcm/transfer/switch_pair_remote_asset/mod.rs
@@ -42,13 +42,11 @@ where
 {
 	fn contains(a: &Asset, b: &Location) -> bool {
 		log::info!(target: LOG_TARGET, "contains {:?}, {:?}", a, b);
-		// 1. Verify a switch pair has been set and is enabled.
+		// 1. Verify a switch pair has been set. We don't care if it's enabled at this
+		//    stage, as we still want the assets to move inside this system.
 		let Some(switch_pair) = SwitchPair::<T, I>::get() else {
 			return false;
 		};
-		if !switch_pair.is_enabled() {
-			return false;
-		}
 
 		// 2. We only trust the EXACT configured remote location (no parent is allowed).
 		let Ok(stored_remote_reserve_location_v4): Result<Location, _> = switch_pair.remote_reserve_location.clone().try_into().map_err(|e| {

--- a/pallets/pallet-asset-switch/src/xcm/transfer/switch_pair_remote_asset/tests.rs
+++ b/pallets/pallet-asset-switch/src/xcm/transfer/switch_pair_remote_asset/tests.rs
@@ -333,7 +333,7 @@ fn false_on_switch_pair_not_set() {
 }
 
 #[test]
-fn false_on_switch_pair_not_enabled() {
+fn true_on_switch_pair_not_enabled() {
 	let location = Location {
 		parents: 1,
 		interior: Junctions::X1([Junction::Parachain(1_000)].into()),
@@ -341,21 +341,15 @@ fn false_on_switch_pair_not_enabled() {
 	let new_switch_pair_info =
 		get_switch_pair_info_for_remote_location::<MockRuntime>(&location, SwitchPairStatus::Paused);
 	ExtBuilder::default()
-		.with_switch_pair_info(new_switch_pair_info)
+		.with_switch_pair_info(new_switch_pair_info.clone())
 		.build()
 		.execute_with(|| {
-			assert!(!IsSwitchPairRemoteAsset::<MockRuntime, _>::contains(
+			assert!(IsSwitchPairRemoteAsset::<MockRuntime, _>::contains(
 				&Asset {
-					id: AssetId(Location {
-						parents: 1,
-						interior: Junctions::X1([Junction::Parachain(1_000)].into())
-					}),
+					id: new_switch_pair_info.clone().remote_asset_id.try_into().unwrap(),
 					fun: Fungibility::Fungible(1)
 				},
-				&Location {
-					parents: 1,
-					interior: Junctions::X1([Junction::Parachain(1_000)].into())
-				}
+				new_switch_pair_info.clone().remote_reserve_location.try_as().unwrap()
 			));
 		});
 }

--- a/pallets/pallet-asset-switch/src/xcm/transfer/xcm_fee_asset/mod.rs
+++ b/pallets/pallet-asset-switch/src/xcm/transfer/xcm_fee_asset/mod.rs
@@ -42,13 +42,11 @@ where
 {
 	fn contains(a: &Asset, b: &Location) -> bool {
 		log::info!(target: LOG_TARGET, "contains {:?}, {:?}", a, b);
-		// 1. Verify a switch pair has been set and is enabled.
+		// 1. Verify a switch pair has been set. We don't care if it's enabled at this
+		//    stage, as we still want the assets to move inside this system.
 		let Some(switch_pair) = SwitchPair::<T, I>::get() else {
 			return false;
 		};
-		if !switch_pair.is_enabled() {
-			return false;
-		}
 
 		// 2. We only trust the EXACT configured remote location (no parent is allowed).
 		let Ok(stored_remote_reserve_location_v4): Result<Location, _> = switch_pair.remote_reserve_location.clone().try_into().map_err(|e| {

--- a/pallets/pallet-asset-switch/src/xcm/transfer/xcm_fee_asset/tests.rs
+++ b/pallets/pallet-asset-switch/src/xcm/transfer/xcm_fee_asset/tests.rs
@@ -373,7 +373,7 @@ fn false_on_switch_pair_not_set() {
 }
 
 #[test]
-fn false_on_switch_pair_not_enabled() {
+fn true_on_switch_pair_not_enabled() {
 	let location = Location {
 		parents: 1,
 		interior: Junctions::X1([Junction::Parachain(1_000)].into()),
@@ -381,21 +381,15 @@ fn false_on_switch_pair_not_enabled() {
 	let new_switch_pair_info =
 		get_switch_pair_info_for_remote_location::<MockRuntime>(&location, SwitchPairStatus::Paused);
 	ExtBuilder::default()
-		.with_switch_pair_info(new_switch_pair_info)
+		.with_switch_pair_info(new_switch_pair_info.clone())
 		.build()
 		.execute_with(|| {
-			assert!(!IsSwitchPairXcmFeeAsset::<MockRuntime, _>::contains(
+			assert!(IsSwitchPairXcmFeeAsset::<MockRuntime, _>::contains(
 				&Asset {
-					id: AssetId(Location {
-						parents: 1,
-						interior: Junctions::X1([Junction::Parachain(1_000)].into())
-					}),
+					id: Asset::try_from(new_switch_pair_info.clone().remote_xcm_fee).unwrap().id,
 					fun: Fungibility::Fungible(1)
 				},
-				&Location {
-					parents: 1,
-					interior: Junctions::X1([Junction::Parachain(1_000)].into())
-				}
+				new_switch_pair_info.clone().remote_reserve_location.try_as().unwrap()
 			));
 		});
 }


### PR DESCRIPTION
Allow funds to make it into our system even if the switch pair is not enabled. If not enabled, they will be trapped later on, but at least we populate the holding registry regardless of the switch pair status.