### PR TITLE
chore: remove experimental feature

### DIFF
--- a/dip-template/runtimes/dip-consumer/Cargo.toml
+++ b/dip-template/runtimes/dip-consumer/Cargo.toml
@@ -33,7 +33,7 @@ frame-executive                            = { workspace = true }
 frame-support                              = { workspace = true }
 frame-system                               = { workspace = true }
 frame-system-rpc-runtime-api               = { workspace = true }
-pallet-aura                                = { workspace = true, features = ["experimental"] }
+pallet-aura                                = { workspace = true }
 pallet-authorship                          = { workspace = true }
 pallet-balances                            = { workspace = true }
 pallet-session                             = { workspace = true }

--- a/dip-template/runtimes/dip-consumer/src/lib.rs
+++ b/dip-template/runtimes/dip-consumer/src/lib.rs
@@ -367,7 +367,6 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
-	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}

--- a/dip-template/runtimes/dip-provider/Cargo.toml
+++ b/dip-template/runtimes/dip-provider/Cargo.toml
@@ -33,7 +33,7 @@ frame-executive                            = { workspace = true }
 frame-support                              = { workspace = true }
 frame-system                               = { workspace = true }
 frame-system-rpc-runtime-api               = { workspace = true }
-pallet-aura                                = { workspace = true, features = ["experimental"] }
+pallet-aura                                = { workspace = true }
 pallet-authorship                          = { workspace = true }
 pallet-balances                            = { workspace = true }
 pallet-session                             = { workspace = true }

--- a/dip-template/runtimes/dip-provider/src/lib.rs
+++ b/dip-template/runtimes/dip-provider/src/lib.rs
@@ -368,7 +368,6 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
-	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
 impl cumulus_pallet_aura_ext::Config for Runtime {}

--- a/integration-tests/emulated/Cargo.toml
+++ b/integration-tests/emulated/Cargo.toml
@@ -12,7 +12,7 @@ version       = { workspace = true }
 
 [dependencies]
 asset-hub-rococo-emulated-chain   = { workspace = true, default-features = true }
-asset-hub-rococo-runtime          = { workspace = true, default-features = true, features = ["experimental"] }
+asset-hub-rococo-runtime          = { workspace = true, default-features = true }
 attestation                       = { workspace = true, default-features = true }
 ctype                             = { workspace = true, default-features = true }
 cumulus-primitives-core           = { workspace = true, default-features = true }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -12,7 +12,7 @@ version       = { workspace = true }
 
 [dev-dependencies]
 kilt-support      = { workspace = true, features = ["mock", "try-runtime"] }
-pallet-aura       = { workspace = true, features = ["experimental", "std"] }
+pallet-aura       = { workspace = true, features = ["std"] }
 pallet-timestamp  = { workspace = true, features = ["std"] }
 sp-consensus-aura = { workspace = true, features = ["std"] }
 sp-core           = { workspace = true, features = ["std"] }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -28,7 +28,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_authorship::EventHandler;
 use sp_consensus_aura::sr25519::AuthorityId;
