### PR TITLE
chore: add bootnodes to spiritnet.json

### DIFF
--- a/chainspecs/spiritnet/spiritnet.json
+++ b/chainspecs/spiritnet/spiritnet.json
@@ -11,7 +11,8 @@
     "/dns/kilt.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWHZ6ftYNVQDm5gbHvtGgkPStaBBQBje8rrtxdH1jJonkW",
     "/dns/kilt.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWMgyhbAKBkEqvKP5bPGTCJZ4nYziJhQep9aHRAkZW8xyy",
     "/dns4/boot.helikon.io/tcp/8570/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
-    "/dns4/boot.helikon.io/tcp/8572/wss/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu"
+    "/dns4/boot.helikon.io/tcp/8572/wss/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
+    "/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4"
   ],
   "telemetryEndpoints": [
     [

--- a/chainspecs/spiritnet/spiritnet.json
+++ b/chainspecs/spiritnet/spiritnet.json
@@ -12,7 +12,8 @@
     "/dns/kilt.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWMgyhbAKBkEqvKP5bPGTCJZ4nYziJhQep9aHRAkZW8xyy",
     "/dns4/boot.helikon.io/tcp/8570/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
     "/dns4/boot.helikon.io/tcp/8572/wss/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
-    "/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4"
+    "/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4",
+    "/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/30368/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
## fixes KILTProtocol/ticket#312
Please include a summary of the changes provided with this pull request and which issue has been fixed.
Please also provide some context if necessary.

- Add bootnodes to kilt spiritnet

New kilt bootnode, verify with :
```
 <kilt-binary> --chain=spiritnet --reserved-only --reserved-nodes=/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4
```
```
<kilt-binary> --chain=spiritnet --reserved-only --reserved-nodes=/dns/kilt-polkadot-boot-ng.dwellir.com/tcp/30368/p2p/12D3KooWRLyHNCYbYMpQWWESNqyW925VP6vMesotaAXSVB3Efhv4
```

## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>
```
```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
```

</details>

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
