### PR TITLE
feat: new runtime API for unique linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15016,6 +15016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unique-linking-runtime-api"
+version = "1.15.0-dev"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8759,6 +8759,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "unique-linking-runtime-api",
 ]
 
 [[package]]
@@ -13813,6 +13814,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "unique-linking-runtime-api",
 ]
 
 [[package]]
@@ -15020,6 +15022,7 @@ name = "unique-linking-runtime-api"
 version = "1.15.0-dev"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ kilt-runtime-api-dip-provider       = { path = "runtime-api/dip-provider", defau
 kilt-runtime-api-public-credentials = { path = "runtime-api/public-credentials", default-features = false }
 kilt-runtime-api-staking            = { path = "runtime-api/staking", default-features = false }
 pallet-asset-switch-runtime-api     = { path = "runtime-api/asset-switch", default-features = false }
+unique-linking-runtime-api          = { path = "runtime-api/unique-linking", default-features = false }
 
 # Internal KILT runtimes (with default disabled)
 kestrel-runtime   = { path = "runtimes/kestrel", default-features = false }

--- a/dip-template/runtimes/dip-provider/src/lib.rs
+++ b/dip-template/runtimes/dip-provider/src/lib.rs
@@ -660,6 +660,18 @@ impl_runtime_apis! {
 			})
 		}
 
+		fn batch_query_by_web3_name(names: Vec<Vec<u8>>) -> Vec<Option<kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			names.into_iter().map(Self::query_by_web3_name).collect()
+		}
+
 		fn query_by_account(account: LinkableAccountId) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -689,6 +701,19 @@ impl_runtime_apis! {
 				})
 		}
 
+		fn batch_query_by_account(accounts: Vec<LinkableAccountId>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			accounts.into_iter().map(Self::query_by_account).collect()
+		}
+
 		fn query(did: DidIdentifier) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -711,6 +736,19 @@ impl_runtime_apis! {
 				service_endpoints,
 				details: details.into(),
 			})
+		}
+
+		fn batch_query(dids: Vec<DidIdentifier>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			dids.into_iter().map(Self::query).collect()
 		}
 	}
 

--- a/runtime-api/did/src/lib.rs
+++ b/runtime-api/did/src/lib.rs
@@ -66,7 +66,7 @@ pub type RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, 
 >;
 
 sp_api::decl_runtime_apis! {
-	#[api_version(2)]
+	#[api_version(3)]
 	pub trait Did<DidIdentifier, AccountId, LinkableAccountId, Balance, Key: Ord, BlockNumber: MaxEncodedLen> where
 		DidIdentifier: Codec,
 		AccountId: Codec,
@@ -84,6 +84,9 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn query_by_web3_name(name: Vec<u8>) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, AccountId, Balance, Key, BlockNumber>>;
 		fn query_by_web3_name(name: Vec<u8>) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>;
+		/// Allows for batching multiple `query_by_web3_name` requests into one. For each requested name, the corresponding vector entry contains either `Some` or `None` depending on the result of each query.
+		#[allow(clippy::type_complexity)]
+		fn batch_query_by_web3_name(names: Vec<Vec<u8>>) -> Vec<Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>>;
 		/// Given an account address this returns:
 		/// * the DID
 		/// * public keys stored for the did
@@ -93,6 +96,9 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn query_by_account(account: AccountId) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, AccountId, Balance, Key, BlockNumber>>;
 		fn query_by_account(account: LinkableAccountId) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>;
+		/// Allows for batching multiple `query_by_account` requests into one. For each requested name, the corresponding vector entry contains either `Some` or `None` depending on the result of each query.
+		#[allow(clippy::type_complexity)]
+		fn batch_query_by_account(accounts: Vec<LinkableAccountId>) -> Vec<Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>>;
 		/// Given a did this returns:
 		/// * the DID
 		/// * public keys stored for the did
@@ -102,5 +108,8 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn query(did: DidIdentifier) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, AccountId, Balance, Key, BlockNumber>>;
 		fn query(did: DidIdentifier) -> Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>;
+		/// Allows for batching multiple `query` requests into one. For each requested name, the corresponding vector entry contains either `Some` or `None` depending on the result of each query.
+		#[allow(clippy::type_complexity)]
+		fn batch_query(dids: Vec<DidIdentifier>) -> Vec<Option<RawDidLinkedInfo<DidIdentifier, AccountId, LinkableAccountId, Balance, Key, BlockNumber>>>;
 	}
 }

