### PR TITLE
feat: reset team and freeze assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7134,6 +7134,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-assets",
  "pallet-balances",
  "parity-scale-codec",

--- a/pallets/pallet-bonded-coins/Cargo.toml
+++ b/pallets/pallet-bonded-coins/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 
 # external 
+log             = { workspace = true }
 substrate-fixed = { workspace = true }
 
 parity-scale-codec = { workspace = true, features = ["derive"] }

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -70,7 +70,7 @@ pub mod pallet {
 	pub(crate) type FungiblesBalanceOf<T> =
 		<<T as Config>::Fungibles as InspectFungibles<<T as frame_system::Config>::AccountId>>::Balance;
 
-	pub type FungiblesAssetIdOf<T> =
+	pub(crate) type FungiblesAssetIdOf<T> =
 		<<T as Config>::Fungibles as InspectFungibles<<T as frame_system::Config>::AccountId>>::AssetId;
 
 	pub(crate) type PoolDetailsOf<T> =

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -105,7 +105,9 @@ pub mod pallet {
 			+ DestroyFungibles<Self::AccountId>
 			+ FungiblesMetadata<Self::AccountId>
 			+ FungiblesInspect<Self::AccountId>
-			+ MutateFungibles<Self::AccountId, Balance = CollateralCurrencyBalanceOf<Self>>;
+			+ MutateFungibles<Self::AccountId, Balance = CollateralCurrencyBalanceOf<Self>>
+			+ ResetTeam<Self::AccountId, AssetId = Self::AssetId>
+			+ Freeze<Self>;
 		/// The maximum number of currencies allowed for a single pool.
 		#[pallet::constant]
 		type MaxCurrencies: Get<u32>;
@@ -136,10 +138,6 @@ pub mod pallet {
 
 		/// The type used for the curve parameters.
 		type CurveParameterType: Parameter + Member + FixedSigned + MaxEncodedLen + PartialOrd<I9F23> + From<I9F23>;
-
-		type FreezeManager: Freeze<Self>;
-
-		type TeamManager: ResetTeam<Self::AccountId, AssetId = Self::AssetId>;
 	}
 
 	#[pallet::pallet]
@@ -269,7 +267,7 @@ pub mod pallet {
 					denomination,
 				)?;
 
-				T::TeamManager::reset_team(
+				T::Fungibles::reset_team(
 					asset_id.clone(),
 					pool_id.clone().into(),
 					entry.team.admin.clone(),
@@ -278,7 +276,7 @@ pub mod pallet {
 				)?;
 
 				if !entry.tradable {
-					T::FreezeManager::freeze_asset(pool_id.clone().into(), asset_id.clone())?;
+					T::Fungibles::freeze_asset(pool_id.clone().into(), asset_id.clone())?;
 				}
 			}
 

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -245,8 +245,6 @@ pub mod runtime {
 		type AssetId = AssetId;
 		type BaseDeposit = ExistentialDeposit;
 		type CurveParameterType = Float;
-		type FreezeManager = Assets;
-		type TeamManager = Assets;
 	}
 
 	#[derive(Clone, Default)]

--- a/pallets/pallet-bonded-coins/src/pool_details.rs
+++ b/pallets/pallet-bonded-coins/src/pool_details.rs
@@ -7,7 +7,6 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies> {
 	pub curve: ParametrizedCurve,
 	pub bonded_currencies: Currencies,
 	pub state: PoolStatus<Locks>,
-	pub transferable: bool,
 	pub denomination: u8,
 }
 
@@ -51,7 +50,6 @@ where
 		manager: AccountId,
 		curve: ParametrizedCurve,
 		bonded_currencies: Currencies,
-		transferable: bool,
 		state: PoolStatus<Locks>,
 		denomination: u8,
 	) -> Self {
@@ -59,7 +57,6 @@ where
 			manager,
 			curve,
 			bonded_currencies,
-			transferable,
 			state,
 			denomination,
 		}
@@ -95,8 +92,17 @@ where
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
-pub struct TokenMeta<Balance, Symbol, Name> {
+pub struct TokenMeta<Balance, Symbol, Name, AccountId> {
 	pub name: Name,
 	pub symbol: Symbol,
 	pub min_balance: Balance,
+	pub tradable: bool,
+	pub team: Team<AccountId>,
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, TypeInfo)]
+pub struct Team<AccountId> {
+	pub admin: AccountId,
+	pub issuer: AccountId,
+	pub freezer: AccountId,
 }

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -16,14 +16,7 @@ fn test_burn_into_account() {
 
 	let denomination = 10;
 
-	let pool = calculate_pool_details(
-		currencies,
-		ACCOUNT_01,
-		false,
-		curve.clone(),
-		PoolStatus::Active,
-		denomination,
-	);
+	let pool = calculate_pool_details(currencies, ACCOUNT_01, curve.clone(), PoolStatus::Active, denomination);
 
 	let active_issuance_pre = Float::from_num(1);
 	let passive_issuance = Float::from_num(0);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/mint_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/mint_into.rs
@@ -16,14 +16,7 @@ fn test_mint_into_account() {
 
 	let denomination = 10;
 
-	let pool = calculate_pool_details(
-		currencies,
-		ACCOUNT_01,
-		false,
-		curve.clone(),
-		PoolStatus::Active,
-		denomination,
-	);
+	let pool = calculate_pool_details(currencies, ACCOUNT_01, curve.clone(), PoolStatus::Active, denomination);
 
 	let active_issuance_pre = Float::from_num(0);
 	let passive_issuance = Float::from_num(0);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
@@ -13,7 +13,7 @@ fn test_set_lock() {
 
 	let curve = get_linear_bonding_curve();
 
-	let pool = calculate_pool_details(currencies, ACCOUNT_01, false, curve.clone(), PoolStatus::Active, 10);
+	let pool = calculate_pool_details(currencies, ACCOUNT_01, curve.clone(), PoolStatus::Active, 10);
 
 	let target_lock: Locks = Default::default();
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/swap_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/swap_into.rs
@@ -17,7 +17,7 @@ fn test_swap_into_non_ratio_function() {
 
 	let curve = get_linear_bonding_curve();
 
-	let pool_details = calculate_pool_details(currencies, ACCOUNT_01, false, curve.clone(), PoolStatus::Active, 10);
+	let pool_details = calculate_pool_details(currencies, ACCOUNT_01, curve.clone(), PoolStatus::Active, 10);
 
 	let collateral_balance_supply = one_collateral_currency * 10;
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
@@ -18,7 +18,6 @@ fn test_unlock() {
 	let pool = calculate_pool_details(
 		currencies,
 		ACCOUNT_01,
-		false,
 		curve.clone(),
 		PoolStatus::Locked(target_lock.clone()),
 		10,

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -1,0 +1,7 @@
+use frame_support::dispatch::DispatchResult;
+
+use crate::Config;
+
+pub trait Freeze<T: Config> {
+	fn freeze_asset(who: T::AccountId, asset_id: T::AssetId) -> DispatchResult;
+}

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -1,7 +1,28 @@
-use frame_support::dispatch::DispatchResult;
+use frame_support::{dispatch::DispatchResult, traits::fungibles::Inspect};
 
 use crate::Config;
 
 pub trait Freeze<T: Config> {
 	fn freeze_asset(who: T::AccountId, asset_id: T::AssetId) -> DispatchResult;
+}
+
+/// Copied from the Polkadot SDK. For version 1.7.0, the trait is not yet implemented.
+/// /// This should be removed once the pallet_asset includes the implementation.
+/// Trait for resetting the team configuration of an existing fungible asset.
+pub trait ResetTeam<AccountId>: Inspect<AccountId> {
+	/// Reset the team for the asset with the given `id`.
+	///
+	/// ### Parameters
+	/// - `id`: The identifier of the asset for which the team is being reset.
+	/// - `owner`: The new `owner` account for the asset.
+	/// - `admin`: The new `admin` account for the asset.
+	/// - `issuer`: The new `issuer` account for the asset.
+	/// - `freezer`: The new `freezer` account for the asset.
+	fn reset_team(
+		id: Self::AssetId,
+		owner: AccountId,
+		admin: AccountId,
+		issuer: AccountId,
+		freezer: AccountId,
+	) -> DispatchResult;
 }


### PR DESCRIPTION
## fixes 

This PR introduces the reset team and the ability to freeze currencies. In the creation step, each currency requires a team, where the issuer, admin, and freezer must be specified. Additionally, the tradability of each currency can be activated or deactivated.

In the latest Polkadot SDK version, the reset team functionality is already implemented in `pallet_assets`. For now, the trait has been copied into the bonded pallet crate. This will need to be updated once the trait becomes available in the Polkadot SDK.

