### PR TITLE
feat: support for unique linking

### DIFF
--- a/dip-template/runtimes/dip-provider/src/lib.rs
+++ b/dip-template/runtimes/dip-provider/src/lib.rs
@@ -433,6 +433,7 @@ impl pallet_did_lookup::Config for Runtime {
 	type OriginSuccess = DidRawOrigin<AccountId, DidIdentifier>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
+	type UniqueLinkingEnabled = ConstBool<false>;
 	type WeightInfo = weights::pallet_did_lookup::WeightInfo<Runtime>;
 }
 

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -131,6 +131,11 @@ pub mod pallet {
 
 		/// Migration manager to handle new created entries
 		type BalanceMigrationManager: BalanceMigrationManager<AccountIdOf<Self>, BalanceOf<Self, I>>;
+
+		// Flag specifying whether there should only ever be a single account <-> DID
+		// link, or multiple.
+		#[pallet::constant]
+		type UniqueLinkingEnabled: Get<bool>;
 	}
 
 	#[pallet::pallet]
@@ -196,6 +201,9 @@ pub mod pallet {
 		///
 		/// NOTE: this will only be returned if the storage has inconsistencies.
 		Migration,
+		/// The deployed pallet supports a single account <-> link, which has
+		/// already been previously created for the provided DID.
+		LinkExisting,
 	}
 
 	#[pallet::genesis_config]
@@ -445,6 +453,19 @@ pub mod pallet {
 				deposit,
 				did: did_identifier.clone(),
 			};