--- a/runtime-api/unique-linking/Cargo.toml
+++ b/runtime-api/unique-linking/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors       = { workspace = true }
+description   = "Runtime APIs for integrating the unique-lookup capabilities."
+documentation = { workspace = true }
+edition       = { workspace = true }
+homepage      = { workspace = true }
+license-file  = { workspace = true }
+name          = "unique-linking-runtime-api"
+readme        = { workspace = true }
+repository    = { workspace = true }
+version       = { workspace = true }
+
+[dependencies]
+# External dependencies
+parity-scale-codec = { workspace = true }
+
+# Substrate dependencies
+sp-api = { workspace = true }
+sp-std = { workspace = true }
+
+[features]
+default = ["std"]
+std     = ["parity-scale-codec/std", "sp-api/std", "sp-std/std"]

--- a/runtime-api/unique-linking/Cargo.toml
+++ b/runtime-api/unique-linking/Cargo.toml
@@ -13,6 +13,7 @@ version       = { workspace = true }
 [dependencies]
 # External dependencies
 parity-scale-codec = { workspace = true }
+scale-info         = { workspace = true }
 
 # Substrate dependencies
 sp-api = { workspace = true }
@@ -20,4 +21,4 @@ sp-std = { workspace = true }
 
 [features]
 default = ["std"]
-std     = ["parity-scale-codec/std", "sp-api/std", "sp-std/std"]
+std     = ["parity-scale-codec/std", "scale-info/std", "sp-api/std", "sp-std/std"]

--- a/runtime-api/unique-linking/src/lib.rs
+++ b/runtime-api/unique-linking/src/lib.rs
@@ -47,7 +47,7 @@ impl<Name, Extra> NameResult<Name, Extra> {
 }
 
 sp_api::decl_runtime_apis! {
-	pub trait UniqueLookup<Address, Name, Extra, Error> where
+	pub trait UniqueLinking<Address, Name, Extra, Error> where
 		Address: Codec,
 		Name: Codec,
 		Extra: Codec,

--- a/runtime-api/unique-linking/src/lib.rs
+++ b/runtime-api/unique-linking/src/lib.rs
@@ -19,29 +19,43 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use parity_scale_codec::{Codec, Decode, Encode};
+use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, TypeInfo)]
 pub struct AddressResult<Address, Extra> {
 	address: Address,
 	extra: Option<Extra>,
 }
 
-#[derive(Encode, Decode)]
+impl<Address, Extra> AddressResult<Address, Extra> {
+	pub const fn new(address: Address, extra: Option<Extra>) -> Self {
+		Self { address, extra }
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo)]
 pub struct NameResult<Name, Extra> {
 	name: Name,
 	extra: Option<Extra>,
 }
 
+impl<Name, Extra> NameResult<Name, Extra> {
+	pub const fn new(name: Name, extra: Option<Extra>) -> Self {
+		Self { name, extra }
+	}
+}
+
 sp_api::decl_runtime_apis! {
-	pub trait UniqueLookup<Address, Name, Extra> where
+	pub trait UniqueLookup<Address, Name, Extra, Error> where
 		Address: Codec,
 		Name: Codec,
 		Extra: Codec,
+		Error: Codec,
 		{
-			fn address_for_name(name: Name) -> Option<AddressResult<Address, Extra>>;
-			fn batch_address_for_name(names: Vec<Name>) -> Vec<Option<AddressResult<Address, Extra>>>;
-			fn name_for_address(address: Address) -> Option<NameResult<Name, Extra>>;
-			fn batch_name_for_address(addresses: Vec<Address>) -> Vec<Option<NameResult<Name, Extra>>>;
+			fn address_for_name(name: Name) -> Result<Option<AddressResult<Address, Extra>>, Error>;
+			fn batch_address_for_name(names: Vec<Name>) -> Result<Vec<Option<AddressResult<Address, Extra>>>, Error>;
+			fn name_for_address(address: Address) -> Result<Option<NameResult<Name, Extra>>, Error>;
+			fn batch_name_for_address(addresses: Vec<Address>) -> Result<Vec<Option<NameResult<Name, Extra>>>, Error>;
 		}
 }

