### PR TITLE
test: reset manager and team

### DIFF
--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -36,7 +36,7 @@ pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
 // accounts
 pub(crate) const ACCOUNT_00: AccountId = AccountId::new([0u8; 32]);
 pub(crate) const ACCOUNT_01: AccountId = AccountId::new([1u8; 32]);
-const ACCOUNT_99: AccountId = AccountId::new([99u8; 32]);
+pub(crate) const ACCOUNT_99: AccountId = AccountId::new([99u8; 32]);
 // assets
 pub(crate) const DEFAULT_BONDED_CURRENCY_ID: AssetId = 1;
 pub(crate) const DEFAULT_COLLATERAL_CURRENCY_ID: AssetId = 0;

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -6,6 +6,7 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::OriginFor, RawOrigin};
 use pallet_assets::Error as AssetsPalletErrors;
+use sp_core::bounded_vec;
 use sp_runtime::{ArithmeticError, BoundedVec};
 use sp_std::ops::Sub;
 
@@ -38,7 +39,7 @@ fn single_currency() {
 				origin,
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
-				BoundedVec::truncate_from(vec![bonded_token]),
+				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
 				true
 			));
@@ -118,7 +119,7 @@ fn multi_currency() {
 				min_balance: 1,
 			};
 
-			let bonded_tokens = vec![bonded_token; 3];
+			let bonded_tokens = bounded_vec![bonded_token; 3];
 
 			let next_asset_id = NextAssetId::<Test>::get();
 
@@ -126,7 +127,7 @@ fn multi_currency() {
 				origin,
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
-				BoundedVec::truncate_from(bonded_tokens),
+				bonded_tokens,
 				DEFAULT_BONDED_DENOMINATION,
 				true
 			));
@@ -179,7 +180,7 @@ fn can_create_identical_pools() {
 				origin.clone(),
 				curve.clone(),
 				DEFAULT_COLLATERAL_CURRENCY_ID,
-				BoundedVec::truncate_from(vec![bonded_token.clone()]),
+				bounded_vec![bonded_token.clone()],
 				DEFAULT_BONDED_DENOMINATION,
 				true
 			));
@@ -188,7 +189,7 @@ fn can_create_identical_pools() {
 				origin,
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
-				BoundedVec::truncate_from(vec![bonded_token]),
+				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
 				true
 			));
@@ -226,7 +227,7 @@ fn fails_if_collateral_not_exists() {
 					origin,
 					curve,
 					100,
-					BoundedVec::truncate_from(vec![bonded_token]),
+					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
 					true
 				),
@@ -258,7 +259,7 @@ fn cannot_create_circular_pool() {
 					curve,
 					// try specifying the id of the currency to be created as collateral
 					next_asset_id,
-					BoundedVec::truncate_from(vec![bonded_token]),
+					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
 					true
 				),
@@ -291,8 +292,8 @@ fn handles_asset_id_overflow() {
 					origin,
 					curve,
 					0,
-					BoundedVec::truncate_from(vec![bonded_token; 2]),
-					10,
+					bounded_vec![bonded_token; 2],
+					DEFAULT_BONDED_DENOMINATION,
 					true
 				),
 				ArithmeticError::Overflow

--- a/pallets/pallet-bonded-coins/src/tests/transactions/mod.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/mod.rs
@@ -1,7 +1,7 @@
 mod burn_into;
 mod create_pool;
 mod mint_into;
+mod reset_manager;
 mod set_lock;
 mod swap_into;
-
 mod unlock;

--- a/pallets/pallet-bonded-coins/src/tests/transactions/mod.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/mod.rs
@@ -2,6 +2,7 @@ mod burn_into;
 mod create_pool;
 mod mint_into;
 mod reset_manager;
