### PR TITLE
chore: add events for deposit owner changes

### DIFF
--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -239,7 +239,7 @@ pub mod pallet {
 		/// The deposit for an attestation has changed owner.
 		DepositOwnerChanged {
 			/// The claim hash of the credential whose deposit owner changed.
-			claim_hash: ClaimHashOf<T>,
+			id: ClaimHashOf<T>,
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -490,7 +490,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				claim_hash,
+				id: claim_hash,
 				from: attestation.deposit.owner,
 				to: sender,
 			});

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -484,14 +484,13 @@ pub mod pallet {
 			let attestation = Attestations::<T>::get(claim_hash).ok_or(Error::<T>::NotFound)?;
 			ensure!(attestation.attester == subject, Error::<T>::NotAuthorized);
 
-			AttestationStorageDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
-				&claim_hash,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = AttestationStorageDepositCollector::<T>::change_deposit_owner::<
+				BalanceMigrationManagerOf<T>,
+			>(&claim_hash, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: claim_hash,
-				from: attestation.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -236,6 +236,15 @@ pub mod pallet {
 			/// was deleted.
 			claim_hash: ClaimHashOf<T>,
 		},
+		/// The deposit for an attestation has changed owner.
+		DepositOwnerChanged {
+			/// The claim hash of the credential whose deposit owner changed.
+			claim_hash: ClaimHashOf<T>,
+			/// The old deposit owner.
+			from: AccountIdOf<T>,
+			/// The new deposit owner.
+			to: AccountIdOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -477,8 +486,14 @@ pub mod pallet {
 
 			AttestationStorageDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
 				&claim_hash,
-				sender,
+				sender.clone(),
 			)?;
+
+			Self::deposit_event(Event::<T>::DepositOwnerChanged {
+				claim_hash,
+				from: attestation.deposit.owner,
+				to: sender,
+			});
 
 			Ok(())
 		}

--- a/pallets/attestation/src/tests/deposit.rs
+++ b/pallets/attestation/src/tests/deposit.rs
@@ -79,7 +79,7 @@ fn test_change_deposit_owner() {
 			);
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					claim_hash,
+					id: claim_hash,
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/attestation/src/tests/deposit.rs
+++ b/pallets/attestation/src/tests/deposit.rs
@@ -77,6 +77,13 @@ fn test_change_deposit_owner() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_01),
 				<Test as Config>::Deposit::get()
 			);
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					claim_hash,
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		});
 }
 

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -251,7 +251,7 @@ pub mod pallet {
 		/// The deposit for a delegation has changed owner.
 		DepositOwnerChanged {
 			/// The ID of the delegation whose deposit owner changed.
-			delegation_id: DelegationNodeIdOf<T>,
+			id: DelegationNodeIdOf<T>,
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -706,7 +706,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				delegation_id,
+				id: delegation_id,
 				from: delegation.deposit.owner,
 				to: sender,
 			});

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -700,14 +700,13 @@ pub mod pallet {
 			// parent or another ancestor.
 			ensure!(delegation.details.owner == source.subject(), Error::<T>::AccessDenied);
 
-			DelegationDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
-				&delegation_id,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = DelegationDepositCollector::<T>::change_deposit_owner::<
+				BalanceMigrationManagerOf<T>,
+			>(&delegation_id, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: delegation_id,
-				from: delegation.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/delegation/src/mock.rs
+++ b/pallets/delegation/src/mock.rs
@@ -232,7 +232,7 @@ pub(crate) mod runtime {
 		type AccountId = AccountId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type BlockHashCount = BlockHashCount;
 		type DbWeight = RocksDbWeight;
 		type Version = ();
@@ -264,7 +264,7 @@ pub(crate) mod runtime {
 		type MaxFreezes = MaxFreezes;
 		type Balance = Balance;
 		type DustRemoval = ();
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
 		type WeightInfo = ();
@@ -288,7 +288,7 @@ pub(crate) mod runtime {
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OverarchingOrigin = EnsureSigned<AccountId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type WeightInfo = ();
 
 		type Currency = Balances;
@@ -305,7 +305,7 @@ pub(crate) mod runtime {
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, DelegatorIdOf<Self>>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, DelegatorIdOf<Self>>;
 		type RuntimeHoldReason = RuntimeHoldReason;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type WeightInfo = ();
 
 		type Currency = Balances;
@@ -335,7 +335,7 @@ pub(crate) mod runtime {
 		type DelegationNodeId = Hash;
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, Self::DelegationEntityId>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, Self::DelegationEntityId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type MaxSignatureByteLength = MaxSignatureByteLength;
 		type MaxParentChecks = MaxParentChecks;
 		type MaxRevocations = MaxRevocations;
@@ -503,6 +503,10 @@ pub(crate) mod runtime {
 			let mut ext = sp_io::TestExternalities::new(storage);
 
 			ext.execute_with(|| {
+				// ensure that we are not at the genesis block. Events are not registered for
+				// the genesis block.
+				System::set_block_number(System::block_number() + 1);
+
 				for (ctype_hash, owner) in self.ctypes.iter() {
 					ctype::Ctypes::<Test>::insert(
 						ctype_hash,

--- a/pallets/delegation/src/tests/deposit.rs
+++ b/pallets/delegation/src/tests/deposit.rs
@@ -77,7 +77,7 @@ fn test_change_deposit_owner() {
 			);
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					delegation_id,
+					id: delegation_id,
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/delegation/src/tests/deposit.rs
+++ b/pallets/delegation/src/tests/deposit.rs
@@ -23,7 +23,7 @@ use frame_support::{
 use kilt_support::mock::mock_origin::DoubleOrigin;
 use sp_runtime::{traits::Zero, TokenError};
 
-use crate::{self as delegation, mock::*, Config, Error, HoldReason};
+use crate::{self as delegation, mock::*, Config, Error, Event, HoldReason};
 
 #[test]
 fn test_change_deposit_owner() {
@@ -75,6 +75,13 @@ fn test_change_deposit_owner() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_01),
 				<Test as Config>::Deposit::get()
 			);
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					delegation_id,
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		});
 }
 

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -369,6 +369,15 @@ pub mod pallet {
 		/// A DID-authorised call has been executed.
 		/// \[DID caller, dispatch result\]
 		DidCallDispatched(DidIdentifierOf<T>, DispatchResult),
+		/// The deposit for a DID has changed owner.
+		DepositOwnerChanged {
+			/// The DID whose deposit owner changed.
+			did: DidIdentifierOf<T>,
+			/// The old deposit owner.
+			from: AccountIdOf<T>,
+			/// The new deposit owner.
+			to: AccountIdOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -1105,7 +1114,18 @@ pub mod pallet {
 			let subject = source.subject();
 			let sender = source.sender();
 
-			DidDepositCollector::<T>::change_deposit_owner::<<T as Config>::BalanceMigrationManager>(&subject, sender)?;
+			let did_entry = Did::<T>::get(&subject).ok_or(Error::<T>::NotFound)?;
+
+			DidDepositCollector::<T>::change_deposit_owner::<<T as Config>::BalanceMigrationManager>(
+				&subject,
+				sender.clone(),
+			)?;
+
+			Self::deposit_event(Event::<T>::DepositOwnerChanged {
+				did: subject,
+				from: did_entry.deposit.owner,
+				to: sender,
+			});
 
 			Ok(())
 		}

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -372,7 +372,7 @@ pub mod pallet {
 		/// The deposit for a DID has changed owner.
 		DepositOwnerChanged {
 			/// The DID whose deposit owner changed.
-			did: DidIdentifierOf<T>,
+			id: DidIdentifierOf<T>,
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -1122,7 +1122,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				did: subject,
+				id: subject,
 				from: did_entry.deposit.owner,
 				to: sender,
 			});

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -1114,16 +1114,13 @@ pub mod pallet {
 			let subject = source.subject();
 			let sender = source.sender();
 
-			let did_entry = Did::<T>::get(&subject).ok_or(Error::<T>::NotFound)?;
-
-			DidDepositCollector::<T>::change_deposit_owner::<<T as Config>::BalanceMigrationManager>(
-				&subject,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = DidDepositCollector::<T>::change_deposit_owner::<
+				<T as Config>::BalanceMigrationManager,
+			>(&subject, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: subject,
-				from: did_entry.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/did/src/tests/deposit.rs
+++ b/pallets/did/src/tests/deposit.rs
@@ -167,6 +167,13 @@ fn test_change_deposit_owner() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &alice_did),
 				<Test as did::Config>::BaseDeposit::get()
 			);
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					alice_did,
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		});
 }
 

--- a/pallets/did/src/tests/deposit.rs
+++ b/pallets/did/src/tests/deposit.rs
@@ -169,7 +169,7 @@ fn test_change_deposit_owner() {
 			);
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					alice_did,
+					id: alice_did,
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -156,7 +156,7 @@ pub mod pallet {
 		/// The deposit for an linked account has changed owner.
 		DepositOwnerChanged {
 			/// The tuple of (DID, linked account) whose deposit owner changed.
-			id: (DidIdentifierOf<T>, LinkableAccountId)
+			id: (DidIdentifierOf<T>, LinkableAccountId),
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -388,14 +388,13 @@ pub mod pallet {
 			let record = ConnectedDids::<T>::get(&account).ok_or(Error::<T>::NotFound)?;
 			ensure!(record.did == subject, Error::<T>::NotAuthorized);
 
-			LinkableAccountDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
-				&account,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = LinkableAccountDepositCollector::<T>::change_deposit_owner::<
+				BalanceMigrationManagerOf<T>,
+			>(&account, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: (subject, account),
-				from: record.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -155,10 +155,8 @@ pub mod pallet {
 		MigrationCompleted,
 		/// The deposit for an linked account has changed owner.
 		DepositOwnerChanged {
-			/// The DID whose deposit owner changed.
-			did: DidIdentifierOf<T>,
-			/// The account linked to the DID whose deposit owner changed.
-			account: LinkableAccountId,
+			/// The tuple of (DID, linked account) whose deposit owner changed.
+			id: (DidIdentifierOf<T>, LinkableAccountId)
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -396,8 +394,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				did: subject,
-				account,
+				id: (subject, account),
 				from: record.deposit.owner,
 				to: sender,
 			});

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -153,6 +153,17 @@ pub mod pallet {
 
 		/// All AccountIds have been migrated to LinkableAccountId.
 		MigrationCompleted,
+		/// The deposit for an linked account has changed owner.
+		DepositOwnerChanged {
+			/// The DID whose deposit owner changed.
+			did: DidIdentifierOf<T>,
+			/// The account linked to the DID whose deposit owner changed.
+			account: LinkableAccountId,
+			/// The old deposit owner.
+			from: AccountIdOf<T>,
+			/// The new deposit owner.
+			to: AccountIdOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -374,14 +385,24 @@ pub mod pallet {
 		pub fn change_deposit_owner(origin: OriginFor<T>, account: LinkableAccountId) -> DispatchResult {
 			let source = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
 			let subject = source.subject();
+			let sender = source.sender();
 
 			let record = ConnectedDids::<T>::get(&account).ok_or(Error::<T>::NotFound)?;
 			ensure!(record.did == subject, Error::<T>::NotAuthorized);
 
 			LinkableAccountDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
 				&account,
-				source.sender(),
-			)
+				sender.clone(),
+			)?;
+
+			Self::deposit_event(Event::<T>::DepositOwnerChanged {
+				did: subject,
+				account,
+				from: record.deposit.owner,
+				to: sender,
+			});
+
+			Ok(())
 		}
 
 		/// Updates the deposit amount to the current deposit rate.

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -189,6 +189,10 @@ impl ExtBuilder {
 		let mut ext = sp_io::TestExternalities::new(storage);
 
 		ext.execute_with(|| {
+			// ensure that we are not at the genesis block. Events are not registered for
+			// the genesis block.
+			System::set_block_number(System::block_number() + 1);
+
 			for (sender, did, account) in self.connections {
 				pallet_did_lookup::Pallet::<Test>::add_association(sender, did, account)
 					.expect("Should create connection");

--- a/pallets/pallet-did-lookup/src/tests/deposit.rs
+++ b/pallets/pallet-did-lookup/src/tests/deposit.rs
@@ -19,7 +19,7 @@ use frame_support::{assert_noop, assert_ok, traits::fungible::InspectHold};
 use kilt_support::mock::mock_origin;
 use sp_runtime::{traits::Zero, TokenError};
 
-use crate::{mock::*, Error, HoldReason};
+use crate::{mock::*, Error, Event, HoldReason};
 
 #[test]
 fn test_change_deposit_owner() {
@@ -39,6 +39,14 @@ fn test_change_deposit_owner() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_01),
 				<Test as crate::Config>::Deposit::get()
 			);
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					did: DID_00,
+					account: LINKABLE_ACCOUNT_00,
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		})
 }
 

--- a/pallets/pallet-did-lookup/src/tests/deposit.rs
+++ b/pallets/pallet-did-lookup/src/tests/deposit.rs
@@ -41,8 +41,7 @@ fn test_change_deposit_owner() {
 			);
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					did: DID_00,
-					account: LINKABLE_ACCOUNT_00,
+					id: (DID_00, LINKABLE_ACCOUNT_00),
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -162,6 +162,15 @@ pub mod pallet {
 		Web3NameBanned { name: Web3NameOf<T> },
 		/// A name has been unbanned.
 		Web3NameUnbanned { name: Web3NameOf<T> },
+		/// The deposit for a web3name has changed owner.
+		DepositOwnerChanged {
+			/// The web3name whose deposit owner changed.
+			web3name: Web3NameOf<T>,
+			/// The old deposit owner.
+			from: AccountIdOf<T>,
+			/// The new deposit owner.
+			to: AccountIdOf<T>,
+		},
 	}
 
 	#[pallet::error]
@@ -353,11 +362,20 @@ pub mod pallet {
 		pub fn change_deposit_owner(origin: OriginFor<T>) -> DispatchResult {
 			let source = <T as Config>::OwnerOrigin::ensure_origin(origin)?;
 			let w3n_owner = source.subject();
+			let sender = source.sender();
 			let name = Names::<T>::get(&w3n_owner).ok_or(Error::<T>::NotFound)?;
+			let w3n_entry = Owner::<T>::get(&name).ok_or(Error::<T>::NotFound)?;
+
 			Web3NameStorageDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
 				&name,
-				source.sender(),
+				sender.clone(),
 			)?;
+
+			Self::deposit_event(Event::<T>::DepositOwnerChanged {
+				web3name: name,
+				from: w3n_entry.deposit.owner,
+				to: sender,
+			});
 
 			Ok(())
 		}

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -364,16 +364,14 @@ pub mod pallet {
 			let w3n_owner = source.subject();
 			let sender = source.sender();
 			let name = Names::<T>::get(&w3n_owner).ok_or(Error::<T>::NotFound)?;
-			let w3n_entry = Owner::<T>::get(&name).ok_or(Error::<T>::NotFound)?;
 
-			Web3NameStorageDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
-				&name,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = Web3NameStorageDepositCollector::<T>::change_deposit_owner::<
+				BalanceMigrationManagerOf<T>,
+			>(&name, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: name,
-				from: w3n_entry.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
 		/// The deposit for a web3name has changed owner.
 		DepositOwnerChanged {
 			/// The web3name whose deposit owner changed.
-			web3name: Web3NameOf<T>,
+			id: Web3NameOf<T>,
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -372,7 +372,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				web3name: name,
+				id: name,
 				from: w3n_entry.deposit.owner,
 				to: sender,
 			});

--- a/pallets/pallet-web3-names/src/mock.rs
+++ b/pallets/pallet-web3-names/src/mock.rs
@@ -224,6 +224,10 @@ pub(crate) mod runtime {
 			let mut ext = sp_io::TestExternalities::new(storage);
 
 			ext.execute_with(|| {
+				// ensure that we are not at the genesis block. Events are not registered for
+				// the genesis block.
+				System::set_block_number(System::block_number() + 1);
+
 				for (owner, web3_name, payer) in self.claimed_web3_names {
 					pallet_web3_names::Pallet::<Test>::register_name(web3_name, owner, payer)
 						.expect("Could not register name");

--- a/pallets/pallet-web3-names/src/tests/claim.rs
+++ b/pallets/pallet-web3-names/src/tests/claim.rs
@@ -52,7 +52,7 @@ fn claiming_successful() {
 				owner_details,
 				Web3OwnershipOf::<Test> {
 					owner: DID_00,
-					claimed_at: 0,
+					claimed_at: 1,
 					deposit: Deposit {
 						owner: ACCOUNT_00,
 						amount: Web3NameDeposit::get(),

--- a/pallets/pallet-web3-names/src/tests/deposit.rs
+++ b/pallets/pallet-web3-names/src/tests/deposit.rs
@@ -21,7 +21,7 @@ use frame_support::{assert_noop, assert_ok, traits::fungible::InspectHold};
 use kilt_support::{mock::mock_origin, Deposit};
 use sp_runtime::{traits::Zero, TokenError};
 
-use crate::{mock::*, Config, Error, HoldReason, Owner, Pallet};
+use crate::{mock::*, Config, Error, Event, HoldReason, Owner, Pallet};
 
 #[test]
 fn test_change_deposit_owner() {
@@ -48,6 +48,13 @@ fn test_change_deposit_owner() {
 				Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_01),
 				<Test as Config>::Deposit::get()
 			);
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					web3name: web3_name_00.clone(),
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		})
 }
 

--- a/pallets/pallet-web3-names/src/tests/deposit.rs
+++ b/pallets/pallet-web3-names/src/tests/deposit.rs
@@ -50,7 +50,7 @@ fn test_change_deposit_owner() {
 			);
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					web3name: web3_name_00.clone(),
+					id: web3_name_00.clone(),
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/public-credentials/src/lib.rs
+++ b/pallets/public-credentials/src/lib.rs
@@ -227,7 +227,7 @@ pub mod pallet {
 		/// The deposit for a public credential has changed owner.
 		DepositOwnerChanged {
 			/// The claim hash of the credential whose deposit owner changed.
-			credential_id: CredentialIdOf<T>,
+			id: CredentialIdOf<T>,
 			/// The old deposit owner.
 			from: AccountIdOf<T>,
 			/// The new deposit owner.
@@ -545,7 +545,7 @@ pub mod pallet {
 			)?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
-				credential_id,
+				id: credential_id,
 				from: credential_entry.deposit.owner,
 				to: sender,
 			});

--- a/pallets/public-credentials/src/lib.rs
+++ b/pallets/public-credentials/src/lib.rs
@@ -539,14 +539,13 @@ pub mod pallet {
 
 			ensure!(subject == credential_entry.attester, Error::<T>::NotAuthorized);
 
-			PublicCredentialDepositCollector::<T>::change_deposit_owner::<BalanceMigrationManagerOf<T>>(
-				&credential_id,
-				sender.clone(),
-			)?;
+			let old_deposit_owner = PublicCredentialDepositCollector::<T>::change_deposit_owner::<
+				BalanceMigrationManagerOf<T>,
+			>(&credential_id, sender.clone())?;
 
 			Self::deposit_event(Event::<T>::DepositOwnerChanged {
 				id: credential_id,
-				from: credential_entry.deposit.owner,
+				from: old_deposit_owner,
 				to: sender,
 			});
 

--- a/pallets/public-credentials/src/mock.rs
+++ b/pallets/public-credentials/src/mock.rs
@@ -421,6 +421,10 @@ pub(crate) mod runtime {
 			let mut ext = sp_io::TestExternalities::new(storage);
 
 			ext.execute_with(|| {
+				// ensure that we are not at the genesis block. Events are not registered for
+				// the genesis block.
+				System::set_block_number(System::block_number() + 1);
+
 				for ctype in self.ctypes {
 					ctype::Ctypes::<Test>::insert(
 						ctype.0,

--- a/pallets/public-credentials/src/mock.rs
+++ b/pallets/public-credentials/src/mock.rs
@@ -287,7 +287,7 @@ pub(crate) mod runtime {
 		type Hashing = BlakeTwo256;
 		type AccountId = AccountId;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type BlockHashCount = ConstU64<250>;
 		type DbWeight = RocksDbWeight;
 		type Version = ();
@@ -312,7 +312,7 @@ pub(crate) mod runtime {
 		type MaxFreezes = ConstU32<10>;
 		type Balance = Balance;
 		type DustRemoval = ();
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type ExistentialDeposit = ConstU128<MILLI_UNIT>;
 		type AccountStore = System;
 		type WeightInfo = ();
@@ -326,7 +326,7 @@ pub(crate) mod runtime {
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, Self::CtypeCreatorId>;
 		type OverarchingOrigin = EnsureSigned<AccountId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type WeightInfo = ();
 
 		type Currency = Balances;
@@ -344,7 +344,7 @@ pub(crate) mod runtime {
 		type Currency = Balances;
 		type Deposit = ConstU128<{ 10 * MILLI_UNIT }>;
 		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, Self::AttesterId>;
-		type RuntimeEvent = ();
+		type RuntimeEvent = RuntimeEvent;
 		type MaxEncodedClaimsLength = ConstU32<500>;
 		type MaxSubjectIdLength = ConstU32<100>;
 		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, Self::AttesterId>;

--- a/pallets/public-credentials/src/tests/claim.rs
+++ b/pallets/public-credentials/src/tests/claim.rs
@@ -65,7 +65,7 @@ fn add_successful_without_authorization() {
 			// Test this pallet logic
 			assert_eq!(stored_public_credential_details.attester, attester);
 			assert!(!stored_public_credential_details.revoked);
-			assert_eq!(stored_public_credential_details.block_number, 0);
+			assert_eq!(stored_public_credential_details.block_number, 1);
 			assert_eq!(stored_public_credential_details.ctype_hash, ctype_hash_1);
 			assert_eq!(stored_public_credential_details.authorization_id, None);
 			assert_eq!(CredentialSubjects::<Test>::get(credential_id_1), Some(subject_id));
@@ -146,7 +146,7 @@ fn add_successful_with_authorization() {
 			// Test this pallet logic
 			assert_eq!(stored_public_credential_details.attester, attester);
 			assert!(!stored_public_credential_details.revoked);
-			assert_eq!(stored_public_credential_details.block_number, 0);
+			assert_eq!(stored_public_credential_details.block_number, 1);
 			assert_eq!(stored_public_credential_details.ctype_hash, ctype_hash);
 			assert_eq!(stored_public_credential_details.authorization_id, Some(attester));
 			assert_eq!(CredentialSubjects::<Test>::get(credential_id), Some(subject_id));

--- a/pallets/public-credentials/src/tests/deposit.rs
+++ b/pallets/public-credentials/src/tests/deposit.rs
@@ -149,7 +149,7 @@ fn test_change_deposit_owner() {
 			assert!(Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_00).is_zero());
 			assert!(System::events().iter().any(|e| e.event
 				== Event::<Test>::DepositOwnerChanged {
-					credential_id,
+					id: credential_id,
 					from: ACCOUNT_00,
 					to: ACCOUNT_01
 				}

--- a/pallets/public-credentials/src/tests/deposit.rs
+++ b/pallets/public-credentials/src/tests/deposit.rs
@@ -25,7 +25,7 @@ use sp_runtime::traits::Zero;
 use ctype::mock::get_ctype_hash;
 use kilt_support::{mock::mock_origin::DoubleOrigin, Deposit};
 
-use crate::{mock::*, Config, CredentialIdOf, CredentialSubjects, Credentials, Error, HoldReason};
+use crate::{mock::*, Config, CredentialIdOf, CredentialSubjects, Credentials, Error, Event, HoldReason};
 
 #[test]
 fn reclaim_deposit_successful() {
@@ -147,6 +147,13 @@ fn test_change_deposit_owner() {
 				<Test as Config>::Deposit::get()
 			);
 			assert!(Balances::balance_on_hold(&HoldReason::Deposit.into(), &ACCOUNT_00).is_zero());
+			assert!(System::events().iter().any(|e| e.event
+				== Event::<Test>::DepositOwnerChanged {
+					credential_id,
+					from: ACCOUNT_00,
+					to: ACCOUNT_01
+				}
+				.into()));
 		});
 }
 

--- a/support/src/traits.rs
+++ b/support/src/traits.rs
@@ -197,7 +197,7 @@ pub trait StorageDepositCollector<AccountId, Key, RuntimeHoldReason> {
 		reserve_deposit::<AccountId, Self::Currency>(who, amount, &reason.into())
 	}
 
-	/// Change the deposit owner.
+	/// Change the deposit owner and returns the old owner.
 	///
 	/// The deposit balance of the current owner will be freed, while the
 	/// deposit balance of the new owner will get reserved. The deposit amount
@@ -205,7 +205,7 @@ pub trait StorageDepositCollector<AccountId, Key, RuntimeHoldReason> {
 	fn change_deposit_owner<DepositBalanceMigrationManager>(
 		key: &Key,
 		new_owner: AccountId,
-	) -> Result<(), DispatchError>
+	) -> Result<AccountId, DispatchError>
 	where
 		DepositBalanceMigrationManager:
 			BalanceMigrationManager<AccountId, <Self::Currency as Inspect<AccountId>>::Balance>,
@@ -222,6 +222,8 @@ pub trait StorageDepositCollector<AccountId, Key, RuntimeHoldReason> {
 			DepositBalanceMigrationManager::exclude_key_from_migration(&hashed_key);
 		}
 
+		let old_deposit_owner = deposit.owner;
+
 		let deposit = Deposit {
 			owner: new_owner,
 			..deposit
@@ -231,7 +233,7 @@ pub trait StorageDepositCollector<AccountId, Key, RuntimeHoldReason> {
 
 		Self::store_deposit(key, deposit)?;
 
-		Ok(())
+		Ok(old_deposit_owner)
 	}
 
 	/// Update the deposit amount.


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3074.

Cc @kilted-andres 

I tried to keep the event structure in all pallets the same, with the same name and the same fields `id`, `from` and `to`. The `id` field has a different type depending on the pallet, but the `from` and `to` are all the same.