--- a/runtime-api/unique-linking/src/lib.rs
+++ b/runtime-api/unique-linking/src/lib.rs
@@ -47,15 +47,14 @@ impl<Name, Extra> NameResult<Name, Extra> {
 }
 
 sp_api::decl_runtime_apis! {
-	pub trait UniqueLinking<Address, Name, Extra, Error> where
+	pub trait UniqueLinking<Address, Name, Extra> where
 		Address: Codec,
 		Name: Codec,
 		Extra: Codec,
-		Error: Codec,
 		{
-			fn address_for_name(name: Name) -> Result<Option<AddressResult<Address, Extra>>, Error>;
-			fn batch_address_for_name(names: Vec<Name>) -> Result<Vec<Option<AddressResult<Address, Extra>>>, Error>;
-			fn name_for_address(address: Address) -> Result<Option<NameResult<Name, Extra>>, Error>;
-			fn batch_name_for_address(addresses: Vec<Address>) -> Result<Vec<Option<NameResult<Name, Extra>>>, Error>;
+			fn address_for_name(name: Name) -> Option<AddressResult<Address, Extra>>;
+			fn batch_address_for_name(names: Vec<Name>) -> Vec<Option<AddressResult<Address, Extra>>>;
+			fn name_for_address(address: Address) -> Option<NameResult<Name, Extra>>;
+			fn batch_name_for_address(addresses: Vec<Address>) -> Vec<Option<NameResult<Name, Extra>>>;
 		}
 }

--- a/runtime-api/unique-linking/src/lib.rs
+++ b/runtime-api/unique-linking/src/lib.rs
@@ -1,0 +1,47 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use parity_scale_codec::{Codec, Decode, Encode};
+use sp_std::vec::Vec;
+
+#[derive(Encode, Decode)]
+pub struct AddressResult<Address, Extra> {
+	address: Address,
+	extra: Option<Extra>,
+}
+
+#[derive(Encode, Decode)]
+pub struct NameResult<Name, Extra> {
+	name: Name,
+	extra: Option<Extra>,
+}
+
+sp_api::decl_runtime_apis! {
+	pub trait UniqueLookup<Address, Name, Extra> where
+		Address: Codec,
+		Name: Codec,
+		Extra: Codec,
+		{
+			fn address_for_name(name: Name) -> Option<AddressResult<Address, Extra>>;
+			fn batch_address_for_name(names: Vec<Name>) -> Vec<Option<AddressResult<Address, Extra>>>;
+			fn name_for_address(address: Address) -> Option<NameResult<Name, Extra>>;
+			fn batch_name_for_address(addresses: Vec<Address>) -> Vec<Option<NameResult<Name, Extra>>>;
+		}
+}

--- a/runtimes/common/src/errors.rs
+++ b/runtimes/common/src/errors.rs
@@ -23,3 +23,8 @@ use scale_info::TypeInfo;
 pub enum PublicCredentialsApiError {
 	InvalidSubjectId,
 }
+
+#[derive(Encode, Decode, TypeInfo)]
+pub enum UniqueLinkingApiError {
+	Internal,
+}

--- a/runtimes/common/src/errors.rs
+++ b/runtimes/common/src/errors.rs
@@ -23,8 +23,3 @@ use scale_info::TypeInfo;
 pub enum PublicCredentialsApiError {
 	InvalidSubjectId,
 }
-
-#[derive(Encode, Decode, TypeInfo)]
-pub enum UniqueLinkingApiError {
-	Internal,
-}

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -1034,6 +1034,18 @@ impl_runtime_apis! {
 			})
 		}
 
+		fn batch_query_by_web3_name(names: Vec<Vec<u8>>) -> Vec<Option<kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			names.into_iter().map(Self::query_by_web3_name).collect()
+		}
+
 		fn query_by_account(account: LinkableAccountId) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1063,6 +1075,19 @@ impl_runtime_apis! {
 				})
 		}
 
