### PR TITLE
docs: remove branch auto name for now as it breaks build

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          branch: gh-pages-${{ github.ref_name }}
+          branch: gh-pages
           folder: target/doc


### PR DESCRIPTION
We attempted to create a different github pages branch for every version, but that doesn't work, so to unblock progress for now, this PR switches back to default GitHub way and we will find a better solution soon.