### PR TITLE
fix: formatting

### DIFF
--- a/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
+++ b/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
@@ -23,8 +23,11 @@ use did::{
 	DidIdentifierOf, DidVerificationKeyRelationship, KeyIdOf,
 };
 use frame_support::{
-	construct_runtime, pallet_prelude::ValueQuery, parameter_types, storage_alias, traits::EnqueueWithOrigin,
-	traits::Everything, Twox64Concat,
+	construct_runtime,
+	pallet_prelude::ValueQuery,
+	parameter_types, storage_alias,
+	traits::{EnqueueWithOrigin, Everything},
+	Twox64Concat,
 };
 use frame_system::{mocking::MockBlock, pallet_prelude::BlockNumberFor, EnsureSigned};
 use hex_literal::hex;

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -30,8 +30,7 @@ use sp_runtime::{
 	traits::{IdentifyAccount, Zero},
 	AccountId32, MultiSigner,
 };
-use sp_std::ops::Mul;
-use sp_std::{convert::TryInto, vec::Vec};
+use sp_std::{convert::TryInto, ops::Mul, vec::Vec};
 
 use kilt_support::{signature::VerifySignature, Deposit};
 

--- a/runtimes/common/src/benchmarks/treasury.rs
+++ b/runtimes/common/src/benchmarks/treasury.rs
@@ -24,8 +24,9 @@ use crate::constants::KILT;
 
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 
-/// Benchmark helper for the treasury pallet. Implements the `ArgumentsFactory` trait.
-/// Used to create accounts and assets for the treasury pallet benchmarks.
+/// Benchmark helper for the treasury pallet. Implements the `ArgumentsFactory`
+/// trait. Used to create accounts and assets for the treasury pallet
+/// benchmarks.
 pub struct BenchmarkHelper<T>(PhantomData<T>);
 
 impl<T> ArgumentsFactory<(), AccountIdOf<T>> for BenchmarkHelper<T>


### PR DESCRIPTION
Done with `cargo +nightly-2023-10-01 fmt`, the same version used in the CI.

To catch formatting errors locally, the rust-analyzer should be configured to use this toolchain as well.
In `.vscode/settings.json` add the following:

```json
"rust-analyzer.rustfmt.extraArgs": [
    "+nightly-2023-10-01"
  ]
```