-use sp_core::{ConstBool, ConstU64, H256};
+use sp_core::{ConstBool, H256};
 use sp_runtime::{
 	impl_opaque_keys,
 	testing::UintAuthorityId,
@@ -120,7 +120,6 @@ impl pallet_aura::Config for Test {
 	type DisabledValidators = ();
 	type MaxAuthorities = MaxCollatorCandidates;
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = ConstU64<2>;
 }
 
 impl pallet_authorship::Config for Test {

--- a/runtimes/kestrel/Cargo.toml
+++ b/runtimes/kestrel/Cargo.toml
@@ -42,7 +42,7 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 frame-executive            = { workspace = true }
 frame-support              = { workspace = true }
 frame-system               = { workspace = true }
-pallet-aura                = { workspace = true, features = ["experimental"] }
+pallet-aura                = { workspace = true }
 pallet-authorship          = { workspace = true }
 pallet-balances            = { workspace = true }
 pallet-grandpa             = { workspace = true }

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -211,7 +211,6 @@ impl pallet_aura::Config for Runtime {
 	type DisabledValidators = ();
 	type MaxAuthorities = MaxAuthorities;
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = ConstU64<1000>;
 }
 
 impl pallet_grandpa::Config for Runtime {

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -70,7 +70,7 @@ frame-executive            = { workspace = true }
 frame-support              = { workspace = true }
 frame-system               = { workspace = true }
 pallet-assets              = { workspace = true }
-pallet-aura                = { workspace = true, features = ["experimental"] }
+pallet-aura                = { workspace = true }
 pallet-authorship          = { workspace = true }
 pallet-balances            = { workspace = true }
 pallet-collective          = { workspace = true }

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -42,7 +42,7 @@ use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot, EnsureSigned};
 use pallet_asset_switch::xcm::{AccountId32ToAccountId32JunctionConverter, MatchesSwitchPairXcmFeeFungibleAsset};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
-use sp_core::{ConstBool, ConstU64, OpaqueMetadata};
+use sp_core::{ConstBool, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, OpaqueKeys},
@@ -295,7 +295,6 @@ impl pallet_aura::Config for Runtime {
 	type DisabledValidators = ();
 	type MaxAuthorities = MaxAuthorities;
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
 parameter_types! {

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -70,7 +70,7 @@ frame-executive            = { workspace = true }
 frame-support              = { workspace = true }
 frame-system               = { workspace = true }
 pallet-assets              = { workspace = true }
-pallet-aura                = { workspace = true, features = ["experimental"] }
+pallet-aura                = { workspace = true }
 pallet-authorship          = { workspace = true }
 pallet-balances            = { workspace = true }
 pallet-collective          = { workspace = true }

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -42,7 +42,7 @@ use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot, EnsureSigned};
 use pallet_asset_switch::xcm::{AccountId32ToAccountId32JunctionConverter, MatchesSwitchPairXcmFeeFungibleAsset};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
-use sp_core::{ConstBool, ConstU64, OpaqueMetadata};
+use sp_core::{ConstBool, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, OpaqueKeys},
@@ -288,7 +288,6 @@ impl pallet_aura::Config for Runtime {
 	type DisabledValidators = ();
 	type MaxAuthorities = MaxAuthorities;
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3593.

Removing the feature everywhere and using the pallet implementation without the feature is equivalent to the current solution.

What the aura pallet does without the feature enabled is taking the `MinimumPeriod` as returned by the timestamp pallet, and multiply that by two: see code [here](https://github.com/paritytech/polkadot-sdk/blob/09df373db9cd5dfed82c5cdb0736d417d54249e6/substrate/frame/aura/src/lib.rs#L252).

Everywhere, we set `SlotDuration` to be exactly 2x `MinimumPeriod` (which is 6s), totalling 12s. So basically the net result is that `SlotDuration` is set to `12s` everywhere.

Current values of `MinimuPeriod` are:
* DIP consumer template: https://github.com/KILTprotocol/kilt-node/blob/d9552b70160465eaedd7263db450aa70f49667df/dip-template/runtimes/dip-consumer/src/lib.rs#L275
* DIP provider template: https://github.com/KILTprotocol/kilt-node/blob/d9552b70160465eaedd7263db450aa70f49667df/dip-template/runtimes/dip-provider/src/lib.rs#L276
* Kestrel (minimum period 0,5 s, block time 1s): https://github.com/KILTprotocol/kilt-node/blob/d9552b70160465eaedd7263db450aa70f49667df/runtimes/kestrel/src/lib.rs#L230
* Peregrine: https://github.com/KILTprotocol/kilt-node/blob/d9552b70160465eaedd7263db450aa70f49667df/runtimes/peregrine/src/lib.rs#L178
* Spiritnet: https://github.com/KILTprotocol/kilt-node/blob/d9552b70160465eaedd7263db450aa70f49667df/runtimes/spiritnet/src/lib.rs#L177C11-L177C62

I invite the reviewer to double-check that.