### PR TITLE
Add RadiumBlock bootnodes to Spiritnet chain spec

### DIFF
--- a/chainspecs/spiritnet/spiritnet.json
+++ b/chainspecs/spiritnet/spiritnet.json
@@ -11,7 +11,9 @@
     "/dns/kilt.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWHZ6ftYNVQDm5gbHvtGgkPStaBBQBje8rrtxdH1jJonkW",
     "/dns/kilt.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWMgyhbAKBkEqvKP5bPGTCJZ4nYziJhQep9aHRAkZW8xyy",
     "/dns4/boot.helikon.io/tcp/8570/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
-    "/dns4/boot.helikon.io/tcp/8572/wss/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu"
+    "/dns4/boot.helikon.io/tcp/8572/wss/p2p/12D3KooWGaE81VE2rzD5TbeRqpTgQwh2sWXMVfMJLBMHQH8AfoXu",
+    "/dns/kilt-bootnode.radiumblock.com/tcp/30333/p2p/12D3KooWDjWPL4sMV92dXb55sbvQkHjZzG3jzF2XePGEHqYtdo3j",
+    "/dns/kilt-bootnode.radiumblock.com/tcp/30336/wss/p2p/12D3KooWDjWPL4sMV92dXb55sbvQkHjZzG3jzF2XePGEHqYtdo3j"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
## fixes KILTProtocol/ticket#312

Please consider adding RadiumBlock bootnodes to Spiritnet Chain spec.

## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>

```
```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
```

</details>

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
