### PR TITLE
refactor: bonding curves teardown

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -481,7 +481,7 @@ pub mod pallet {
 
 			ensure!(pool_details.is_manager(&who), Error::<T>::Unauthorized);
 
-			Self::do_start_destroy_pool(&mut pool_details)?;
+			Self::do_start_destroy_pool(&mut pool_details, &pool_id.clone().into())?;
 
 			Self::deposit_event(Event::DestructionStarted(pool_id));
 			Ok(())
@@ -494,7 +494,7 @@ pub mod pallet {
 
 			let mut pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
-			Self::do_start_destroy_pool(&mut pool_details)?;
+			Self::do_start_destroy_pool(&mut pool_details, &pool_id.clone().into())?;
 
 			Self::deposit_event(Event::DestructionStarted(pool_id));
 			Ok(())
@@ -516,7 +516,7 @@ pub mod pallet {
 
 			let pool_account = pool_id.clone().into();
 
-			let total_collateral_issuance = Self::get_pool_collateral(&pool_account);
+			let mut total_collateral_issuance = Self::get_pool_collateral(&pool_account);
 
 			ensure!(!total_collateral_issuance.is_zero(), Error::<T>::ZeroAmount);
 
@@ -526,36 +526,47 @@ pub mod pallet {
 				.map(|id| T::Fungibles::total_issuance(id.clone()))
 				.collect();
 
-			let sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
+			let mut sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
 				.iter()
 				.fold(Zero::zero(), |sum, x| sum.saturating_add(*x));
 
 			ensure!(!sum_of_issuances.is_zero(), Error::<T>::ZeroAmount);
 
 			for (idx, currency_id) in pool_details.bonded_currencies.iter().enumerate() {
-				if !total_issuances[idx].is_zero() {
-					let burnt = T::Fungibles::decrease_balance(
-						currency_id.clone(),
-						&who,
-						Bounded::max_value(),
-						Precision::BestEffort,
-						Preservation::Expendable,
-						Fortitude::Force,
-					)?;
+				if total_issuances[idx].is_zero() {
+					continue;
+				}
+				let burnt = T::Fungibles::decrease_balance(
+					currency_id.clone(),
+					&who,
+					Bounded::max_value(),
+					Precision::BestEffort,
+					Preservation::Expendable,
+					Fortitude::Force,
+				)?;
 
-					let amount = burnt
-						.checked_mul(&total_collateral_issuance)
-						.ok_or(ArithmeticError::Overflow)? // TODO: do we need a fallback if this fails?
-						.checked_div(&sum_of_issuances)
-						.unwrap_or(Zero::zero());
+				let amount = burnt
+					.checked_mul(&total_collateral_issuance)
+					.ok_or(ArithmeticError::Overflow)? // TODO: do we need a fallback if this fails?
+					.checked_div(&sum_of_issuances)
+					.unwrap_or(Zero::zero());
 
-					T::CollateralCurrency::transfer(
-						T::CollateralAssetId::get(),
-						&pool_account,
-						&who,
-						amount,
-						Preservation::Expendable,
-					)?;
+				T::CollateralCurrency::transfer(
+					T::CollateralAssetId::get(),
+					&pool_account,
+					&who,
+					amount,
+					Preservation::Expendable,
+				)?;
+
+				total_collateral_issuance -= amount;
+				sum_of_issuances -= burnt;
+			}
+
+			// destroy currencies if the total issuance or collateral has dropped to 0
+			if total_collateral_issuance.is_zero() || sum_of_issuances.is_zero() {
+				for currency_id in pool_details.bonded_currencies.iter() {
+					T::Fungibles::start_destroy(currency_id.clone(), None)?;
 				}
 			}
 
@@ -563,40 +574,6 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(9)]
-		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
-		pub fn start_destroy_currencies(origin: OriginFor<T>, pool_id: T::PoolId) -> DispatchResult {
-			ensure_signed(origin)?;
-
-			let pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
-
-			ensure!(pool_details.state.is_destroying(), Error::<T>::InUse);
-
-			let pool_account = pool_id.clone().into();
-
-			let total_collateral_issuance = Self::get_pool_collateral(&pool_account);
-
-			if !total_collateral_issuance.is_zero() {
-				let total_issuances: Vec<FungiblesBalanceOf<T>> = pool_details
-					.bonded_currencies
-					.iter()
-					.map(|id| T::Fungibles::total_issuance(id.clone()))
-					.collect();
-
-				let sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
-					.iter()
-					.fold(Zero::zero(), |sum, x| sum.saturating_add(*x));
-
-				ensure!(!sum_of_issuances.is_zero(), Error::<T>::InUse);
-			}
-
-			for currency_id in pool_details.bonded_currencies.iter() {
-				T::Fungibles::start_destroy(currency_id.clone(), None)?;
-			}
-
-			Ok(())
-		}
-
-		#[pallet::call_index(10)]
 		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
 		pub fn finish_destroy(origin: OriginFor<T>, pool_id: T::PoolId) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -763,10 +740,32 @@ pub mod pallet {
 			Ok(cost)
 		}
 
-		fn do_start_destroy_pool(pool_details: &mut PoolDetailsOf<T>) -> DispatchResult {
+		fn do_start_destroy_pool(pool_details: &mut PoolDetailsOf<T>, pool_account: &AccountIdOf<T>) -> DispatchResult {
 			ensure!(!pool_details.state.is_destroying(), Error::<T>::Destroying);
 
 			pool_details.state.destroy();
+
+			let total_collateral_issuance = Self::get_pool_collateral(&pool_account);
+
+			if !total_collateral_issuance.is_zero() {
+				let total_issuances: Vec<FungiblesBalanceOf<T>> = pool_details
+					.bonded_currencies
+					.iter()
+					.map(|id| T::Fungibles::total_issuance(id.clone()))
+					.collect();
+
+				let sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
+					.iter()
+					.fold(Zero::zero(), |sum, x| sum.saturating_add(*x));
+
+				if !sum_of_issuances.is_zero() {
+					return Ok(());
+				};
+			}
+
+			for currency_id in pool_details.bonded_currencies.iter() {
+				T::Fungibles::start_destroy(currency_id.clone(), None)?;
+			}
 
 			Ok(())
 		}

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -204,7 +204,6 @@ pub mod pallet {
 			curve: Curve<CurveParameterTypeOf<T>>,
 			currencies: BoundedVec<TokenMetaOf<T>, T::MaxCurrencies>,
 			tradable: bool, // Todo: make it useful.
-			state: PoolStatus<Locks>,
 			pool_manager: AccountIdOf<T>,
 		) -> DispatchResult {
 			// ensure origin is PoolCreateOrigin
@@ -264,7 +263,13 @@ pub mod pallet {
 
 			Pools::<T>::set(
 				&pool_id,
-				Some(PoolDetails::new(pool_manager, curve, currency_ids, tradable, state)),
+				Some(PoolDetails::new(
+					pool_manager,
+					curve,
+					currency_ids,
+					tradable,
+					PoolStatus::Locked(Locks::default()),
+				)),
 			);
 
 			Self::deposit_event(Event::PoolCreated(pool_id));
@@ -503,9 +508,14 @@ pub mod pallet {
 		pub fn refund_accounts(origin: OriginFor<T>, pool_id: T::PoolId, max_accounts: u32) -> DispatchResult {
 			ensure_signed(origin)?;
 
-			let pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
+			let mut pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
-			ensure!(pool_details.state.is_destroying(), Error::<T>::Destroying); // TODO: incorrect error
+			let last_completed_currency: usize = match pool_details.state {
+				PoolStatus::Destroying(last_index) => Ok(last_index.saturated_into()),
+				_ => Err(Error::<T>::Destroying), // TODO: incorrect error
+			}?;
+
+			let currencies_todo = &pool_details.bonded_currencies[last_completed_currency..];
 
 			let pool_account = pool_id.clone().into();
 
@@ -513,10 +523,9 @@ pub mod pallet {
 
 			let total_issuances: Vec<FungiblesBalanceOf<T>> = if total_collateral_issuance.is_zero() {
 				// nothing to distribute
-				vec![Zero::zero(); pool_details.bonded_currencies.len()]
+				vec![Zero::zero(); currencies_todo.len()]
 			} else {
-				pool_details
-					.bonded_currencies
+				currencies_todo
 					.iter()
 					.map(|id| T::Fungibles::total_issuance(id.clone()))
 					.collect()
@@ -531,7 +540,7 @@ pub mod pallet {
 
 			let mut remaining_max_accounts = max_accounts.clone();
 
-			for (idx, currency_id) in pool_details.bonded_currencies.clone().iter().enumerate() {
+			for (idx, currency_id) in currencies_todo.iter().enumerate() {
 				if !total_issuances[idx].is_zero() {
 					let refunded_accounts = Self::do_refund_accounts(
 						currency_id.clone(),
@@ -547,7 +556,11 @@ pub mod pallet {
 					}
 				}
 				// issuance is zero or no more accounts; currency can be destroyed
-				T::Fungibles::start_destroy(currency_id.clone(), None)?; // TODO: can be called multiple times, but can we somehow avoid it?
+				T::Fungibles::start_destroy(currency_id.clone(), None)?;
+				let this_currency_idx = idx
+					.checked_add(last_completed_currency)
+					.ok_or(ArithmeticError::Overflow)?;
+				pool_details.state.set_destroying(this_currency_idx.saturated_into());
 			}
 
 			Ok(())
@@ -723,7 +736,7 @@ pub mod pallet {
 		fn do_start_destroy_pool(pool_details: &mut PoolDetailsOf<T>) -> DispatchResult {
 			ensure!(!pool_details.state.is_destroying(), Error::<T>::Destroying);
 
-			pool_details.state.destroy();
+			pool_details.state.set_destroying(0);
 
 			Ok(())
 		}

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -40,7 +40,7 @@ pub mod pallet {
 	use parity_scale_codec::FullCodec;
 	use scale_info::TypeInfo;
 	use sp_runtime::{
-		traits::{Bounded, CheckedAdd, CheckedDiv, CheckedSub, One, Saturating, StaticLookup, Zero},
+		traits::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, Saturating, StaticLookup, Zero},
 		ArithmeticError, BoundedVec, FixedPointNumber, SaturatedConversion,
 	};
 	use sp_std::{default::Default, iter::Iterator, vec::Vec};
@@ -185,6 +185,8 @@ pub mod pallet {
 		Destroying,
 		/// The user is not privileged to perform the requested operation.
 		Unauthorized,
+		/// The pool is in use and cannot be destroyed at this point.
+		InUse,
 	}
 
 	#[pallet::composite_enum]
@@ -500,54 +502,61 @@ pub mod pallet {
 
 		#[pallet::call_index(8)]
 		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
-		pub fn refund_accounts(origin: OriginFor<T>, pool_id: T::PoolId, max_accounts: u32) -> DispatchResult {
+		pub fn refund_account(
+			origin: OriginFor<T>,
+			pool_id: T::PoolId,
+			account: AccountIdLookupOf<T>,
+		) -> DispatchResult {
 			ensure_signed(origin)?;
+			let who = T::Lookup::lookup(account)?;
 
 			let pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
-			ensure!(pool_details.state.is_destroying(), Error::<T>::Destroying); // TODO: incorrect error
+			ensure!(pool_details.state.is_destroying(), Error::<T>::InUse);
 
 			let pool_account = pool_id.clone().into();
 
 			let total_collateral_issuance = Self::get_pool_collateral(&pool_account);
 
-			let total_issuances: Vec<FungiblesBalanceOf<T>> = if total_collateral_issuance.is_zero() {
-				// nothing to distribute
-				vec![Zero::zero(); pool_details.bonded_currencies.len()]
-			} else {
-				pool_details
-					.bonded_currencies
-					.iter()
-					.map(|id| T::Fungibles::total_issuance(id.clone()))
-					.collect()
-			};
+			ensure!(!total_collateral_issuance.is_zero(), Error::<T>::ZeroAmount);
+
+			let total_issuances: Vec<FungiblesBalanceOf<T>> = pool_details
+				.bonded_currencies
+				.iter()
+				.map(|id| T::Fungibles::total_issuance(id.clone()))
+				.collect();
 
 			let sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
 				.iter()
 				.fold(Zero::zero(), |sum, x| sum.saturating_add(*x));
-			let collateral_per_token = total_collateral_issuance
-				.checked_div(&sum_of_issuances)
-				.unwrap_or(Zero::zero());
 
-			let mut remaining_max_accounts = max_accounts.clone();
+			ensure!(!sum_of_issuances.is_zero(), Error::<T>::ZeroAmount);
 
-			for (idx, currency_id) in pool_details.bonded_currencies.clone().iter().enumerate() {
+			for (idx, currency_id) in pool_details.bonded_currencies.iter().enumerate() {
 				if !total_issuances[idx].is_zero() {
-					let refunded_accounts = Self::do_refund_accounts(
+					let burnt = T::Fungibles::decrease_balance(
 						currency_id.clone(),
-						collateral_per_token,
-						remaining_max_accounts,
-						&pool_account,
+						&who,
+						Bounded::max_value(),
+						Precision::BestEffort,
+						Preservation::Expendable,
+						Fortitude::Force,
 					)?;
-					if remaining_max_accounts > refunded_accounts {
-						remaining_max_accounts -= refunded_accounts;
-					} else {
-						// max_accounts reached; stop execution
-						return Ok(());
-					}
+
+					let amount = burnt
+						.checked_mul(&total_collateral_issuance)
+						.ok_or(ArithmeticError::Overflow)? // TODO: do we need a fallback if this fails?
+						.checked_div(&sum_of_issuances)
+						.unwrap_or(Zero::zero());
+
+					T::CollateralCurrency::transfer(
+						T::CollateralAssetId::get(),
+						&pool_account,
+						&who,
+						amount,
+						Preservation::Expendable,
+					)?;
 				}
-				// issuance is zero or no more accounts; currency can be destroyed
-				T::Fungibles::start_destroy(currency_id.clone(), None)?; // TODO: can be called multiple times, but can we somehow avoid it?
 			}
 
 			Ok(())
@@ -555,12 +564,46 @@ pub mod pallet {
 
 		#[pallet::call_index(9)]
 		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
+		pub fn start_destroy_currencies(origin: OriginFor<T>, pool_id: T::PoolId) -> DispatchResult {
+			ensure_signed(origin)?;
+
+			let pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
+
+			ensure!(pool_details.state.is_destroying(), Error::<T>::InUse);
+
+			let pool_account = pool_id.clone().into();
+
+			let total_collateral_issuance = Self::get_pool_collateral(&pool_account);
+
+			if !total_collateral_issuance.is_zero() {
+				let total_issuances: Vec<FungiblesBalanceOf<T>> = pool_details
+					.bonded_currencies
+					.iter()
+					.map(|id| T::Fungibles::total_issuance(id.clone()))
+					.collect();
+
+				let sum_of_issuances: FungiblesBalanceOf<T> = total_issuances
+					.iter()
+					.fold(Zero::zero(), |sum, x| sum.saturating_add(*x));
+
+				ensure!(!sum_of_issuances.is_zero(), Error::<T>::InUse);
+			}
+
+			for currency_id in pool_details.bonded_currencies.iter() {
+				T::Fungibles::start_destroy(currency_id.clone(), None)?;
+			}
+
+			Ok(())
+		}
+
+		#[pallet::call_index(10)]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
 		pub fn finish_destroy(origin: OriginFor<T>, pool_id: T::PoolId) -> DispatchResult {
 			ensure_signed(origin)?;
 
 			let pool_details = Pools::<T>::get(pool_id.clone()).ok_or(Error::<T>::PoolUnknown)?;
 
-			ensure!(pool_details.state.is_destroying(), Error::<T>::Destroying);
+			ensure!(pool_details.state.is_destroying(), Error::<T>::InUse);
 
 			for currency_id in pool_details.bonded_currencies {
 				if T::Fungibles::asset_exists(currency_id.clone()) {
@@ -726,37 +769,6 @@ pub mod pallet {
 			pool_details.state.destroy();
 
 			Ok(())
-		}
-
-		fn do_refund_accounts(
-			currency_id: FungiblesAssetIdOf<T>,
-			collateral_per_token: CollateralCurrencyBalanceOf<T>,
-			remaining_max_accounts: u32,
-			collateral_account: &AccountIdOf<T>,
-		) -> Result<u32, DispatchError> {
-			// TODO: how do we get the accounts?
-			let accounts = vec![];
-
-			for who in accounts.iter() {
-				let burnt = T::Fungibles::decrease_balance(
-					currency_id.clone(),
-					who,
-					Bounded::max_value(),
-					Precision::BestEffort,
-					Preservation::Expendable,
-					Fortitude::Force,
-				)?;
-
-				T::CollateralCurrency::transfer(
-					T::CollateralAssetId::get(),
-					collateral_account,
-					who,
-					burnt.saturating_mul(collateral_per_token.clone()),
-					Preservation::Expendable,
-				)?;
-			}
-
-			Ok(accounts.len().saturated_into())
 		}
 
 		fn generate_sequential_asset_ids(mut start_id: T::AssetId, count: usize) -> (Vec<T::AssetId>, T::AssetId) {

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -12,27 +12,27 @@ pub struct Locks {
 }
 
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub enum PoolStatus<LockType, CurrencyIndex> {
+pub enum PoolStatus<LockType> {
 	Active,
 	Locked(LockType),
-	Destroying(CurrencyIndex),
+	Destroying,
 }
 
-impl<LockType, CurrencyIndex> PoolStatus<LockType, CurrencyIndex> {
+impl<LockType> PoolStatus<LockType> {
 	pub fn is_active(&self) -> bool {
 		matches!(self, Self::Active)
 	}
 
 	pub fn is_destroying(&self) -> bool {
-		matches!(self, Self::Destroying(_))
+		matches!(self, Self::Destroying)
 	}
 
-	pub fn set_frozen(&mut self, lock: LockType) {
+	pub fn freeze(&mut self, lock: LockType) {
 		*self = Self::Locked(lock);
 	}
 
-	pub fn set_destroying(&mut self, at_currency: CurrencyIndex) {
-		*self = Self::Destroying(at_currency);
+	pub fn destroy(&mut self) {
+		*self = Self::Destroying;
 	}
 }
 
@@ -41,7 +41,7 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies> {
 	pub manager: AccountId,
 	pub curve: ParametrizedCurve,
 	pub bonded_currencies: Currencies,
-	pub state: PoolStatus<Locks, u32>,
+	pub state: PoolStatus<Locks>,
 	pub transferable: bool,
 }
 
@@ -54,7 +54,7 @@ where
 		curve: ParametrizedCurve,
 		bonded_currencies: Currencies,
 		transferable: bool,
-		state: PoolStatus<Locks, u32>,
+		state: PoolStatus<Locks>,
 	) -> Self {
 		Self {
 			manager,

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -12,27 +12,27 @@ pub struct Locks {
 }
 
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub enum PoolStatus<LockType> {
+pub enum PoolStatus<LockType, CurrencyIndex> {
 	Active,
 	Locked(LockType),
-	Destroying,
+	Destroying(CurrencyIndex),
 }
 
-impl<LockType> PoolStatus<LockType> {
+impl<LockType, CurrencyIndex> PoolStatus<LockType, CurrencyIndex> {
 	pub fn is_active(&self) -> bool {
 		matches!(self, Self::Active)
 	}
 
 	pub fn is_destroying(&self) -> bool {
-		matches!(self, Self::Destroying)
+		matches!(self, Self::Destroying(_))
 	}
 
-	pub fn freeze(&mut self, lock: LockType) {
+	pub fn set_frozen(&mut self, lock: LockType) {
 		*self = Self::Locked(lock);
 	}
 
-	pub fn destroy(&mut self) {
-		*self = Self::Destroying;
+	pub fn set_destroying(&mut self, at_currency: CurrencyIndex) {
+		*self = Self::Destroying(at_currency);
 	}
 }
 
@@ -41,7 +41,7 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies> {
 	pub manager: AccountId,
 	pub curve: ParametrizedCurve,
 	pub bonded_currencies: Currencies,
-	pub state: PoolStatus<Locks>,
+	pub state: PoolStatus<Locks, u32>,
 	pub transferable: bool,
 }
 
@@ -54,7 +54,7 @@ where
 		curve: ParametrizedCurve,
 		bonded_currencies: Currencies,
 		transferable: bool,
-		state: PoolStatus<Locks>,
+		state: PoolStatus<Locks, u32>,
 	) -> Self {
 		Self {
 			manager,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3655

Implements a refund mechanism which awards each bonded token holder a share of the pool collateral, proportional to the amount of tokens they hold.

In the current state, the shutdown process for a pool is as follows:
1. As the pool owner/admin, call the `start_destroy` extrinsic on the bonded coins pallet. This sets the pool in 'destroying' state.
2. In this state, anyone can call the `refund_account` extrinsic for any account that holds bonded tokens. This will result in the account's holdings being destroyed, in exchange for some amount of collateral. The call will fail if there is no collateral left, or if no bonded tokens exist (bonded token total issuance is 0).
3. If the collateral or bonded token total issuance is 0, and the pool is in 'destroying' state, anyone can call `start_destroy_currencies`. This sets all currencies linked to the pool to 'destroying' state.
4. If there are any accounts that have not been destroyed by draining their balance, `destroy_accounts` on the assets pallet must be called. This is a permissionless call and can be called by anyone.
5. If there are any approvals created via assets pallet calls, `destroy_approvals` on the assets pallet must be called. This is a permissionless call and can be called by anyone.
6. Once there are no more accounts and approvals, `finish_destroy` can be called on the bonded tokens pallet, which will destroy all linked assets (if still existing) and the pool, refunding deposits and remaining collateral to the pool admin/owner.

__ALTERNATIVE:__

I can most likely check for collateral/total issuance being zero already on steps 1 & 2, which would allow to get rid of step 3 - but at the cost of increased complexity & weight of step 2, which is called repeatedly.

## Metadata Diff to Develop Branch

<details>
<summary>Peregrine Diff</summary>

```
```

</details>

<details>
<summary>Spiritnet Diff</summary>

```
```

</details>

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
