### PR TITLE
chore: update cargo-deny file

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -15,6 +15,7 @@ ignore = [
   { id = "RUSTSEC-2024-0336", reason = "`rustls` vulnerability. Re-verify upon next polkadot-sdk updates." },
   { id = "RUSTSEC-2024-0344", reason = "`curve25519-dalek` vulnerability. Re-verify upon next polkadot-sdk updates." },
   { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is unmaintained but a Substrate dependency. Re-verify upon next polkadot-sdk updates." },
+  { id = "RUSTSEC-2024-0384", reason = "`instant` is unmaintained but a Substrate dependency. Re-verify upon next polkadot-sdk updates." },
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained but a Substrate dependency. Re-verify upon next polkadot-sdk updates." },
 ]
 yanked = "deny"

--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -15,6 +15,7 @@ ignore = [
   { id = "RUSTSEC-2024-0336", reason = "`rustls` vulnerability. Re-verify upon next polkadot-sdk updates." },
   { id = "RUSTSEC-2024-0344", reason = "`curve25519-dalek` vulnerability. Re-verify upon next polkadot-sdk updates." },
   { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is unmaintained but a Substrate dependency. Re-verify upon next polkadot-sdk updates." },
+  { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained but a Substrate dependency. Re-verify upon next polkadot-sdk updates." },
 ]
 yanked = "deny"
 


### PR DESCRIPTION
The CI started failing because a Substrate dependency has gone officially unmaintained. We start ignoring that dependency and will re-evaluate at the next polkadot-sdk upgrade what to do.