+		fn batch_query_by_account(accounts: Vec<LinkableAccountId>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			accounts.into_iter().map(Self::query_by_account).collect()
+		}
+
 		fn query(did: DidIdentifier) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1085,6 +1110,19 @@ impl_runtime_apis! {
 				service_endpoints,
 				details: details.into(),
 			})
+		}
+
+		fn batch_query(dids: Vec<DidIdentifier>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			dids.into_iter().map(Self::query).collect()
 		}
 	}
 

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -33,6 +33,7 @@ kilt-runtime-api-public-credentials        = { workspace = true }
 kilt-runtime-api-staking                   = { workspace = true }
 pallet-asset-switch-runtime-api            = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+unique-linking-runtime-api                 = { workspace = true }
 
 # KILT pallets & primitives
 attestation                   = { workspace = true }
@@ -247,6 +248,7 @@ std = [
   "sp-transaction-pool/std",
   "sp-version/std",
   "sp-weights/std",
+  "unique-linking-runtime-api/std",
   "xcm-builder/std",
   "xcm-executor/std",
   "xcm/std",

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1756,7 +1756,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl unique_linking_runtime_api::UniqueLookup<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
+	impl unique_linking_runtime_api::UniqueLinking<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
 		fn address_for_name(name: DotName) -> Result<Option<AddressResult<LinkableAccountId, DidIdentifier>>, UniqueLinkingApiError> {
 			let Some(Web3NameOwnership { owner, .. }) = DotNames::owner(name) else {
 				return Ok(None);

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1572,6 +1572,18 @@ impl_runtime_apis! {
 			})
 		}
 
+		fn batch_query_by_web3_name(names: Vec<Vec<u8>>) -> Vec<Option<kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			names.into_iter().map(Self::query_by_web3_name).collect()
+		}
+
 		fn query_by_account(account: LinkableAccountId) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1601,6 +1613,19 @@ impl_runtime_apis! {
 				})
 		}
 
+		fn batch_query_by_account(accounts: Vec<LinkableAccountId>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			accounts.into_iter().map(Self::query_by_account).collect()
+		}
+
 		fn query(did: DidIdentifier) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1623,6 +1648,19 @@ impl_runtime_apis! {
 				service_endpoints,
 				details: details.into(),
 			})
+		}
+
+		fn batch_query(dids: Vec<DidIdentifier>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			dids.into_iter().map(Self::query).collect()
 		}
 	}
 

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -1765,6 +1765,7 @@ impl_runtime_apis! {
 				(owner_linked_accounts.next(), owner_linked_accounts.next())
 			};
 			let linked_account = match (first_account, second_account) {
+				#[allow(clippy::panic)]
 				(Some(_), Some(_)) => { panic!("More than a single account found for DID {:?}.", owner) },
 				(first, _) => first
 			}?;

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -58,9 +58,11 @@ use xcm_builder::{FungiblesAdapter, NoChecking};
 
 use delegation::DelegationAc;
 use kilt_support::traits::ItemFilter;
-use pallet_did_lookup::linkable_account::LinkableAccountId;
+use pallet_did_lookup::{linkable_account::LinkableAccountId, ConnectionRecord};
+use pallet_web3_names::web3_name::Web3NameOwnership;
 pub use parachain_staking::InflationInfo;
 pub use public_credentials;
+use unique_linking_runtime_api::{AddressResult, NameResult};
 
 use runtime_common::{
 	asset_switch::{runtime_api::Error as AssetSwitchApiError, EnsureRootAsTreasury},
@@ -71,12 +73,12 @@ use runtime_common::{
 		RELAY_CHAIN_SLOT_DURATION_MILLIS, SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
 	},
 	dip::merkle::{CompleteMerkleProof, DidMerkleProofOf, DidMerkleRootGenerator},
-	errors::PublicCredentialsApiError,
+	errors::{PublicCredentialsApiError, UniqueLinkingApiError},
 	fees::{ToAuthorCredit, WeightToFee},
 	pallet_id,
 	xcm_config::RelayOrigin,
-	AccountId, AuthorityId, Balance, BlockHashCount, BlockLength, BlockNumber, BlockWeights, DidIdentifier, DotName,
-	FeeSplit, Hash, Header, Nonce, SendDustAndFeesToTreasury, Signature, SlowAdjustingFeeUpdate,
+	AccountId, AuthorityId, Balance, BlockHashCount, BlockLength, BlockNumber, BlockWeights, DidIdentifier, FeeSplit,
+	Hash, Header, Nonce, SendDustAndFeesToTreasury, Signature, SlowAdjustingFeeUpdate,
 };
 
 use crate::xcm_config::{LocationToAccountIdConverter, UniversalLocation, XcmRouter};
