### PR TITLE
chore: add peregrine-dev id

### DIFF
--- a/nodes/parachain/src/chain_spec/mod.rs
+++ b/nodes/parachain/src/chain_spec/mod.rs
@@ -112,7 +112,7 @@ impl FromStr for ParachainRuntime {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		match s {
 			// Peregrine development
-			"dev" => Ok(Self::Peregrine(PeregrineRuntime::Dev)),
+			"dev" | "peregrine-dev" => Ok(Self::Peregrine(PeregrineRuntime::Dev)),
 			// New blank Peregrine chainspec
 			"peregrine-new" => Ok(Self::Peregrine(PeregrineRuntime::New)),
 			// Peregrine chainspec


### PR DESCRIPTION
Because we match a Peregrine chainspec if the name itself has `peregrine` in it, currently we cannot spin up a Zombienet-based network using Peregrine dev because its name is only `dev`, which would fail to match. I added a second way to generate a peregrine dev chainspec, which is `peregrine-dev`, which contains the word `peregrine` in it, and would allow us to spin up a Zombienet network.