### PR TITLE
refactor: decouple balance to fixed from config

### DIFF
--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -13,7 +13,8 @@ use crate::{
 		square_root::{SquareRootParameters, SquareRootParametersInput},
 		Curve, CurveInput,
 	},
-	Call, CollateralAssetIdOf, CollateralCurrenciesBalanceOf, Config, CurveParameterTypeOf, FungiblesAssetIdOf, Pallet,
+	Call, CollateralAssetIdOf, CollateralCurrenciesBalanceOf, Config, CurveParameterTypeOf, FungiblesAssetIdOf,
+	FungiblesBalanceOf, Pallet,
 };
 
 /// Helper trait to calculate asset ids for collateral and bonded assets used in
@@ -66,6 +67,7 @@ fn get_lmsr_curve_input<Float: FixedUnsigned>() -> CurveInput<Float> {
 #[benchmarks(where
 	<CurveParameterTypeOf<T> as Fixed>::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256> + TryInto<U256>,
 	CollateralCurrenciesBalanceOf<T>: Into<U256> + TryFrom<U256>,
+	FungiblesBalanceOf<T>: Into<U256> + TryFrom<U256>,
 	T::CollateralCurrencies: Create<T::AccountId> ,
 	T::Fungibles: InspectRoles<T::AccountId> + AccountTouch<FungiblesAssetIdOf<T>, AccountIdOf<T>>,
 	T::DepositCurrency: Mutate<T::AccountId>,

--- a/pallets/pallet-bonded-coins/src/curves/mod.rs
+++ b/pallets/pallet-bonded-coins/src/curves/mod.rs
@@ -140,7 +140,9 @@ fn calculate_accumulated_passive_issuance<Balance: Fixed>(passive_issuance: &[Ba
 		.fold(Balance::from_num(0u8), |sum, x| sum.saturating_add(*x))
 }
 
-pub(crate) fn convert_to_fixed<Balance, FixedType: Fixed>(
+/// Converts an integer balance type to a fixed type by scaling the balance down
+/// by its denomination.
+pub(crate) fn balance_to_fixed<Balance, FixedType: Fixed>(
 	balance: Balance,
 	denomination: u8,
 	round_kind: &Round,
@@ -182,11 +184,12 @@ where
 	Ok(fixed)
 }
 
-/// Rounds the given value to the given rounding kind.
-pub(crate) fn convert_fixed_to_collateral<Balance, FixedType: Fixed>(
+/// Converts a fixed type representation of a balance back to an integer type
+/// via scaling up by its denomination.
+pub(crate) fn fixed_to_balance<Balance, FixedType: Fixed>(
 	fixed: FixedType,
-	round_kind: &Round,
 	denomination: u8,
+	round_kind: &Round,
 ) -> Result<Balance, ArithmeticError>
 where
 	FixedType::Bits: TryInto<U256>,

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -137,7 +137,7 @@ pub mod pallet {
 			+ DestroyFungibles<Self::AccountId>
 			+ FungiblesMetadata<Self::AccountId>
 			+ FungiblesInspect<Self::AccountId>
-			+ MutateFungibles<Self::AccountId, Balance = CollateralCurrenciesBalanceOf<Self>>
+			+ MutateFungibles<Self::AccountId>
 			+ FreezeAccounts<Self::AccountId, Self::AssetId>
 			+ ResetTeam<Self::AccountId>;
 		/// The maximum number of currencies allowed for a single pool.
@@ -300,7 +300,8 @@ pub mod pallet {
 	where
 		<CurveParameterTypeOf<T> as Fixed>::Bits:
 			Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256> + TryInto<U256>,
-		CollateralCurrenciesBalanceOf<T>: Into<U256> + TryFrom<U256> + TryInto<U256>,
+		CollateralCurrenciesBalanceOf<T>: Into<U256> + TryFrom<U256>,
+		FungiblesBalanceOf<T>: Into<U256> + TryFrom<U256>,
 		// TODO: make large integer type configurable
 	{
 		/// Creates a new bonded token pool. The pool will be created with the
@@ -1267,6 +1268,7 @@ pub mod pallet {
 		<CurveParameterTypeOf<T> as Fixed>::Bits:
 			Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256> + TryInto<U256>,
 		CollateralCurrenciesBalanceOf<T>: TryFrom<U256> + TryInto<U256>,
+		FungiblesBalanceOf<T>: TryFrom<U256> + TryInto<U256>,
 	{
 		/// Calculates the collateral by the given curve and the normalized
 		/// costs. High is the upper bound of the curve, low is the lower bound.

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pallet {
 	};
 
 	use crate::{
-		curves::{convert_fixed_to_collateral, convert_to_fixed, BondingFunction, Curve, CurveInput},
+		curves::{balance_to_fixed, fixed_to_balance, BondingFunction, Curve, CurveInput},
 		traits::{FreezeAccounts, ResetTeam},
 		types::{Locks, PoolDetails, PoolManagingTeam, PoolStatus, Round, TokenMeta},
 		WeightInfo,
@@ -673,7 +673,7 @@ pub mod pallet {
 				&round_kind,
 			)?;
 
-			let normalized_amount_to_mint = convert_to_fixed(
+			let normalized_amount_to_mint = balance_to_fixed(
 				amount_to_mint.saturated_into::<u128>(),
 				pool_details.denomination,
 				&round_kind,
@@ -803,7 +803,7 @@ pub mod pallet {
 				&round_kind,
 			)?;
 
-			let normalized_amount_to_burn = convert_to_fixed(amount_to_burn, pool_details.denomination, &round_kind)?;
+			let normalized_amount_to_burn = balance_to_fixed(amount_to_burn, pool_details.denomination, &round_kind)?;
 
 			let low = high
 				.checked_sub(normalized_amount_to_burn)
@@ -1300,7 +1300,7 @@ pub mod pallet {
 
 			let denomination = T::CollateralCurrencies::decimals(collateral_currency_id);
 
-			convert_fixed_to_collateral(normalized_costs, round_kind, denomination)
+			fixed_to_balance(normalized_costs, denomination, round_kind)
 		}
 
 		/// Calculates the normalized passive and active issuance for a pool.
@@ -1331,7 +1331,7 @@ pub mod pallet {
 			let mut normalized_total_issuances = bonded_currencies
 				.iter()
 				.map(|currency_id| {
-					convert_to_fixed(
+					balance_to_fixed(
 						T::Fungibles::total_issuance(currency_id.to_owned()),
 						denomination,
 						round_kind,

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -673,7 +673,7 @@ pub mod pallet {
 				&round_kind,
 			)?;
 
-			let normalized_amount_to_mint = convert_to_fixed::<T>(
+			let normalized_amount_to_mint = convert_to_fixed(
 				amount_to_mint.saturated_into::<u128>(),
 				pool_details.denomination,
 				&round_kind,
@@ -803,11 +803,7 @@ pub mod pallet {
 				&round_kind,
 			)?;
 
-			let normalized_amount_to_burn = convert_to_fixed::<T>(
-				amount_to_burn.saturated_into::<u128>(),
-				pool_details.denomination,
-				&round_kind,
-			)?;
+			let normalized_amount_to_burn = convert_to_fixed(amount_to_burn, pool_details.denomination, &round_kind)?;
 
 			let low = high
 				.checked_sub(normalized_amount_to_burn)
@@ -1270,7 +1266,7 @@ pub mod pallet {
 	where
 		<CurveParameterTypeOf<T> as Fixed>::Bits:
 			Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256> + TryInto<U256>,
-		CollateralCurrenciesBalanceOf<T>: TryFrom<U256>,
+		CollateralCurrenciesBalanceOf<T>: TryFrom<U256> + TryInto<U256>,
 	{
 		/// Calculates the collateral by the given curve and the normalized
 		/// costs. High is the upper bound of the curve, low is the lower bound.
@@ -1304,7 +1300,7 @@ pub mod pallet {
 
 			let denomination = T::CollateralCurrencies::decimals(collateral_currency_id);
 
-			convert_fixed_to_collateral::<T>(normalized_costs, round_kind, denomination)
+			convert_fixed_to_collateral(normalized_costs, round_kind, denomination)
 		}
 
 		/// Calculates the normalized passive and active issuance for a pool.
@@ -1335,8 +1331,8 @@ pub mod pallet {
 			let mut normalized_total_issuances = bonded_currencies
 				.iter()
 				.map(|currency_id| {
-					convert_to_fixed::<T>(
-						T::Fungibles::total_issuance(currency_id.to_owned()).saturated_into(),
+					convert_to_fixed(
+						T::Fungibles::total_issuance(currency_id.to_owned()),
 						denomination,
 						round_kind,
 					)

--- a/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
+++ b/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
@@ -1,6 +1,6 @@
 use crate::{
 	curves::{convert_fixed_to_collateral, convert_to_fixed},
-	mock::runtime::{Float, Test},
+	mock::runtime::Float,
 	types::Round,
 };
 use frame_support::assert_ok;
@@ -13,7 +13,7 @@ fn test_convert_to_fixed_basic() {
 	let x = 1000u128;
 	let denomination = 2u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	// Test runtime uses I75F53 for CurveParameterTypeOf, which is what we'll cover
 	// in testing.
 	let expected = Float::from_num(10); // 1000 / 100 = 10
@@ -26,7 +26,7 @@ fn test_convert_to_fixed_with_remainder() {
 	let x = 1050u128;
 	let denomination = 2u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(10.5); // 1050 / 100 = 10.5
 
 	assert_eq!(result, expected);
@@ -37,7 +37,7 @@ fn test_convert_to_fixed_smaller_than_denomination() {
 	let x = 1050u128;
 	let denomination = 6u8; // 10^6 = 1000000
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(0.00105); // 1050 / 1000000 = 0.00105
 
 	assert_eq!(result, expected);
@@ -48,7 +48,7 @@ fn test_convert_to_fixed_large_value() {
 	let x = 1_000_000_000_000_000u128;
 	let denomination = 12u8; // 10^12 = 1_000_000_000_000
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1000); // 1_000_000_000_000_000 / 1_000_000_000_000 = 1000
 
 	assert_eq!(result, expected);
@@ -59,7 +59,7 @@ fn test_convert_to_fixed_small_denomination() {
 	let x = 12345u128;
 	let denomination = 1u8; // 10^1 = 10
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1234.5); // 12345 / 10 = 1234.5
 
 	assert_eq!(result, expected);
@@ -70,7 +70,7 @@ fn test_convert_to_fixed_overflow() {
 	let x = u128::MAX;
 	let denomination = 0u8; // 10^0 = 1, no scaling
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	result.unwrap_err();
 	assert_eq!(result.unwrap_err(), ArithmeticError::Overflow);
 }
@@ -80,7 +80,7 @@ fn test_convert_to_fixed_denomination_overflow() {
 	let x = 1000u128;
 	let denomination = 128u8; // 10^128 overflows
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	result.unwrap_err();
 	assert_eq!(result.unwrap_err(), ArithmeticError::Overflow);
 }
@@ -90,7 +90,7 @@ fn test_convert_to_fixed_overflow_avoided() {
 	let x = u128::MAX; // around 3.4e+38
 	let denomination = 17u8; // I75F53 should handle around 1.8e+22, 38 - 23 -> 17
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	assert_ok!(result);
 }
 
@@ -99,7 +99,7 @@ fn test_convert_to_fixed_handles_large_denomination() {
 	let x = u128::MAX; // around 3.4e+38
 	let denomination = 22u8; // I75F53 should handle around 1.8e+22; this is the maximum safe denomination
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	assert_ok!(result);
 }
 
@@ -108,19 +108,19 @@ fn test_convert_to_fixed_very_large_denomination() {
 	let denomination = 30u8; // I75F53 should handle around 1.8e+22, this can lead to overflow
 
 	// multiple of denomination would not result in remainder = 0
-	assert_ok!(convert_to_fixed::<Test>(
+	assert_ok!(convert_to_fixed::<u128, Float>(
 		10u128.pow(31),
 		denomination,
 		&DEFAULT_ROUND_KIND
 	));
 
 	// non-multiples of denomination could lead to overflow of remainder
-	assert_ok!(convert_to_fixed::<Test>(
+	assert_ok!(convert_to_fixed::<u128, Float>(
 		11u128.pow(31),
 		denomination,
 		&DEFAULT_ROUND_KIND
 	));
-	assert_ok!(convert_to_fixed::<Test>(
+	assert_ok!(convert_to_fixed::<u128, Float>(
 		10u128.pow(29),
 		denomination,
 		&DEFAULT_ROUND_KIND
@@ -132,7 +132,7 @@ fn test_convert_to_fixed_zero_denomination() {
 	let x = 1000u128;
 	let denomination = 0u8; // 10^0 = 1
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1000); // 1000 / 1 = 1000
 
 	assert_eq!(result, expected);
@@ -143,7 +143,7 @@ fn test_convert_to_fixed_zero_input() {
 	let x = 0u128;
 	let denomination = 10u8; // 10^10 = large divisor
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(0); // 0 / any number = 0
 
 	assert_eq!(result, expected);
@@ -154,11 +154,11 @@ fn test_convert_to_fixed_round_up() {
 	let x = 1001u128;
 	let denomination = 4u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<Test>(x, denomination, &Round::Up).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
 
 	assert!(result > Float::from_num(0.1001));
 
-	let result = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 
 	assert_eq!(result, Float::from_num(0.1001));
 }
@@ -168,11 +168,11 @@ fn test_convert_to_fixed_round_up_representable() {
 	let x = 1125u128;
 	let denomination = 3u8; // 10^2 = 100
 
-	let result1 = convert_to_fixed::<Test>(x, denomination, &Round::Up).unwrap();
+	let result1 = convert_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
 
 	assert_eq!(result1, Float::from_num(1.125));
 
-	let result2 = convert_to_fixed::<Test>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result2 = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 
 	assert_eq!(result1, result2);
 }
@@ -180,13 +180,13 @@ fn test_convert_to_fixed_round_up_representable() {
 #[test]
 fn test_round_up() {
 	let value = Float::from_num(1.1200000000005);
-	let result = convert_fixed_to_collateral::<Test>(value, &Round::Up, 2).unwrap();
+	let result = convert_fixed_to_collateral::<u128, Float>(value, &Round::Up, 2).unwrap();
 	assert_eq!(result, 113u128);
 }
 
 #[test]
 fn test_round_up_exact_representable() {
 	let value = Float::from_num(1.125);
-	let result = convert_fixed_to_collateral::<Test>(value, &Round::Up, 3).unwrap();
+	let result = convert_fixed_to_collateral::<u128, Float>(value, &Round::Up, 3).unwrap();
 	assert_eq!(result, 1125u128);
 }

--- a/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
+++ b/pallets/pallet-bonded-coins/src/tests/curves/arithmetic.rs
@@ -1,5 +1,5 @@
 use crate::{
-	curves::{convert_fixed_to_collateral, convert_to_fixed},
+	curves::{balance_to_fixed, fixed_to_balance},
 	mock::runtime::Float,
 	types::Round,
 };
@@ -9,11 +9,11 @@ use sp_runtime::ArithmeticError;
 const DEFAULT_ROUND_KIND: Round = Round::Down;
 
 #[test]
-fn test_convert_to_fixed_basic() {
+fn test_balance_to_fixed_basic() {
 	let x = 1000u128;
 	let denomination = 2u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	// Test runtime uses I75F53 for CurveParameterTypeOf, which is what we'll cover
 	// in testing.
 	let expected = Float::from_num(10); // 1000 / 100 = 10
@@ -22,105 +22,105 @@ fn test_convert_to_fixed_basic() {
 }
 
 #[test]
-fn test_convert_to_fixed_with_remainder() {
+fn test_balance_to_fixed_with_remainder() {
 	let x = 1050u128;
 	let denomination = 2u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(10.5); // 1050 / 100 = 10.5
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_smaller_than_denomination() {
+fn test_balance_to_fixed_smaller_than_denomination() {
 	let x = 1050u128;
 	let denomination = 6u8; // 10^6 = 1000000
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(0.00105); // 1050 / 1000000 = 0.00105
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_large_value() {
+fn test_balance_to_fixed_large_value() {
 	let x = 1_000_000_000_000_000u128;
 	let denomination = 12u8; // 10^12 = 1_000_000_000_000
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1000); // 1_000_000_000_000_000 / 1_000_000_000_000 = 1000
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_small_denomination() {
+fn test_balance_to_fixed_small_denomination() {
 	let x = 12345u128;
 	let denomination = 1u8; // 10^1 = 10
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1234.5); // 12345 / 10 = 1234.5
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_overflow() {
+fn test_balance_to_fixed_overflow() {
 	let x = u128::MAX;
 	let denomination = 0u8; // 10^0 = 1, no scaling
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	result.unwrap_err();
 	assert_eq!(result.unwrap_err(), ArithmeticError::Overflow);
 }
 
 #[test]
-fn test_convert_to_fixed_denomination_overflow() {
+fn test_balance_to_fixed_denomination_overflow() {
 	let x = 1000u128;
 	let denomination = 128u8; // 10^128 overflows
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	result.unwrap_err();
 	assert_eq!(result.unwrap_err(), ArithmeticError::Overflow);
 }
 
 #[test]
-fn test_convert_to_fixed_overflow_avoided() {
+fn test_balance_to_fixed_overflow_avoided() {
 	let x = u128::MAX; // around 3.4e+38
 	let denomination = 17u8; // I75F53 should handle around 1.8e+22, 38 - 23 -> 17
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	assert_ok!(result);
 }
 
 #[test]
-fn test_convert_to_fixed_handles_large_denomination() {
+fn test_balance_to_fixed_handles_large_denomination() {
 	let x = u128::MAX; // around 3.4e+38
 	let denomination = 22u8; // I75F53 should handle around 1.8e+22; this is the maximum safe denomination
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND);
 	assert_ok!(result);
 }
 
 #[test]
-fn test_convert_to_fixed_very_large_denomination() {
+fn test_balance_to_fixed_very_large_denomination() {
 	let denomination = 30u8; // I75F53 should handle around 1.8e+22, this can lead to overflow
 
 	// multiple of denomination would not result in remainder = 0
-	assert_ok!(convert_to_fixed::<u128, Float>(
+	assert_ok!(balance_to_fixed::<u128, Float>(
 		10u128.pow(31),
 		denomination,
 		&DEFAULT_ROUND_KIND
 	));
 
 	// non-multiples of denomination could lead to overflow of remainder
-	assert_ok!(convert_to_fixed::<u128, Float>(
+	assert_ok!(balance_to_fixed::<u128, Float>(
 		11u128.pow(31),
 		denomination,
 		&DEFAULT_ROUND_KIND
 	));
-	assert_ok!(convert_to_fixed::<u128, Float>(
+	assert_ok!(balance_to_fixed::<u128, Float>(
 		10u128.pow(29),
 		denomination,
 		&DEFAULT_ROUND_KIND
@@ -128,51 +128,51 @@ fn test_convert_to_fixed_very_large_denomination() {
 }
 
 #[test]
-fn test_convert_to_fixed_zero_denomination() {
+fn test_balance_to_fixed_zero_denomination() {
 	let x = 1000u128;
 	let denomination = 0u8; // 10^0 = 1
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(1000); // 1000 / 1 = 1000
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_zero_input() {
+fn test_balance_to_fixed_zero_input() {
 	let x = 0u128;
 	let denomination = 10u8; // 10^10 = large divisor
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 	let expected = Float::from_num(0); // 0 / any number = 0
 
 	assert_eq!(result, expected);
 }
 
 #[test]
-fn test_convert_to_fixed_round_up() {
+fn test_balance_to_fixed_round_up() {
 	let x = 1001u128;
 	let denomination = 4u8; // 10^2 = 100
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
 
 	assert!(result > Float::from_num(0.1001));
 
-	let result = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 
 	assert_eq!(result, Float::from_num(0.1001));
 }
 
 #[test]
-fn test_convert_to_fixed_round_up_representable() {
+fn test_balance_to_fixed_round_up_representable() {
 	let x = 1125u128;
 	let denomination = 3u8; // 10^2 = 100
 
-	let result1 = convert_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
+	let result1 = balance_to_fixed::<u128, Float>(x, denomination, &Round::Up).unwrap();
 
 	assert_eq!(result1, Float::from_num(1.125));
 
-	let result2 = convert_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
+	let result2 = balance_to_fixed::<u128, Float>(x, denomination, &DEFAULT_ROUND_KIND).unwrap();
 
 	assert_eq!(result1, result2);
 }
@@ -180,13 +180,13 @@ fn test_convert_to_fixed_round_up_representable() {
 #[test]
 fn test_round_up() {
 	let value = Float::from_num(1.1200000000005);
-	let result = convert_fixed_to_collateral::<u128, Float>(value, &Round::Up, 2).unwrap();
+	let result = fixed_to_balance::<u128, Float>(value, 2, &Round::Up).unwrap();
 	assert_eq!(result, 113u128);
 }
 
 #[test]
 fn test_round_up_exact_representable() {
 	let value = Float::from_num(1.125);
-	let result = convert_fixed_to_collateral::<u128, Float>(value, &Round::Up, 3).unwrap();
+	let result = fixed_to_balance::<u128, Float>(value, 3, &Round::Up).unwrap();
 	assert_eq!(result, 1125u128);
 }


### PR DESCRIPTION
Unties the utility functions performing scaled conversion from a balance type to a fixed (and back) from the pallet config trait.
This also allows us to easily drop the requirement that the bonded coins and collateral need to use the same balance type.
Finally, I made sure that the symmetry of the two functions is reflected in their names and parameter order.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