@@ -737,6 +739,8 @@ impl pallet_web3_names::Config for Runtime {
 	type BalanceMigrationManager = Migration;
 }
 
+pub type DotName = runtime_common::DotName<{ constants::dot_names::MIN_LENGTH }, { constants::dot_names::MAX_LENGTH }>;
+
 type DotNamesDeployment = pallet_web3_names::Instance2;
 impl pallet_web3_names::Config<DotNamesDeployment> for Runtime {
 	type BalanceMigrationManager = ();
@@ -749,7 +753,7 @@ impl pallet_web3_names::Config<DotNamesDeployment> for Runtime {
 	type OwnerOrigin = did::EnsureDidOrigin<DidIdentifier, AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	type Web3Name = DotName<{ Self::MinNameLength::get() }, { Self::MaxNameLength::get() }>;
+	type Web3Name = DotName;
 	type Web3NameOwner = DidIdentifier;
 	type WeightInfo = weights::pallet_web3_names_dot_names::WeightInfo<Runtime>;
 }
@@ -1749,6 +1753,49 @@ impl_runtime_apis! {
 			let remote_asset_fee_v4 = Asset::try_from(switch_pair.remote_xcm_fee).map_err(|_| AssetSwitchApiError::Internal)?;
 
 			Ok(VersionedXcm::V4(AssetSwitchPool1::compute_xcm_for_switch(&our_location_for_destination, &from_v4.into(), &to_v4, amount, &asset_id_v4, &remote_asset_fee_v4)))
+		}
+	}
+
+	impl unique_linking_runtime_api::UniqueLookup<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
+		fn address_for_name(name: DotName) -> Result<Option<AddressResult<LinkableAccountId, DidIdentifier>>, UniqueLinkingApiError> {
+			let Some(Web3NameOwnership { owner, .. }) = DotNames::owner(name) else {
+				return Ok(None);
+			};
+
+			let (first_account, second_account) = {
+				let mut owner_linked_accounts = pallet_did_lookup::ConnectedAccounts::<Runtime, UniqueLinkingDeployment>::iter_key_prefix(&owner);
+				(owner_linked_accounts.next(), owner_linked_accounts.next())
+			};
+			let linked_account = match (first_account, second_account) {
+				(Some(_), Some(_)) => Err(UniqueLinkingApiError::Internal),
+				(first, _) => Ok(first)
+			}?;
+
+			let Some(account) = linked_account else {
+				return Ok(None);
+			};
+
+			Ok(Some(AddressResult::new(account, Some(owner))))
+		}
+
+		fn batch_address_for_name(names: Vec<DotName>) -> Result<Vec<Option<AddressResult<LinkableAccountId, DidIdentifier>>>, UniqueLinkingApiError> {
+			names.into_iter().map(Self::address_for_name).collect::<Result<Vec<_>, _>>()
+		}
+
+		fn name_for_address(address: LinkableAccountId) -> Result<Option<NameResult<DotName, DidIdentifier>>, UniqueLinkingApiError> {
+			let Some(ConnectionRecord { did, .. }) = UniqueLinking::connected_dids(address) else {
+				return Ok(None);
+			};
+
+			let Some(name) = DotNames::names(&did) else {
+				return Ok(None);
+			};
+
+			Ok(Some(NameResult::new(name, Some(did))))
+		}
+
+		fn batch_name_for_address(addresses: Vec<LinkableAccountId>) -> Result<Vec<Option<NameResult<DotName, DidIdentifier>>>, UniqueLinkingApiError> {
+			addresses.into_iter().map(Self::name_for_address).collect::<Result<Vec<_>, _>>()
 		}
 	}
 

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -33,6 +33,7 @@ kilt-runtime-api-public-credentials        = { workspace = true }
 kilt-runtime-api-staking                   = { workspace = true }
 pallet-asset-switch-runtime-api            = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+unique-linking-runtime-api                 = { workspace = true }
 
 # KILT pallets & primitives
 attestation                   = { workspace = true }