+mod reset_team;
 mod set_lock;
 mod swap_into;
 mod unlock;

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
@@ -1,0 +1,95 @@
+use frame_support::{assert_err, assert_ok};
+use frame_system::RawOrigin;
+
+use crate::{
+	mock::{runtime::*, *},
+	types::PoolStatus,
+	Error as BondingPalletErrors, Event as BondingPalletEvents, Pools,
+};
+
+#[test]
+fn changes_manager() {
+	let curve = get_linear_bonding_curve();
+
+	let pool_details = generate_pool_details(
+		vec![0],
+		curve,
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+	);
+	let pool_id = calculate_pool_id(&[0]);
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let origin = RawOrigin::Signed(ACCOUNT_00).into();
+			assert_ok!(BondingPallet::reset_manager(origin, pool_id.clone(), Some(ACCOUNT_01)));
+
+			System::assert_has_event(
+				BondingPalletEvents::ManagerUpdated {
+					id: pool_id.clone(),
+					manager: Some(ACCOUNT_01),
+				}
+				.into(),
+			);
+
+			let new_details = Pools::<Test>::get(&pool_id).unwrap();
+			assert_eq!(new_details.manager, Some(ACCOUNT_01));
+			assert_eq!(new_details.owner, pool_details.owner)
+		})
+}
+
+#[test]
+fn only_manager_can_change_manager() {
+	let curve = get_linear_bonding_curve();
+
+	let manager = AccountId::new([10u8; 32]);
+	let pool_details = generate_pool_details(
+		vec![0],
+		curve,
+		false,
+		Some(PoolStatus::Active),
+		Some(manager.clone()),
+		None,
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[0]);
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let owner_origin = RawOrigin::Signed(ACCOUNT_00).into();
+			let other_origin = RawOrigin::Signed(ACCOUNT_01).into();
+
+			assert_err!(
+				BondingPallet::reset_manager(owner_origin, pool_id.clone(), Some(ACCOUNT_00)),
+				BondingPalletErrors::<Test>::NoPermission
+			);
+
+			assert_err!(
+				BondingPallet::reset_manager(other_origin, pool_id.clone(), Some(ACCOUNT_00)),
+				BondingPalletErrors::<Test>::NoPermission
+			);
+
+			let new_details = Pools::<Test>::get(&pool_id).unwrap();
+			assert_eq!(new_details.manager, Some(manager));
+		})
+}
+
+#[test]
+fn cant_change_manager_if_pool_nonexistent() {
+	let pool_id = calculate_pool_id(&[0]);
+	ExtBuilder::default().build().execute_with(|| {
+		let origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+		assert!(Pools::<Test>::get(&pool_id).is_none());
+
+		assert_err!(
+			BondingPallet::reset_manager(origin, pool_id.clone(), Some(ACCOUNT_00)),
+			BondingPalletErrors::<Test>::PoolUnknown
+		);
+	})
+}

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
@@ -12,7 +12,7 @@ fn changes_manager() {
 	let curve = get_linear_bonding_curve();
 
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		curve,
 		false,
 		Some(PoolStatus::Active),
@@ -20,7 +20,7 @@ fn changes_manager() {
 		None,
 		None,
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
 		.build()
@@ -48,7 +48,7 @@ fn only_manager_can_change_manager() {
 
 	let manager = AccountId::new([10u8; 32]);
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		curve,
 		false,
 		Some(PoolStatus::Active),
@@ -56,7 +56,7 @@ fn only_manager_can_change_manager() {
 		None,
 		Some(ACCOUNT_00),
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
 		.build()
@@ -81,7 +81,7 @@ fn only_manager_can_change_manager() {
 
 #[test]
 fn cant_change_manager_if_pool_nonexistent() {
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default().build().execute_with(|| {
 		let origin = RawOrigin::Signed(ACCOUNT_00).into();
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -1,0 +1,171 @@
+use frame_support::{assert_err, assert_ok};
+use frame_system::RawOrigin;
+use pallet_assets::Event as AssetsPalletEvents;
+
+use crate::{
+	mock::{runtime::*, *},
+	types::{PoolManagingTeam, PoolStatus},
+	Error as BondingPalletErrors, Pools,
+};
+
+#[test]
+fn resets_team() {
+	let pool_details = generate_pool_details(
+		vec![0],
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+	);
+	let pool_id = calculate_pool_id(&[0]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::reset_team(
+				manager_origin,
+				pool_id.clone(),
+				PoolManagingTeam {
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				},
+				0
+			));
+
+			System::assert_has_event(
+				AssetsPalletEvents::<Test>::TeamChanged {
+					asset_id: 0,
+					issuer: pool_id,
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				}
+				.into(),
+			);
+		})
+}
+
+#[test]
+fn does_not_change_team_when_not_live() {
+	let pool_details = generate_pool_details(
+		vec![0],
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Refunding),
+		Some(ACCOUNT_00),
+		None,
+		None,
+	);
+	let pool_id = calculate_pool_id(&[0]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_err!(
+				BondingPallet::reset_team(
+					manager_origin,
+					pool_id.clone(),
+					PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_00,
+					},
+					0
+				),
+				BondingPalletErrors::<Test>::PoolNotLive
+			);
+		})
+}
+
+#[test]
+fn only_manager_can_change_team() {
+	let curve = get_linear_bonding_curve();
+
+	let manager = AccountId::new([10u8; 32]);
+	let pool_details = generate_pool_details(
+		vec![0],
+		curve,
+		false,
+		Some(PoolStatus::Active),
+		Some(manager.clone()),
+		None,
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[0]);
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let owner_origin = RawOrigin::Signed(ACCOUNT_00).into();
+			let other_origin = RawOrigin::Signed(ACCOUNT_01).into();
+
+			assert_err!(
+				BondingPallet::reset_team(
+					owner_origin,
+					pool_id.clone(),
+					PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_00,
+					},
+					0
+				),
+				BondingPalletErrors::<Test>::NoPermission
+			);
+
+			assert_err!(
+				BondingPallet::reset_team(
+					other_origin,
+					pool_id.clone(),
+					PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_00,
+					},
+					0
+				),
+				BondingPalletErrors::<Test>::NoPermission
+			);
+
+			let new_details = Pools::<Test>::get(&pool_id).unwrap();
+			assert_eq!(new_details.manager, Some(manager));
+		})
+}
+
+#[test]
+fn handles_currency_idx_out_of_bounds() {
+	let pool_details = generate_pool_details(
+		vec![0],
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+	);
+	let pool_id = calculate_pool_id(&[0]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.build()
+		.execute_with(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_err!(
+				BondingPallet::reset_team(
+					manager_origin,
+					pool_id.clone(),
+					PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_00,
+					},
+					2
+				),
+				BondingPalletErrors::<Test>::IndexOutOfBounds
+			);
+		})
+}

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -11,7 +11,7 @@ use crate::{
 #[test]
 fn resets_team() {
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
 		false,
 		Some(PoolStatus::Active),
@@ -19,7 +19,7 @@ fn resets_team() {
 		None,
 		None,
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
@@ -39,7 +39,7 @@ fn resets_team() {
 
 			System::assert_has_event(
 				AssetsPalletEvents::<Test>::TeamChanged {
-					asset_id: 0,
+					asset_id: DEFAULT_BONDED_CURRENCY_ID,
 					issuer: pool_id,
 					admin: ACCOUNT_00,
 					freezer: ACCOUNT_01,
@@ -52,7 +52,7 @@ fn resets_team() {
 #[test]
 fn does_not_change_team_when_not_live() {
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
 		false,
 		Some(PoolStatus::Refunding),
@@ -60,7 +60,7 @@ fn does_not_change_team_when_not_live() {
 		None,
 		None,
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
@@ -89,7 +89,7 @@ fn only_manager_can_change_team() {
 
 	let manager = AccountId::new([10u8; 32]);
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		curve,
 		false,
 		Some(PoolStatus::Active),
@@ -97,7 +97,7 @@ fn only_manager_can_change_team() {
 		None,
 		Some(ACCOUNT_00),
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
 		.build()
@@ -139,7 +139,7 @@ fn only_manager_can_change_team() {
 #[test]
 fn handles_currency_idx_out_of_bounds() {
 	let pool_details = generate_pool_details(
-		vec![0],
+		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
 		false,
 		Some(PoolStatus::Active),
@@ -147,7 +147,7 @@ fn handles_currency_idx_out_of_bounds() {
 		None,
 		None,
 	);
-	let pool_id = calculate_pool_id(&[0]);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])


### PR DESCRIPTION
## re/ KILTProtocol/ticket#3671

Adds unit tests for changing/resetting pool manager and asset (admin) team.
To be rebased and merged after https://github.com/KILTprotocol/kilt-node/pull/785

Tests currently failing (fix TBD in another PR):

- [ ] Team cannot be reset when pool is not live (fixed by https://github.com/KILTprotocol/kilt-node/pull/786)

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