+
+			// We don't care if an account is linked to a new DID (handled below by
+			// replacing the old with the new), but we care that if the unique linking flag
+			// is on, the DID can have a single account linked.
+			let is_did_already_linked = ConnectedAccounts::<T, I>::iter_key_prefix(&did_identifier)
+				.next()
+				.is_some();
+			let is_unique_flag_enabled = <T as Config<I>>::UniqueLinkingEnabled::get();
+			// Either flag not enabled, or if it is, the DID is not already linked.
+			ensure!(
+				!is_unique_flag_enabled || !is_did_already_linked,
+				Error::<T, I>::LinkExisting
+			);
 
 			LinkableAccountDepositCollector::<T, I>::create_deposit(
 				record.clone().deposit.owner,

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -454,18 +454,13 @@ pub mod pallet {
 				did: did_identifier.clone(),
 			};
 
-			// We don't care if an account is linked to a new DID (handled below by
-			// replacing the old with the new), but we care that if the unique linking flag
-			// is on, the DID can have a single account linked.
-			let is_did_already_linked = ConnectedAccounts::<T, I>::iter_key_prefix(&did_identifier)
-				.next()
-				.is_some();
 			let is_unique_flag_enabled = <T as Config<I>>::UniqueLinkingEnabled::get();
-			// Either flag not enabled, or if it is, the DID is not already linked.
-			ensure!(
-				!is_unique_flag_enabled || !is_did_already_linked,
-				Error::<T, I>::LinkExisting
-			);
+			if is_unique_flag_enabled {
+				let is_did_already_linked = ConnectedAccounts::<T, I>::iter_key_prefix(&did_identifier)
+					.next()
+					.is_some();
+				ensure!(!is_did_already_linked, Error::<T, I>::LinkExisting);
+			}
 
 			LinkableAccountDepositCollector::<T, I>::create_deposit(
 				record.clone().deposit.owner,

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -199,7 +199,6 @@ impl ExtBuilder {
 		self
 	}
 
-	#[allow(dead_code)]
 	pub fn with_unique_connections(mut self) -> Self {
 		self.unique_flag = Some(());
 		self

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -16,13 +16,14 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_support::parameter_types;
+use frame_support::{pallet_prelude::ValueQuery, parameter_types, storage_alias};
 use frame_system::pallet_prelude::BlockNumberFor;
 use kilt_support::{
 	mock::{mock_origin, SubjectId},
 	traits::StorageDepositCollector,
 };
 
+use sp_core::Get;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
 	BuildStorage, MultiSignature,
@@ -109,6 +110,23 @@ parameter_types! {
 	pub const DidLookupDeposit: Balance = 10;
 }
 
+pub struct UniqueLinkEnabledFlag;
+
+#[storage_alias]
+type FlagStorage = StorageValue<DidLookup, bool, ValueQuery>;
+
+impl UniqueLinkEnabledFlag {
+	fn set(flag: bool) {
+		FlagStorage::set(flag)
+	}
+}
+
+impl Get<bool> for UniqueLinkEnabledFlag {
+	fn get() -> bool {
+		FlagStorage::get()
+	}
+}
+
 impl pallet_did_lookup::Config for Test {
 	type BalanceMigrationManager = ();
 	type RuntimeEvent = RuntimeEvent;
@@ -119,6 +137,7 @@ impl pallet_did_lookup::Config for Test {
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type DidIdentifier = SubjectId;
 	type WeightInfo = ();
+	type UniqueLinkingEnabled = UniqueLinkEnabledFlag;
 }
 
 impl mock_origin::Config for Test {
@@ -163,6 +182,7 @@ pub struct ExtBuilder {
 	balances: Vec<(AccountId, Balance)>,
 	/// list of connection (sender, did, connected address)
 	connections: Vec<(AccountId, SubjectId, LinkableAccountId)>,
+	unique_flag: Option<()>,
 }
 
 impl ExtBuilder {
@@ -176,6 +196,12 @@ impl ExtBuilder {
 	#[must_use]
 	pub fn with_connections(mut self, connections: Vec<(AccountId, SubjectId, LinkableAccountId)>) -> Self {
 		self.connections = connections;
+		self
+	}
+
+	#[allow(dead_code)]
+	pub fn with_unique_connections(mut self) -> Self {
+		self.unique_flag = Some(());
 		self
 	}
 
@@ -197,6 +223,8 @@ impl ExtBuilder {
 				pallet_did_lookup::Pallet::<Test>::add_association(sender, did, account)
 					.expect("Should create connection");
 			}
+
+			UniqueLinkEnabledFlag::set(self.unique_flag.is_some());
 		});
 		ext
 	}

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -182,7 +182,7 @@ pub struct ExtBuilder {
 	balances: Vec<(AccountId, Balance)>,
 	/// list of connection (sender, did, connected address)
 	connections: Vec<(AccountId, SubjectId, LinkableAccountId)>,
-	unique_flag: Option<()>,
+	unique_flag: bool,
 }
 
 impl ExtBuilder {
@@ -200,7 +200,7 @@ impl ExtBuilder {
 	}
 
 	pub fn with_unique_connections(mut self) -> Self {
-		self.unique_flag = Some(());
+		self.unique_flag = true;
 		self
 	}
 
@@ -223,7 +223,7 @@ impl ExtBuilder {
 					.expect("Should create connection");
 			}
 
-			UniqueLinkEnabledFlag::set(self.unique_flag.is_some());
+			UniqueLinkEnabledFlag::set(self.unique_flag);
 		});
 		ext
 	}

--- a/pallets/pallet-dip-consumer/src/mock.rs
+++ b/pallets/pallet-dip-consumer/src/mock.rs
@@ -23,7 +23,7 @@ use frame_support::{
 		traits::{BlakeTwo256, IdentityLookup},
 		AccountId32,
 	},
-	traits::{ConstU16, ConstU32, ConstU64, Contains, Currency, Everything},
+	traits::{ConstBool, ConstU16, ConstU32, ConstU64, Contains, Currency, Everything},
 };
 use frame_system::{mocking::MockBlock, EnsureSigned};
 
@@ -94,6 +94,7 @@ impl pallet_did_lookup::Config for TestRuntime {
 	type OriginSuccess = DipOrigin<AccountId32, AccountId32, ()>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
+	type UniqueLinkingEnabled = ConstBool<false>;
 	type WeightInfo = ();
 }
 

--- a/pallets/pallet-migration/src/mock.rs
+++ b/pallets/pallet-migration/src/mock.rs
@@ -57,7 +57,7 @@ pub mod runtime {
 	use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 	use public_credentials::InputSubjectIdOf;
 	use scale_info::TypeInfo;
-	use sp_core::{ed25519, ConstU128, ConstU32};
+	use sp_core::{ed25519, ConstBool, ConstU128, ConstU32};
 	use sp_runtime::{
 		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
 		AccountId32, BuildStorage, MultiSignature, MultiSigner, Perquintill, RuntimeDebug,
@@ -309,6 +309,7 @@ pub mod runtime {
 		type DidIdentifier = SubjectId;
 		type WeightInfo = ();
 		type BalanceMigrationManager = Migration;
+		type UniqueLinkingEnabled = ConstBool<false>;
 	}
 
 	pub(crate) type TestWeb3Name = AsciiWeb3Name<Test>;

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -30,7 +30,7 @@ use frame_system::{mocking::MockBlock, pallet_prelude::BlockNumberFor, EnsureRoo
 use kilt_dip_primitives::RevealedWeb3Name;
 use pallet_did_lookup::{account::AccountId20, linkable_account::LinkableAccountId};
 use pallet_web3_names::{web3_name::AsciiWeb3Name, Web3NameOf};
-use sp_core::{sr25519, ConstU128, ConstU16, ConstU32, ConstU64};
+use sp_core::{sr25519, ConstBool, ConstU128, ConstU16, ConstU32, ConstU64};
 use sp_runtime::{traits::IdentityLookup, AccountId32, BoundedVec};
 
 use crate::{
@@ -169,6 +169,7 @@ impl pallet_did_lookup::Config for TestRuntime {
 	type OriginSuccess = AccountId;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
+	type UniqueLinkingEnabled = ConstBool<false>;
 	type WeightInfo = ();
 }
 

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -437,6 +437,9 @@ impl pallet_did_lookup::Config for Runtime {
 	type OriginSuccess = did::DidRawOrigin<AccountId, DidIdentifier>;
 	type BalanceMigrationManager = ();
 	type WeightInfo = ();
+	// Do not change the below flag to `true` without also deploying a runtime
+	// migration which removes any links that point to the same DID!
+	type UniqueLinkingEnabled = ConstBool<false>;
 }
 
 impl pallet_web3_names::Config for Runtime {

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -702,6 +702,9 @@ impl pallet_did_lookup::Config for Runtime {
 
 	type WeightInfo = weights::pallet_did_lookup::WeightInfo<Runtime>;
 	type BalanceMigrationManager = Migration;
+	// Do not change the below flag to `true` without also deploying a runtime
+	// migration which removes any links that point to the same DID!
+	type UniqueLinkingEnabled = ConstBool<false>;
 }
 
 impl pallet_web3_names::Config for Runtime {

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -695,6 +695,9 @@ impl pallet_did_lookup::Config for Runtime {
 
 	type WeightInfo = weights::pallet_did_lookup::WeightInfo<Runtime>;
 	type BalanceMigrationManager = Migration;
+	// Do not change the below flag to `true` without also deploying a runtime
+	// migration which removes any links that point to the same DID!
+	type UniqueLinkingEnabled = ConstBool<false>;
 }
 
 impl pallet_web3_names::Config for Runtime {


### PR DESCRIPTION
Part of https://github.com/KILTprotocol/ticket/issues/3650. Built on top of https://github.com/KILTprotocol/kilt-node/pull/781.

## Trade-off

I chose to go this way instead of providing an optional counter, because providing a counter would require one of the following two approaches:

1. Transform the storage double map into a counted one, requiring a migration also for our currently-deployed pallet, which I wanted to avoid
2. Not use a counter, but iterate every time to make sure there are still "spots" left for the current DID. This would require changing the benchmarking logic as now we have a potentially unbounded iteration happening. I also wanted to avoid that.

Hence, the solution was to provide a somehow more limited feature of simply specifying whether the links are expected to be unique per DID or not. This, as long as we set `false` for our deployed pallets would not require any storage migration, and does not require any changes in the benchmarks, so I found it a good compromise.