### PR TITLE
test: lock/unlock

### DIFF
--- a/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
@@ -1,1 +1,187 @@
+use crate::{
+	mock::{runtime::*, *},
+	types::{Locks, PoolStatus},
+	Error, Event, Pools,
+};
+use frame_support::{assert_err, assert_ok};
+use frame_system::{pallet_prelude::OriginFor, RawOrigin};
 
+#[test]
+fn set_lock_works() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			let origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::set_lock(origin, pool_id.clone(), Default::default()));
+
+			// Verify that the pool state has been updated to locked
+			let updated_pool = Pools::<Test>::get(&pool_id).unwrap();
+			assert!(matches!(updated_pool.state, PoolStatus::Locked(_)));
+
+			// Verify the expected event has been deposited
+			System::assert_last_event(
+				Event::LockSet {
+					id: pool_id,
+					lock: Default::default(),
+				}
+				.into(),
+			);
+		});
+}
+
+#[test]
+fn set_lock_works_when_locked() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Locked(Locks {
+			allow_mint: true,
+			allow_burn: false,
+			allow_swap: false,
+		})),
+		Some(ACCOUNT_00),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	let new_state = Locks {
+		allow_mint: false,
+		allow_burn: true,
+		allow_swap: false,
+	};
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			let origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::set_lock(origin, pool_id.clone(), new_state.clone()));
+
+			// Verify that the pool state has been updated to locked
+			let updated_pool = Pools::<Test>::get(&pool_id).unwrap();
+			assert_eq!(updated_pool.state, PoolStatus::Locked(new_state.clone()));
+
+			// Verify the expected event has been deposited
+			System::assert_last_event(
+				Event::LockSet {
+					id: pool_id,
+					lock: new_state,
+				}
+				.into(),
+			);
+		});
+}
+
+#[test]
+fn set_lock_fails_when_not_authorized() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_99),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_01, u128::MAX)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			// Does not work for owner
+			assert_err!(
+				BondingPallet::set_lock(
+					RawOrigin::Signed(ACCOUNT_00).into(),
+					pool_id.clone(),
+					Default::default()
+				),
+				Error::<Test>::NoPermission
+			);
+			// Does not work for some other account
+			assert_err!(
+				BondingPallet::set_lock(
+					RawOrigin::Signed(ACCOUNT_01).into(),
+					pool_id.clone(),
+					Default::default()
+				),
+				Error::<Test>::NoPermission
+			);
+		});
+}
+
+#[test]
+fn set_lock_fails_when_not_live() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Refunding),
+		Some(ACCOUNT_00),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
+
+			// Ensure the unlock call fails due to the pool not being in a 'live' state
+			assert_err!(
+				BondingPallet::set_lock(origin.clone(), pool_id.clone(), Default::default()),
+				Error::<Test>::PoolNotLive
+			);
+
+			Pools::<Test>::mutate(&pool_id, |details| {
+				details.as_mut().unwrap().state.start_destroy();
+			});
+
+			assert_err!(
+				BondingPallet::set_lock(origin, pool_id.clone(), Default::default()),
+				Error::<Test>::PoolNotLive
+			);
+		});
+}

--- a/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
@@ -1,1 +1,121 @@
+use crate::{
+	mock::{runtime::*, *},
+	types::PoolStatus,
+	Error, Event, Pools,
+};
+use frame_support::{assert_err, assert_ok};
+use frame_system::{pallet_prelude::OriginFor, RawOrigin};
 
+#[test]
+fn unlock_works() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Locked(Default::default())),
+		Some(ACCOUNT_00),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		None,
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX / 2)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			let origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::unlock(origin, pool_id.clone()));
+
+			// Verify that the pool state has been updated to active
+			let updated_pool = Pools::<Test>::get(&pool_id).unwrap();
+			assert!(matches!(updated_pool.state, PoolStatus::Active));
+
+			// Verify the expected event has been deposited
+			System::assert_last_event(Event::Unlocked { id: pool_id }.into());
+		});
+}
+
+#[test]
+fn unlock_works_only_for_manager() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Locked(Default::default())),
+		Some(ACCOUNT_99),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_01),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX / 2)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			// Does not work for owner
+			assert_err!(
+				BondingPallet::unlock(RawOrigin::Signed(ACCOUNT_01).into(), pool_id.clone()),
+				Error::<Test>::NoPermission
+			);
+			// Does not work for some other account
+			assert_err!(
+				BondingPallet::unlock(RawOrigin::Signed(ACCOUNT_00).into(), pool_id.clone()),
+				Error::<Test>::NoPermission
+			);
+		});
+}
+
+#[test]
+fn unlock_fails_when_not_live() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		true,
+		Some(PoolStatus::Refunding),
+		Some(ACCOUNT_00),
+		Some(DEFAULT_COLLATERAL_CURRENCY_ID),
+		Some(ACCOUNT_00),
+	);
+	let pool_id = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![
+			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
+			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
+		])
+		.build()
+		.execute_with(|| {
+			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
+
+			// Ensure the unlock call fails due to the pool not being in a 'live' state
+			assert_err!(
+				BondingPallet::unlock(origin.clone(), pool_id.clone()),
+				Error::<Test>::PoolNotLive
+			);
+
+			Pools::<Test>::mutate(&pool_id, |details| {
+				details.as_mut().unwrap().state.start_destroy();
+			});
+
+			assert_err!(
+				BondingPallet::unlock(origin, pool_id.clone()),
+				Error::<Test>::PoolNotLive
+			);
+		});
+}


### PR DESCRIPTION
## re/ https://github.com/KILTprotocol/ticket/issues/3671

Implements unit tests for `set_lock` & `unlock`.

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
