### PR TITLE
fix: mint into and burn into with min operation balance

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -269,9 +269,8 @@ pub mod pallet {
 		InvalidInput,
 		Internal,
 		Slippage,
-		/// The requested Operation could not be performed due to insufficient
-		/// balance.
-		InsufficientBalance,
+		/// The amount to mint or burn is below the minimum allowed.
+		BelowMinimum,
 		/// The calculated collateral is zero.
 		ZeroCollateral,
 	}
@@ -485,7 +484,7 @@ pub mod pallet {
 
 			ensure!(
 				amount_to_mint >= pool_details.min_operation_balance.saturated_into(),
-				Error::<T>::InsufficientBalance
+				Error::<T>::BelowMinimum
 			);
 
 			ensure!(
@@ -564,7 +563,7 @@ pub mod pallet {
 			ensure!(pool_details.can_burn(&who), Error::<T>::NoPermission);
 			ensure!(
 				amount_to_burn >= pool_details.min_operation_balance.saturated_into(),
-				Error::<T>::InsufficientBalance
+				Error::<T>::BelowMinimum
 			);
 
 			ensure!(

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -301,6 +301,8 @@ pub mod pallet {
 
 			ensure!(denomination <= T::MaxDenomination::get(), Error::<T>::InvalidInput);
 
+			ensure!(!min_operation_balance.is_zero(), Error::<T>::InvalidInput);
+
 			let checked_curve = curve.try_into().map_err(|_| Error::<T>::InvalidInput)?;
 
 			let currency_length = currencies.len();

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -87,11 +87,13 @@ pub mod runtime {
 		manager: Option<AccountId>,
 		collateral_id: Option<AssetId>,
 		owner: Option<AccountId>,
+		min_operation_balance: Option<u128>,
 	) -> PoolDetailsOf<Test> {
 		let bonded_currencies = BoundedVec::truncate_from(currencies);
 		let state = state.unwrap_or(PoolStatus::Active);
 		let owner = owner.unwrap_or(ACCOUNT_99);
 		let collateral_id = collateral_id.unwrap_or(DEFAULT_COLLATERAL_CURRENCY_ID);
+		let min_operation_balance = min_operation_balance.unwrap_or(0);
 		PoolDetailsOf::<Test> {
 			curve,
 			manager,
@@ -101,6 +103,7 @@ pub mod runtime {
 			collateral_id,
 			denomination: DEFAULT_BONDED_DENOMINATION,
 			owner,
+			min_operation_balance,
 		}
 	}
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -41,7 +41,8 @@ fn single_currency() {
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
-				true
+				true,
+				0,
 			));
 
 			let pool_id = calculate_pool_id(&[new_asset_id]);
@@ -129,7 +130,8 @@ fn multi_currency() {
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
 				DEFAULT_BONDED_DENOMINATION,
-				true
+				true,
+				0
 			));
 
 			assert_eq!(NextAssetId::<Test>::get(), next_asset_id + 3);
@@ -182,7 +184,8 @@ fn can_create_identical_pools() {
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token.clone()],
 				DEFAULT_BONDED_DENOMINATION,
-				true
+				true,
+				0
 			));
 
 			assert_ok!(BondingPallet::create_pool(
@@ -191,7 +194,8 @@ fn can_create_identical_pools() {
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
-				true
+				true,
+				0
 			));
 
 			assert_eq!(NextAssetId::<Test>::get(), next_asset_id + 2);
@@ -229,7 +233,8 @@ fn fails_if_collateral_not_exists() {
 					100,
 					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
-					true
+					true,
+					0
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -261,7 +266,8 @@ fn cannot_create_circular_pool() {
 					next_asset_id,
 					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
-					true
+					true,
+					0
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -294,7 +300,8 @@ fn handles_asset_id_overflow() {
 					0,
 					bounded_vec![bonded_token; 2],
 					DEFAULT_BONDED_DENOMINATION,
-					true
+					true,
+					0
 				),
 				ArithmeticError::Overflow
 			);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
@@ -19,6 +19,7 @@ fn changes_manager() {
 		Some(ACCOUNT_00),
 		None,
 		None,
+		None,
 	);
 	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
@@ -55,6 +56,7 @@ fn only_manager_can_change_manager() {
 		Some(manager.clone()),
 		None,
 		Some(ACCOUNT_00),
+		None,
 	);
 	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -17,6 +17,7 @@ fn resets_team() {
 		Some(ACCOUNT_00),
 		None,
 		None,
+		None,
 	);
 	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
@@ -65,6 +66,7 @@ fn does_not_change_team_when_not_live() {
 		Some(ACCOUNT_00),
 		None,
 		None,
+		None,
 	);
 	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
@@ -107,6 +109,7 @@ fn only_manager_can_change_team() {
 		Some(manager.clone()),
 		None,
 		Some(ACCOUNT_00),
+		None,
 	);
 	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
@@ -157,6 +160,7 @@ fn handles_currency_idx_out_of_bounds() {
 		false,
 		Some(PoolStatus::Active),
 		Some(ACCOUNT_00),
+		None,
 		None,
 		None,
 	);

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -59,6 +59,7 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId>
 	pub state: PoolStatus<Locks>,
 	pub transferable: bool,
 	pub denomination: u8,
+	pub min_operation_balance: u128,
 }
 
 impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId>
@@ -73,6 +74,7 @@ where
 		bonded_currencies: Currencies,
 		transferable: bool,
 		denomination: u8,
+		min_operation_balance: u128,
 	) -> Self {
 		Self {
 			manager: Some(owner.clone()),
@@ -83,6 +85,7 @@ where
 			transferable,
 			state: PoolStatus::default(),
 			denomination,
+			min_operation_balance,
 		}
 	}
 


### PR DESCRIPTION
Since the funds are scaled down, we encountered a strange situation where a user could mint or burn funds without returning or taking any collateral.

For example, if a user wants to mint a single unit of a bonded currency, the amount to mint is scaled down based on the denomination specified in the bonding curve. With a denomination of 15, the provided value would be 1 * 10^-15. Such small values can cause side effects, as x^2 of 1 * 10^-15 results in 1 * 10^-30, which underflows and becomes zero.

This allowed users to mint bonded coins without providing any collateral. This behavior is now prevented through two mechanisms:

1. The calculated collateral must always be greater than 0.  
2. The pool creator must specify a `min_operation_balance` to enforce a minimum amount for minting or burning.

I think setting the min_operation_balance in an atomic tx is not a vise idea. This parameter should not be changeable. 