### PR TITLE
fix: gitlab release pipeline

### DIFF
--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -18,12 +18,20 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync HEAD with GitLab
+        uses: saderi/push-to-gitlab@v1
+        with:
+          gitlab_repository: 'gitlab.com/kiltprotocol/kilt-node'
+          gitlab_token: ${{ secrets.KILTBOT_PUSH_ACCESS_TOKEN  }}
+
       - name: Trigger GitLab CI
-        env:
-          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          GITLAB_PROJECT_ID: ${{ secrets.GITLAB_PROJECT_ID }}
         run: |
           curl -X POST \
-            -F token=$GITLAB_TRIGGER_TOKEN \
+            -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} \
             -F ref=${{ github.ref_name }} \
-            https://gitlab.com/api/v4/projects/$GITLAB_PROJECT_ID/trigger/pipeline
+            https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 workflow:
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "api"'
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
 
 stages:
   - build


### PR DESCRIPTION
The Gitlab project ID did not need to be a secret, so I made it a repo variable. Everything else seems to work, at least the Pipeline is properly triggered with the latest HEAD.