### PR TITLE
feat: implement burn_into extrinsic

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -207,10 +207,6 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
-			if !amount_to_mint.gt(&Zero::zero()) {
-				return Ok(().into())
-			}
-
 			let pool_details = <Pools<T>>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
 			let mint_enabled = match pool_details.state {
@@ -229,6 +225,10 @@ pub mod pallet {
 				.bonded_currencies
 				.get(currency_idx_usize)
 				.ok_or(Error::<T>::IndexOutOfBounds)?;
+
+			if !amount_to_mint.gt(&Zero::zero()) {
+				return Ok(().into());
+			}
 
 			let total_issuances: Vec<FungiblesBalanceOf<T>> = pool_details
 				.bonded_currencies
@@ -270,10 +270,6 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
-			if !amount_to_burn.gt(&Zero::zero()) {
-				return Ok(().into());
-			}
-
 			let pool_details = <Pools<T>>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
 			let burn_enabled = match pool_details.state {
@@ -292,6 +288,10 @@ pub mod pallet {
 				.bonded_currencies
 				.get(currency_idx_usize)
 				.ok_or(Error::<T>::IndexOutOfBounds)?;
+
+			if !amount_to_burn.gt(&Zero::zero()) {
+				return Ok(().into());
+			}
 
 			// TODO: remove lock if one exists / if pool_details.transferable != true
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -207,6 +207,10 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
+			if !amount_to_mint.gt(&Zero::zero()) {
+				return Ok(().into())
+			}
+
 			let pool_details = <Pools<T>>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
 			let mint_enabled = match pool_details.state {

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -73,6 +73,11 @@ pub enum Curve<ParamType> {
 	LinearRatioCurve(LinearRatioCurveParams<ParamType>),
 }
 
+pub enum DiffKind {
+	Mint,
+	Burn,
+}
+
 pub struct MockCurve {}
 
 impl MockCurve {


### PR DESCRIPTION
Implements bonding curve based token burning. Refactors the get_cost associated function to do so.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
