### PR TITLE
feat: embed chainspecs in binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,5 @@ VOLUME ["/data"]
 
 COPY ./chainspecs /node/chainspecs
 
-ENV CHAINSPECS_FOLDER=/node/chainspecs
-
 ENTRYPOINT ["/usr/local/bin/node-executable"]
 CMD ["--help"]

--- a/nodes/parachain/src/chain_spec/mod.rs
+++ b/nodes/parachain/src/chain_spec/mod.rs
@@ -134,7 +134,9 @@ impl FromStr for ParachainRuntime {
 			// Any other Spiritnet-based chainspec
 			s if s.contains("spiritnet") => Ok(Self::Spiritnet(SpiritnetRuntime::Other(s.to_string()))),
 
-			_ => Err(format!("Unknown chainspec id provided: {s}")),
+			// Instead of panicking, we use the Peregrine runtime, since we don't expect Spiritnet to ever be used in
+			// this way
+			path => Ok(Self::Peregrine(PeregrineRuntime::Other(path.to_string()))),
 		}
 	}
 }

--- a/nodes/parachain/src/chain_spec/rilt/mod.rs
+++ b/nodes/parachain/src/chain_spec/rilt/mod.rs
@@ -25,7 +25,3 @@ const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub(crate) type ChainSpec =
 	sc_service::GenericChainSpec<peregrine_runtime::RuntimeGenesisConfig, crate::chain_spec::Extensions>;
-
-pub(crate) fn load_chain_spec(path: &str) -> Result<ChainSpec, String> {
-	ChainSpec::from_json_file(path.into())
-}

--- a/nodes/parachain/src/chain_spec/utils.rs
+++ b/nodes/parachain/src/chain_spec/utils.rs
@@ -16,8 +16,6 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use std::path::{Path, PathBuf};
-
 use runtime_common::{AccountId, AccountPublic};
 use sc_service::Properties;
 use sp_core::{Pair, Public};
@@ -57,18 +55,14 @@ pub(crate) fn load_spec(id: &str) -> Result<Box<dyn sc_service::ChainSpec>, Stri
 				"rococo_local",
 			))),
 			PeregrineRuntime::New => Ok(Box::new(chain_spec::peregrine::new::generate_chain_spec())),
-			PeregrineRuntime::Peregrine => Ok(Box::new(chain_spec::peregrine::load_chain_spec(
-				get_chainspec_full_path("peregrine/peregrine-paseo.json")
-					.to_str()
-					.unwrap(),
+			PeregrineRuntime::Peregrine => Ok(Box::new(chain_spec::peregrine::ChainSpec::from_json_bytes(
+				include_bytes!("../../../../chainspecs/peregrine/peregrine-paseo.json").as_slice(),
 			)?)),
-			PeregrineRuntime::PeregrineStg => Ok(Box::new(chain_spec::peregrine::load_chain_spec(
-				get_chainspec_full_path("peregrine-stg/peregrine-stg.json")
-					.to_str()
-					.unwrap(),
+			PeregrineRuntime::PeregrineStg => Ok(Box::new(chain_spec::peregrine::ChainSpec::from_json_bytes(
+				include_bytes!("../../../../chainspecs/peregrine-stg/peregrine-stg.json").as_slice(),
 			)?)),
-			PeregrineRuntime::Rilt => Ok(Box::new(chain_spec::rilt::load_chain_spec(
-				get_chainspec_full_path("rilt/peregrine-rilt.json").to_str().unwrap(),
+			PeregrineRuntime::Rilt => Ok(Box::new(chain_spec::peregrine::ChainSpec::from_json_bytes(
+				include_bytes!("../../../../chainspecs/rilt/peregrine-rilt.json").as_slice(),
 			)?)),
 			PeregrineRuntime::RiltNew => Ok(Box::new(chain_spec::rilt::new::generate_chain_spec())),
 			PeregrineRuntime::Other(s) => Ok(Box::new(chain_spec::peregrine::load_chain_spec(s.as_str())?)),
@@ -78,38 +72,10 @@ pub(crate) fn load_spec(id: &str) -> Result<Box<dyn sc_service::ChainSpec>, Stri
 				"rococo_local",
 			))),
 			SpiritnetRuntime::New => Ok(Box::new(chain_spec::spiritnet::new::generate_chain_spec())),
-			SpiritnetRuntime::Spiritnet => Ok(Box::new(chain_spec::spiritnet::load_chain_spec(
-				get_chainspec_full_path("spiritnet/spiritnet.json").to_str().unwrap(),
+			SpiritnetRuntime::Spiritnet => Ok(Box::new(chain_spec::spiritnet::ChainSpec::from_json_bytes(
+				include_bytes!("../../../../chainspecs/spiritnet/spiritnet.json").as_slice(),
 			)?)),
 			SpiritnetRuntime::Other(s) => Ok(Box::new(chain_spec::spiritnet::load_chain_spec(s.as_str())?)),
 		},
 	}
-}
-
-// Compile-time env variable used when running the binary with cargo or via
-// cargo (after `cargo build`).
-const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
-// Name of the runtime-time env variable that can be used to configure the
-// chainspecs folder path, useful especially when running the binary in a Docker
-// container.
-const CHAINSPECS_FOLDER_VAR_NAME: &str = "CHAINSPECS_FOLDER";
-
-fn get_chainspec_full_path(path: &str) -> PathBuf {
-	// Use the provided env variable, if present at runtime, or else uses the
-	// compile-time `CARGO_MANIFEST_DIR` variable (e.g., if the binary is run via
-	// cargo instead of in a Docker container).
-	let chainspecs_root = match std::env::var(CHAINSPECS_FOLDER_VAR_NAME) {
-		Ok(chainspecs_folder_name) => chainspecs_folder_name.to_owned(),
-		Err(_) => Path::new(MANIFEST_DIR)
-			.join("..")
-			.join("..")
-			.join("chainspecs")
-			.to_string_lossy()
-			.into_owned(),
-	};
-
-	Path::new(chainspecs_root.as_str())
-		.join(path)
-		.canonicalize()
-		.expect("Invalid path provided.")
 }


### PR DESCRIPTION
To avoid runtime panics. Fixes https://github.com/KILTprotocol/ticket/issues/3601 by embedding the well-known chainspecs into the binary. Fixes https://github.com/KILTprotocol/ticket/issues/3597 by defaulting to "peregrine" if a chainspec path is specified that does not contain neither `peregrine` nor `spiritnet`.