@@ -246,6 +247,7 @@ std = [
   "sp-transaction-pool/std",
   "sp-version/std",
   "sp-weights/std",
+  "unique-linking-runtime-api/std",
   "xcm-builder/std",
   "xcm-executor/std",
   "xcm/std",

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -1755,6 +1755,7 @@ impl_runtime_apis! {
 				(owner_linked_accounts.next(), owner_linked_accounts.next())
 			};
 			let linked_account = match (first_account, second_account) {
+				#[allow(clippy::panic)]
 				(Some(_), Some(_)) => { panic!("More than a single account found for DID {:?}.", owner) },
 				(first, _) => first
 			}?;

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -1562,6 +1562,18 @@ impl_runtime_apis! {
 			})
 		}
 
+		fn batch_query_by_web3_name(names: Vec<Vec<u8>>) -> Vec<Option<kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			names.into_iter().map(Self::query_by_web3_name).collect()
+		}
+
 		fn query_by_account(account: LinkableAccountId) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1591,6 +1603,19 @@ impl_runtime_apis! {
 				})
 		}
 
+		fn batch_query_by_account(accounts: Vec<LinkableAccountId>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			accounts.into_iter().map(Self::query_by_account).collect()
+		}
+
 		fn query(did: DidIdentifier) -> Option<
 			kilt_runtime_api_did::RawDidLinkedInfo<
 				DidIdentifier,
@@ -1613,6 +1638,19 @@ impl_runtime_apis! {
 				service_endpoints,
 				details: details.into(),
 			})
+		}
+
+		fn batch_query(dids: Vec<DidIdentifier>) -> Vec<Option<
+			kilt_runtime_api_did::RawDidLinkedInfo<
+				DidIdentifier,
+				AccountId,
+				LinkableAccountId,
+				Balance,
+				Hash,
+				BlockNumber
+			>
+		>> {
+			dids.into_iter().map(Self::query).collect()
 		}
 	}
 

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -73,7 +73,7 @@ use runtime_common::{
 		RELAY_CHAIN_SLOT_DURATION_MILLIS, SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
 	},
 	dip::merkle::{CompleteMerkleProof, DidMerkleProofOf, DidMerkleRootGenerator},
-	errors::{PublicCredentialsApiError, UniqueLinkingApiError},
+	errors::PublicCredentialsApiError,
 	fees::{ToAuthorCredit, WeightToFee},
 	pallet_id,
 	xcm_config::RelayOrigin,
