### PR TITLE
refactor: use U256 for infallible scaling

### DIFF
--- a/pallets/pallet-bonded-coins/src/curves/mod.rs
+++ b/pallets/pallet-bonded-coins/src/curves/mod.rs
@@ -108,7 +108,7 @@ fn calculate_accumulated_passive_issuance<Balance: Fixed>(passive_issuance: &[Ba
 
 pub(crate) fn convert_to_fixed<T: Config>(x: u128, denomination: u8) -> Result<CurveParameterTypeOf<T>, ArithmeticError>
 where
-	<CurveParameterTypeOf<T> as Fixed>::Bits: TryFrom<U256>,
+	<CurveParameterTypeOf<T> as Fixed>::Bits: TryFrom<U256>, // TODO: make large integer type configurable in runtime
 {
 	let decimals = U256::from(10)
 		.checked_pow(denomination.into())
@@ -117,6 +117,8 @@ where
 	let mut x_u256 = U256::from(x);
 	// Shift left to produce the representation that our fixed type would have (but
 	// with extra integer bits that would potentially not fit in the fixed type).
+	// This function can panic in theory, but only if frac_nbits() would be larger
+	// than 256 - and no Fixed of that size exists.
 	x_u256.shl_assign(CurveParameterTypeOf::<T>::frac_nbits());
 	// Perform division. Due to the shift the precision/truncation is identical to
 	// division on the fixed type.

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -262,7 +262,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T>
 	where
 		<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256>,
-		CollateralCurrenciesBalanceOf<T>: Into<U256> + TryFrom<U256>,
+		CollateralCurrenciesBalanceOf<T>: Into<U256> + TryFrom<U256>, // TODO: make large integer type configurable
 	{
 		#[pallet::call_index(0)]
 		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -35,7 +35,7 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::FullCodec;
-	use sp_arithmetic::ArithmeticError;
+	use sp_arithmetic::{traits::CheckedAdd, ArithmeticError};
 	use sp_core::U256;
 	use sp_runtime::{
 		traits::{
@@ -688,7 +688,10 @@ pub mod pallet {
 				.into_iter()
 				.fold(U256::from(0), |sum, id| {
 					sum.saturating_add(T::Fungibles::total_issuance(id).into())
-				});
+				})
+				// Add the burnt amount back to the sum of total supplies
+				.checked_add(burnt)
+				.ok_or(ArithmeticError::Overflow)?;
 
 			defensive_assert!(
 				sum_of_issuances >= burnt,

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::FullCodec;
 	use sp_arithmetic::{traits::CheckedRem, ArithmeticError};
+	use sp_core::U256;
 	use sp_runtime::{
 		traits::{
 			Bounded, CheckedAdd, CheckedDiv, CheckedMul, One, SaturatedConversion, Saturating, StaticLookup,
@@ -261,6 +262,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T>
 	where
+		<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256>,
 		<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<u128>,
 	{
 		#[pallet::call_index(0)]
@@ -824,7 +826,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T>
 	where
-		<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<u128>,
+		<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256>,
 	{
 		fn calculate_collateral(
 			low: CurveParameterTypeOf<T>,

--- a/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
+++ b/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
@@ -75,7 +75,7 @@ fn test_convert_to_fixed_overflow() {
 #[test]
 fn test_convert_to_fixed_denomination_overflow() {
 	let x = 1000u128;
-	let denomination = 128u8; // 10^128 overflows and results in division by zero
+	let denomination = 128u8; // 10^128 overflows
 
 	let result = convert_to_fixed::<Test>(x, denomination);
 	assert!(result.is_err());
@@ -102,11 +102,14 @@ fn test_convert_to_fixed_handles_large_denomination() {
 
 #[test]
 fn test_convert_to_fixed_very_large_denomination() {
-	let x = 10u128.pow(31); // multiple of denomination should not result in overflow of remainder
 	let denomination = 30u8; // I75F53 should handle around 1.8e+22, this can lead to overflow
 
-	let result = convert_to_fixed::<Test>(x, denomination);
-	assert_ok!(result);
+	// multiple of denomination would not result in remainder = 0
+	assert_ok!(convert_to_fixed::<Test>(10u128.pow(31), denomination));
+
+	// non-multiples of denomination could lead to overflow of remainder
+	assert_ok!(convert_to_fixed::<Test>(11u128.pow(31), denomination));
+	assert_ok!(convert_to_fixed::<Test>(10u128.pow(29), denomination));
 }
 
 #[test]


### PR DESCRIPTION
I realised that scaling may be done more elegantly and less likely to overflow by using a U256 to implement what essentially amounts to direct division on a fixed point number with >= 128 integer bits. This way the only overflow we can get is when the result (the scaled value) is too large to fit into the target type. 

In other words, the scaling logic is infallible, with the only error case being that the scaling factor is too small, so that the result cannot be represented.

I wanted to ask for your opinion on this solution before I apply it to my pending PR.    

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