@@ -1746,46 +1746,35 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl unique_linking_runtime_api::UniqueLinking<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
-		fn address_for_name(name: DotName) -> Result<Option<AddressResult<LinkableAccountId, DidIdentifier>>, UniqueLinkingApiError> {
-			let Some(Web3NameOwnership { owner, .. }) = DotNames::owner(name) else {
-				return Ok(None);
-			};
+	impl unique_linking_runtime_api::UniqueLinking<Block, LinkableAccountId, DotName, DidIdentifier> for Runtime {
+		fn address_for_name(name: DotName) -> Option<AddressResult<LinkableAccountId, DidIdentifier>> {
+			let Web3NameOwnership { owner, .. } = DotNames::owner(name)?;
 
 			let (first_account, second_account) = {
 				let mut owner_linked_accounts = pallet_did_lookup::ConnectedAccounts::<Runtime, UniqueLinkingDeployment>::iter_key_prefix(&owner);
 				(owner_linked_accounts.next(), owner_linked_accounts.next())
 			};
 			let linked_account = match (first_account, second_account) {
-				(Some(_), Some(_)) => Err(UniqueLinkingApiError::Internal),
-				(first, _) => Ok(first)
+				(Some(_), Some(_)) => { panic!("More than a single account found for DID {:?}.", owner) },
+				(first, _) => first
 			}?;
 
-			let Some(account) = linked_account else {
-				return Ok(None);
-			};
-
-			Ok(Some(AddressResult::new(account, Some(owner))))
+			Some(AddressResult::new(linked_account, Some(owner)))
 		}
 
-		fn batch_address_for_name(names: Vec<DotName>) -> Result<Vec<Option<AddressResult<LinkableAccountId, DidIdentifier>>>, UniqueLinkingApiError> {
-			names.into_iter().map(Self::address_for_name).collect::<Result<Vec<_>, _>>()
+		fn batch_address_for_name(names: Vec<DotName>) -> Vec<Option<AddressResult<LinkableAccountId, DidIdentifier>>> {
+			names.into_iter().map(Self::address_for_name).collect()
 		}
 
-		fn name_for_address(address: LinkableAccountId) -> Result<Option<NameResult<DotName, DidIdentifier>>, UniqueLinkingApiError> {
-			let Some(ConnectionRecord { did, .. }) = UniqueLinking::connected_dids(address) else {
-				return Ok(None);
-			};
+		fn name_for_address(address: LinkableAccountId) -> Option<NameResult<DotName, DidIdentifier>> {
+			let ConnectionRecord { did, .. } = UniqueLinking::connected_dids(address)?;
+			let name = DotNames::names(&did)?;
 
-			let Some(name) = DotNames::names(&did) else {
-				return Ok(None);
-			};
-
-			Ok(Some(NameResult::new(name, Some(did))))
+			Some(NameResult::new(name, Some(did)))
 		}
 
-		fn batch_name_for_address(addresses: Vec<LinkableAccountId>) -> Result<Vec<Option<NameResult<DotName, DidIdentifier>>>, UniqueLinkingApiError> {
-			addresses.into_iter().map(Self::name_for_address).collect::<Result<Vec<_>, _>>()
+		fn batch_name_for_address(addresses: Vec<LinkableAccountId>) -> Vec<Option<NameResult<DotName, DidIdentifier>>> {
+			addresses.into_iter().map(Self::name_for_address).collect()
 		}
 	}
 

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -1746,7 +1746,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl unique_linking_runtime_api::UniqueLookup<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
+	impl unique_linking_runtime_api::UniqueLinking<Block, LinkableAccountId, DotName, DidIdentifier, UniqueLinkingApiError> for Runtime {
 		fn address_for_name(name: DotName) -> Result<Option<AddressResult<LinkableAccountId, DidIdentifier>>, UniqueLinkingApiError> {
 			let Some(Web3NameOwnership { owner, .. }) = DotNames::owner(name) else {
 				return Ok(None);


### PR DESCRIPTION
Part of https://github.com/KILTprotocol/ticket/issues/3650, based on top of https://github.com/KILTprotocol/kilt-node/pull/784. Last bit of required functionality.

## Features

* Since it's not possible to batch multiple runtime API calls, I introduced a `batch_` version for our old `did` runtime API, which allows to do batching instead of firing one request per lookup
* Similarly to that, I introduced a new runtime API (since it's not possible to implement the same API twice for the same runtime), which resolves an account given a name, or a name given an account. This new API also provides a batched version to resolve multiple names or addresses at once. This was one of the requirements we got from Parity to make the solution easier to integrate in the mobile app

## How to test

Polkadot Apps support new runtime APIs out of the box. So just compile Peregrine or Spiritnet runtime and spin up a network with Chopsticks. Then:

1. Create a new account-controlled DID. For the Sudo key, use this call `0x401003921cbc0ffe09a865dbf4ae1d0410aa17c656881fe86666da0f97939e3701b674`
2. Claim a new dotname. For the Sudo key, use this call `0x400f921cbc0ffe09a865dbf4ae1d0410aa17c656881fe86666da0f97939e3701b674490020746573742e646f74`
3. Link the Sudo account to the DID. Use this call `0x400f921cbc0ffe09a865dbf4ae1d0410aa17c656881fe86666da0f97939e3701b6744a01`
4. Call the runtime API `uniqueLinking.addressForName("test.dot")` which should return
```
{
  Ok: {
    address: {
      AccountId32: 4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB
    }
    extra: 4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB
  }
}
```
5. Call the runtime API `uniqueLinking.nameForAddress({AccountId32: "4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB"})` which should return
```
{
  Ok: {
    name: test.dot
    extra: 4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB
  }
}
```