### PR TITLE
feat: support gatekeeping web3names and account linkings

### DIFF
--- a/dip-template/runtimes/dip-provider/src/lib.rs
+++ b/dip-template/runtimes/dip-provider/src/lib.rs
@@ -425,6 +425,7 @@ impl did::Config for Runtime {
 }
 
 impl pallet_did_lookup::Config for Runtime {
+	type AssociateOrigin = Self::EnsureOrigin;
 	type BalanceMigrationManager = ();
 	type Currency = Balances;
 	type Deposit = ConstU128<UNIT>;
@@ -441,6 +442,7 @@ pub type Web3Name = runtime_common::Web3Name<3, 32>;
 impl pallet_web3_names::Config for Runtime {
 	type BalanceMigrationManager = ();
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = Self::OwnerOrigin;
 	type Currency = Balances;
 	type Deposit = ConstU128<UNIT>;
 	type MaxNameLength = ConstU32<32>;

--- a/pallets/did/src/origin.rs
+++ b/pallets/did/src/origin.rs
@@ -88,8 +88,8 @@ where
 	}
 }
 
-impl<OuterOrigin, DidIdentifier, AccountId> EnsureOriginWithArg<OuterOrigin, DidIdentifier>
-	for EnsureDidOrigin<DidIdentifier, AccountId>
+impl<OuterOrigin, DidIdentifier, AccountId, ExpectedSubmitter> EnsureOriginWithArg<OuterOrigin, DidIdentifier>
+	for EnsureDidOrigin<DidIdentifier, AccountId, ExpectedSubmitter>
 where
 	OuterOrigin: Into<Result<DidRawOrigin<DidIdentifier, AccountId>, OuterOrigin>>
 		+ From<DidRawOrigin<DidIdentifier, AccountId>>
@@ -121,9 +121,9 @@ where
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-impl<OuterOrigin, AccountId, DidIdentifier>
+impl<OuterOrigin, AccountId, DidIdentifier, ExpectedSubmitter>
 	kilt_support::traits::GenerateBenchmarkOrigin<OuterOrigin, AccountId, DidIdentifier>
-	for EnsureDidOrigin<DidIdentifier, AccountId>
+	for EnsureDidOrigin<DidIdentifier, AccountId, ExpectedSubmitter>
 where
 	OuterOrigin: Into<Result<DidRawOrigin<DidIdentifier, AccountId>, OuterOrigin>>
 		+ From<DidRawOrigin<DidIdentifier, AccountId>>,

--- a/pallets/did/src/origin.rs
+++ b/pallets/did/src/origin.rs
@@ -20,6 +20,7 @@ use frame_support::traits::{EnsureOrigin, EnsureOriginWithArg};
 use kilt_support::traits::CallSources;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use sp_core::Get;
 use sp_runtime::RuntimeDebug;
 use sp_std::marker::PhantomData;
 
@@ -36,19 +37,43 @@ impl<DidIdentifier, AccountId> DidRawOrigin<DidIdentifier, AccountId> {
 	}
 }
 
-pub struct EnsureDidOrigin<DidIdentifier, AccountId>(PhantomData<(DidIdentifier, AccountId)>);
+impl<DidIdentifier: Clone, AccountId: Clone> CallSources<AccountId, DidIdentifier>
+	for DidRawOrigin<DidIdentifier, AccountId>
+{
+	fn sender(&self) -> AccountId {
+		self.submitter.clone()
+	}
 
-impl<OuterOrigin, DidIdentifier, AccountId> EnsureOrigin<OuterOrigin> for EnsureDidOrigin<DidIdentifier, AccountId>
+	fn subject(&self) -> DidIdentifier {
+		self.id.clone()
+	}
+}
+
+pub struct EnsureDidOrigin<DidIdentifier, AccountId, ExpectedSubmitter = ()>(
+	PhantomData<(DidIdentifier, AccountId, ExpectedSubmitter)>,
+);
+
+impl<OuterOrigin, DidIdentifier, AccountId, ExpectedSubmitter> EnsureOrigin<OuterOrigin>
+	for EnsureDidOrigin<DidIdentifier, AccountId, ExpectedSubmitter>
 where
 	OuterOrigin: Into<Result<DidRawOrigin<DidIdentifier, AccountId>, OuterOrigin>>
-		+ From<DidRawOrigin<DidIdentifier, AccountId>>,
+		+ From<DidRawOrigin<DidIdentifier, AccountId>>
+		+ Clone,
 	DidIdentifier: From<AccountId>,
-	AccountId: Clone + Decode,
+	AccountId: Clone + Decode + PartialEq,
+	ExpectedSubmitter: Get<Option<AccountId>>,
 {
 	type Success = DidRawOrigin<DidIdentifier, AccountId>;
 
 	fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
-		o.into()
+		let did_raw_origin = o.clone().into()?;
+		// Origin check succeeds if no authorized account is configured, or if the one
+		// configured matches the tx submitter. Fails otherwise.
+		match ExpectedSubmitter::get() {
+			None => Ok(did_raw_origin),
+			Some(authorised_submitter) if authorised_submitter == did_raw_origin.submitter => Ok(did_raw_origin),
+			_ => Err(o),
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
@@ -95,18 +120,6 @@ where
 	}
 }
 
-impl<DidIdentifier: Clone, AccountId: Clone> CallSources<AccountId, DidIdentifier>
-	for DidRawOrigin<DidIdentifier, AccountId>
-{
-	fn sender(&self) -> AccountId {
-		self.submitter.clone()
-	}
-
-	fn subject(&self) -> DidIdentifier {
-		self.id.clone()
-	}
-}
-
 #[cfg(feature = "runtime-benchmarks")]
 impl<OuterOrigin, AccountId, DidIdentifier>
 	kilt_support::traits::GenerateBenchmarkOrigin<OuterOrigin, AccountId, DidIdentifier>
@@ -128,11 +141,15 @@ mod tests {
 	#[cfg(feature = "runtime-benchmarks")]
 	#[test]
 	pub fn successful_origin() {
-		use crate::{mock::Test, EnsureDidOrigin};
+		use crate::{
+			mock::{AccountId, DidIdentifier, Test},
+			EnsureDidOrigin,
+		};
 		use frame_support::{assert_ok, traits::EnsureOrigin};
 
 		let origin: <Test as frame_system::Config>::RuntimeOrigin =
-			EnsureDidOrigin::try_successful_origin().expect("Successful origin creation should not fail.");
-		assert_ok!(EnsureDidOrigin::try_origin(origin));
+			EnsureDidOrigin::<DidIdentifier, AccountId>::try_successful_origin()
+				.expect("Successful origin creation should not fail.");
+		assert_ok!(EnsureDidOrigin::<DidIdentifier, AccountId>::try_origin(origin));
 	}
 }

--- a/pallets/pallet-did-lookup/src/benchmarking.rs
+++ b/pallets/pallet-did-lookup/src/benchmarking.rs
@@ -66,6 +66,7 @@ benchmarks_instance_pallet! {
 		T::AccountId: From<sr25519::Public> + From<ed25519::Public> + Into<LinkableAccountId> + Into<AccountId32> + From<sp_runtime::AccountId32>,
 		<T as Config<I>>::DidIdentifier: From<T::AccountId>,
 		<T as Config<I>>::EnsureOrigin: GenerateBenchmarkOrigin<T::RuntimeOrigin, T::AccountId, <T as Config<I>>::DidIdentifier>,
+		<T as Config<I>>::AssociateOrigin: GenerateBenchmarkOrigin<T::RuntimeOrigin, T::AccountId, <T as Config<I>>::DidIdentifier>,
 		<T as Config<I>>::Currency: Mutate<T::AccountId>,
 	}
 
@@ -92,7 +93,7 @@ benchmarks_instance_pallet! {
 		// Add existing connected_acc -> previous_did connection that will be replaced
 		Pallet::<T, I>::add_association(caller.clone(), previous_did.clone(), linkable_id.clone()).expect("should create previous association");
 		assert!(ConnectedAccounts::<T, I>::get(&previous_did, linkable_id.clone()).is_some());
-		let origin = T::EnsureOrigin::generate_origin(caller, did.clone());
+		let origin = T::AssociateOrigin::generate_origin(caller, did.clone());
 		let id_arg = linkable_id.clone();
 		let req = AssociateAccountRequest::Polkadot(connected_acc_id.into(), sig.into());
 	}: associate_account<T::RuntimeOrigin>(origin, req, expire_at)
@@ -125,7 +126,7 @@ benchmarks_instance_pallet! {
 		// Add existing connected_acc -> previous_did connection that will be replaced
 		Pallet::<T, I>::add_association(caller.clone(), previous_did.clone(), linkable_id.clone()).expect("should create previous association");
 		assert!(ConnectedAccounts::<T, I>::get(&previous_did, linkable_id.clone()).is_some());
-		let origin = T::EnsureOrigin::generate_origin(caller, did.clone());
+		let origin = T::AssociateOrigin::generate_origin(caller, did.clone());
 		let id_arg = linkable_id.clone();
 		let req = AssociateAccountRequest::Polkadot(connected_acc_id.into(), sig.into());
 	}: associate_account<T::RuntimeOrigin>(origin, req, expire_at)
@@ -158,7 +159,7 @@ benchmarks_instance_pallet! {
 		// Add existing connected_acc -> previous_did connection that will be replaced
 		Pallet::<T, I>::add_association(caller.clone(), previous_did.clone(), linkable_id.clone()).expect("should create previous association");
 		assert!(ConnectedAccounts::<T, I>::get(&previous_did, linkable_id.clone()).is_some());
-		let origin = T::EnsureOrigin::generate_origin(caller, did.clone());
+		let origin = T::AssociateOrigin::generate_origin(caller, did.clone());
 		let id_arg = linkable_id.clone();
 		let req = AssociateAccountRequest::Polkadot(connected_acc_id, sig.into());
 	}: associate_account<T::RuntimeOrigin>(origin, req, expire_at)
@@ -193,7 +194,7 @@ benchmarks_instance_pallet! {
 		// Add existing connected_acc -> previous_did connection that will be replaced
 		Pallet::<T, I>::add_association(caller.clone(), previous_did.clone(), eth_account.into()).expect("should create previous association");
 		assert!(ConnectedAccounts::<T, I>::get(&previous_did, LinkableAccountId::from(eth_account)).is_some());
-		let origin = T::EnsureOrigin::generate_origin(caller, did.clone());
+		let origin = T::AssociateOrigin::generate_origin(caller, did.clone());
 		let req = AssociateAccountRequest::Ethereum(eth_account, sig.into());
 	}: associate_account<T::RuntimeOrigin>(origin, req, expire_at)
 	verify {
@@ -213,7 +214,7 @@ benchmarks_instance_pallet! {
 		// Add existing sender -> previous_did connection that will be replaced
 		Pallet::<T, I>::add_association(caller.clone(), previous_did.clone(), caller.clone().into()).expect("should create previous association");
 		assert!(ConnectedAccounts::<T, I>::get(&previous_did, &linkable_id).is_some());
-		let origin = T::EnsureOrigin::generate_origin(caller, did.clone());
+		let origin = T::AssociateOrigin::generate_origin(caller, did.clone());
 	}: _<T::RuntimeOrigin>(origin)
 	verify {
 		assert!(ConnectedDids::<T, I>::get(&linkable_id).is_some());

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -107,6 +107,9 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// The origin that can associate accounts to itself.
+		type AssociateOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
+		/// The origin that can do other regular operations, except what
+		/// `AssociateOrigin` allows.
 		type EnsureOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
 
 		/// The information that is returned by the origin check.
@@ -272,7 +275,7 @@ pub mod pallet {
 			req: AssociateAccountRequest,
 			expiration: BlockNumberFor<T>,
 		) -> DispatchResult {
-			let source = <T as Config<I>>::EnsureOrigin::ensure_origin(origin)?;
+			let source = <T as Config<I>>::AssociateOrigin::ensure_origin(origin)?;
 			let did_identifier = source.subject();
 			let sender = source.sender();
 
@@ -314,7 +317,7 @@ pub mod pallet {
 		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::associate_sender())]
 		pub fn associate_sender(origin: OriginFor<T>) -> DispatchResult {
-			let source = <T as Config<I>>::EnsureOrigin::ensure_origin(origin)?;
+			let source = <T as Config<I>>::AssociateOrigin::ensure_origin(origin)?;
 
 			ensure!(
 				<<T as Config<I>>::Currency as InspectHold<AccountIdOf<T>>>::can_hold(

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -134,6 +134,7 @@ impl pallet_did_lookup::Config for Test {
 	type Currency = Balances;
 	type Deposit = DidLookupDeposit;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
+	type AssociateOrigin = Self::EnsureOrigin;
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type DidIdentifier = SubjectId;
 	type WeightInfo = ();

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -134,7 +134,7 @@ impl pallet_did_lookup::Config for Test {
 	type Currency = Balances;
 	type Deposit = DidLookupDeposit;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
-	type AssociateOrigin = Self::EnsureOrigin;
+	type AssociateOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type DidIdentifier = SubjectId;
 	type WeightInfo = ();

--- a/pallets/pallet-dip-consumer/src/mock.rs
+++ b/pallets/pallet-dip-consumer/src/mock.rs
@@ -86,6 +86,7 @@ impl pallet_balances::Config for TestRuntime {
 }
 
 impl pallet_did_lookup::Config for TestRuntime {
+	type AssociateOrigin = Self::EnsureOrigin;
 	type BalanceMigrationManager = ();
 	type Currency = Balances;
 	type Deposit = ConstU64<1>;

--- a/pallets/pallet-migration/src/mock.rs
+++ b/pallets/pallet-migration/src/mock.rs
@@ -283,6 +283,7 @@ impl pallet_did_lookup::Config for Test {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type Currency = Balances;
 	type Deposit = DidLookupDeposit;
+	type AssociateOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
 	type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
 	type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 	type DidIdentifier = SubjectId;
@@ -329,6 +330,7 @@ parameter_types! {
 
 impl pallet_web3_names::Config for Test {
 	type BanOrigin = TestBanOrigin;
+	type ClaimOrigin = TestOwnerOrigin;
 	type OwnerOrigin = TestOwnerOrigin;
 	type OriginSuccess = TestOriginSuccess;
 	type Currency = Balances;

--- a/pallets/pallet-web3-names/src/benchmarking.rs
+++ b/pallets/pallet-web3-names/src/benchmarking.rs
@@ -71,6 +71,7 @@ benchmarks_instance_pallet! {
 		T::AccountId: From<sr25519::Public>,
 		<T as Config<I>>::Web3NameOwner: From<T::AccountId>,
 		<T as Config<I>>::OwnerOrigin: GenerateBenchmarkOrigin<T::RuntimeOrigin, T::AccountId, <T as Config<I>>::Web3NameOwner>,
+		<T as Config<I>>::ClaimOrigin: GenerateBenchmarkOrigin<T::RuntimeOrigin, T::AccountId, <T as Config<I>>::Web3NameOwner>,
 		<T as Config<I>>::BanOrigin: EnsureOrigin<T::RuntimeOrigin>,
 		<<T as Config<I>>::Web3Name as TryFrom<Vec<u8>>>::Error: Into<Error<T, I>>,
 		<T as Config<I>>::Currency: Mutate<T::AccountId>,
@@ -82,7 +83,7 @@ benchmarks_instance_pallet! {
 		let owner: Web3NameOwnerOf<T, I> = account("owner", 0, OWNER_SEED);
 		let web3_name_input: BoundedVec<u8, <T as Config<I>>::MaxNameLength> = BoundedVec::try_from(<T as Config<I>>::BenchmarkHelper::generate_name_input_with_length(n.saturated_into())).expect("BoundedVec creation should not fail.");
 		let web3_name_input_clone = web3_name_input.clone();
-		let origin = <T as Config<I>>::OwnerOrigin::generate_origin(caller.clone(), owner.clone());
+		let origin = <T as Config<I>>::ClaimOrigin::generate_origin(caller.clone(), owner.clone());
 
 		make_free_for_did::<T, I>(&caller);
 	}: _<T::RuntimeOrigin>(origin, web3_name_input_clone)

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -121,7 +121,10 @@ pub mod pallet {
 	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// The origin allowed to ban names.
 		type BanOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-		/// The origin allowed to perform regular operations.
+		/// The origin allowed to claim a web3name.
+		type ClaimOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
+		/// The origin allowed to perform all regular operations, except
+		/// claiming a name, which is performed by `ClaimOrigin`.
 		type OwnerOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
 		/// The type of origin after a successful origin check.
 		type OriginSuccess: CallSources<AccountIdOf<Self>, Web3NameOwnerOf<Self, I>>;
@@ -244,7 +247,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::claim(name.len().saturated_into()))]
 		pub fn claim(origin: OriginFor<T>, name: Web3NameInput<T, I>) -> DispatchResult {
-			let runtime_origin = T::OwnerOrigin::ensure_origin(origin)?;
+			let runtime_origin = T::ClaimOrigin::ensure_origin(origin)?;
 			let payer = runtime_origin.sender();
 			let owner = runtime_origin.subject();
 

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -124,7 +124,7 @@ pub mod pallet {
 		/// The origin allowed to claim a web3name.
 		type ClaimOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
 		/// The origin allowed to perform all regular operations, except
-		/// claiming a name, which is performed by `ClaimOrigin`.
+		/// claiming a name, which is authorized by `ClaimOrigin`.
 		type OwnerOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin, Success = Self::OriginSuccess>;
 		/// The type of origin after a successful origin check.
 		type OriginSuccess: CallSources<AccountIdOf<Self>, Web3NameOwnerOf<Self, I>>;

--- a/pallets/pallet-web3-names/src/mock.rs
+++ b/pallets/pallet-web3-names/src/mock.rs
@@ -180,6 +180,7 @@ pub(crate) mod runtime {
 
 	impl pallet_web3_names::Config for Test {
 		type BanOrigin = TestBanOrigin;
+		type ClaimOrigin = TestOwnerOrigin;
 		type OwnerOrigin = TestOwnerOrigin;
 		type OriginSuccess = TestOriginSuccess;
 		type Currency = Balances;

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -91,7 +91,6 @@ runtime-benchmarks = [
   "pallet-multisig/runtime-benchmarks",
   "pallet-tips/runtime-benchmarks",
   "pallet-treasury/runtime-benchmarks",
-  "pallet-web3-names/runtime-benchmarks",
   "polkadot-parachain/runtime-benchmarks",
   "polkadot-runtime-common/runtime-benchmarks",
   "public-credentials/runtime-benchmarks",

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -91,6 +91,7 @@ runtime-benchmarks = [
   "pallet-multisig/runtime-benchmarks",
   "pallet-tips/runtime-benchmarks",
   "pallet-treasury/runtime-benchmarks",
+  "pallet-web3-names/runtime-benchmarks",
   "polkadot-parachain/runtime-benchmarks",
   "polkadot-runtime-common/runtime-benchmarks",
   "public-credentials/runtime-benchmarks",

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -147,6 +147,7 @@ impl did::Config for TestRuntime {
 impl pallet_web3_names::Config for TestRuntime {
 	type BalanceMigrationManager = ();
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = Self::OwnerOrigin;
 	type Currency = Balances;
 	type Deposit = ConstU128<KILT>;
 	type MaxNameLength = MaxNameLength;

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -147,7 +147,7 @@ impl did::Config for TestRuntime {
 impl pallet_web3_names::Config for TestRuntime {
 	type BalanceMigrationManager = ();
 	type BanOrigin = EnsureRoot<AccountId>;
-	type ClaimOrigin = Self::OwnerOrigin;
+	type ClaimOrigin = EnsureSigned<AccountId>;
 	type Currency = Balances;
 	type Deposit = ConstU128<KILT>;
 	type MaxNameLength = MaxNameLength;
@@ -165,6 +165,7 @@ impl pallet_web3_names::Config for TestRuntime {
 }
 
 impl pallet_did_lookup::Config for TestRuntime {
+	type AssociateOrigin = EnsureSigned<AccountId>;
 	type BalanceMigrationManager = ();
 	type Currency = Balances;
 	type Deposit = ConstU128<KILT>;

--- a/runtimes/common/src/dot_names/mod.rs
+++ b/runtimes/common/src/dot_names/mod.rs
@@ -30,6 +30,9 @@ use crate::constants::dot_names::DOT_NAME_SUFFIX;
 #[cfg(test)]
 mod tests;
 
+mod origin;
+pub use origin::AllowedNameClaimer;
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum DotNameValidationError {
 	TooShort,

--- a/runtimes/common/src/dot_names/mod.rs
+++ b/runtimes/common/src/dot_names/mod.rs
@@ -31,7 +31,7 @@ use crate::constants::dot_names::DOT_NAME_SUFFIX;
 mod tests;
 
 mod origin;
-pub use origin::AllowedNameClaimer;
+pub use origin::{dot_names::AllowedDotNameClaimer, unique_linking::AllowedUniqueLinkingAssociator};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum DotNameValidationError {

--- a/runtimes/common/src/dot_names/origin.rs
+++ b/runtimes/common/src/dot_names/origin.rs
@@ -23,7 +23,7 @@ pub(super) mod dot_names {
 
 	use crate::AccountId;
 
-	const LOG_TARGET: &'static str = "runtime::DotNames::AllowedDotNameClaimer";
+	const LOG_TARGET: &str = "runtime::DotNames::AllowedDotNameClaimer";
 
 	// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
 	// migrate this custom implementation into the pallet.
@@ -56,7 +56,7 @@ pub(super) mod unique_linking {
 
 	use crate::AccountId;
 
-	const LOG_TARGET: &'static str = "runtime::UniqueLinking::AllowedUniqueLinkingAssociator";
+	const LOG_TARGET: &str = "runtime::UniqueLinking::AllowedUniqueLinkingAssociator";
 
 	// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
 	// migrate this custom implementation into the pallet.

--- a/runtimes/common/src/dot_names/origin.rs
+++ b/runtimes/common/src/dot_names/origin.rs
@@ -24,10 +24,14 @@ use crate::AccountId;
 
 // TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
 // migrate this custom implementation into the pallet.
+// The downside of this approach is that no try-runtime checks will be run on
+// this piece of storage.
 #[storage_alias]
 type AllowedNameClaimerStorage<DotNamesDeployment: PalletInfoAccess> =
 	StorageValue<DotNamesDeployment, AccountId, OptionQuery>;
 
+/// Stored information about the allowed claimer inside the DotNames pallet,
+/// without the pallet knowing about it.
 pub struct AllowedNameClaimer<DotNamesDeployment>(PhantomData<DotNamesDeployment>);
 
 impl<DotNamesDeployment> Get<Option<AccountId>> for AllowedNameClaimer<DotNamesDeployment>

--- a/runtimes/common/src/dot_names/origin.rs
+++ b/runtimes/common/src/dot_names/origin.rs
@@ -1,0 +1,40 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use frame_support::{pallet_prelude::OptionQuery, storage_alias, traits::PalletInfoAccess};
+use sp_core::Get;
+use sp_std::marker::PhantomData;
+
+use crate::AccountId;
+
+// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
+// migrate this custom implementation into the pallet.
+#[storage_alias]
+type AllowedNameClaimerStorage<DotNamesDeployment: PalletInfoAccess> =
+	StorageValue<DotNamesDeployment, AccountId, OptionQuery>;
+
+pub struct AllowedNameClaimer<DotNamesDeployment>(PhantomData<DotNamesDeployment>);
+
+impl<DotNamesDeployment> Get<Option<AccountId>> for AllowedNameClaimer<DotNamesDeployment>
+where
+	DotNamesDeployment: PalletInfoAccess,
+{
+	fn get() -> Option<AccountId> {
+		AllowedNameClaimerStorage::<DotNamesDeployment>::get()
+	}
+}

--- a/runtimes/common/src/dot_names/origin.rs
+++ b/runtimes/common/src/dot_names/origin.rs
@@ -16,33 +16,68 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_support::{pallet_prelude::OptionQuery, storage_alias, traits::PalletInfoAccess};
-use sp_core::Get;
-use sp_std::marker::PhantomData;
+pub(super) mod dot_names {
+	use frame_support::{pallet_prelude::OptionQuery, storage_alias, traits::PalletInfoAccess};
+	use sp_core::Get;
+	use sp_std::marker::PhantomData;
 
-use crate::AccountId;
+	use crate::AccountId;
 
-const LOG_TARGET: &'static str = "runtime::DotNames::AllowedNameClaimer";
+	const LOG_TARGET: &'static str = "runtime::DotNames::AllowedDotNameClaimer";
 
-// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
-// migrate this custom implementation into the pallet.
-// The downside of this approach is that no try-runtime checks will be run on
-// this piece of storage.
-#[storage_alias]
-type AllowedNameClaimerStorage<DotNamesDeployment: PalletInfoAccess> =
-	StorageValue<DotNamesDeployment, AccountId, OptionQuery>;
+	// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
+	// migrate this custom implementation into the pallet.
+	// The downside of this approach is that no try-runtime checks will be run on
+	// this piece of storage.
+	#[storage_alias]
+	type AllowedDotNameClaimerStorage<DotNamesDeployment: PalletInfoAccess> =
+		StorageValue<DotNamesDeployment, AccountId, OptionQuery>;
 
-/// Stored information about the allowed claimer inside the DotNames pallet,
-/// without the pallet knowing about it.
-pub struct AllowedNameClaimer<DotNamesDeployment>(PhantomData<DotNamesDeployment>);
+	/// Stored information about the allowed claimer inside the DotNames pallet,
+	/// without the pallet knowing about it.
+	pub struct AllowedDotNameClaimer<DotNamesDeployment>(PhantomData<DotNamesDeployment>);
 
-impl<DotNamesDeployment> Get<Option<AccountId>> for AllowedNameClaimer<DotNamesDeployment>
-where
-	DotNamesDeployment: PalletInfoAccess,
-{
-	fn get() -> Option<AccountId> {
-		let stored_account = AllowedNameClaimerStorage::<DotNamesDeployment>::get();
-		log::trace!(target: LOG_TARGET, "Stored value for DotNames authorized account: {:#?}", stored_account);
-		stored_account
+	impl<DotNamesDeployment> Get<Option<AccountId>> for AllowedDotNameClaimer<DotNamesDeployment>
+	where
+		DotNamesDeployment: PalletInfoAccess,
+	{
+		fn get() -> Option<AccountId> {
+			let stored_account = AllowedDotNameClaimerStorage::<DotNamesDeployment>::get();
+			log::trace!(target: LOG_TARGET, "Stored value for DotNames authorized account: {:#?}", stored_account);
+			stored_account
+		}
+	}
+}
+
+pub(super) mod unique_linking {
+	use frame_support::{pallet_prelude::OptionQuery, storage_alias, traits::PalletInfoAccess};
+	use sp_core::Get;
+	use sp_std::marker::PhantomData;
+
+	use crate::AccountId;
+
+	const LOG_TARGET: &'static str = "runtime::UniqueLinking::AllowedUniqueLinkingAssociator";
+
+	// TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
+	// migrate this custom implementation into the pallet.
+	// The downside of this approach is that no try-runtime checks will be run on
+	// this piece of storage.
+	#[storage_alias]
+	type AllowedUniqueLinkingAssociatorStorage<UniqueLinkingDeployment: PalletInfoAccess> =
+		StorageValue<UniqueLinkingDeployment, AccountId, OptionQuery>;
+
+	/// Stored information about the allowed claimer inside the UniqueLinking
+	/// pallet, without the pallet knowing about it.
+	pub struct AllowedUniqueLinkingAssociator<UniqueLinkingDeployment>(PhantomData<UniqueLinkingDeployment>);
+
+	impl<UniqueLinkingDeployment> Get<Option<AccountId>> for AllowedUniqueLinkingAssociator<UniqueLinkingDeployment>
+	where
+		UniqueLinkingDeployment: PalletInfoAccess,
+	{
+		fn get() -> Option<AccountId> {
+			let stored_account = AllowedUniqueLinkingAssociatorStorage::<UniqueLinkingDeployment>::get();
+			log::trace!(target: LOG_TARGET, "Stored value for UniqueLinking authorized account: {:#?}", stored_account);
+			stored_account
+		}
 	}
 }

--- a/runtimes/common/src/dot_names/origin.rs
+++ b/runtimes/common/src/dot_names/origin.rs
@@ -22,6 +22,8 @@ use sp_std::marker::PhantomData;
 
 use crate::AccountId;
 
+const LOG_TARGET: &'static str = "runtime::DotNames::AllowedNameClaimer";
+
 // TODO: When upgrading to 1.8.0, which introduces a new `pallet-parameteres`,
 // migrate this custom implementation into the pallet.
 // The downside of this approach is that no try-runtime checks will be run on
@@ -39,6 +41,8 @@ where
 	DotNamesDeployment: PalletInfoAccess,
 {
 	fn get() -> Option<AccountId> {
-		AllowedNameClaimerStorage::<DotNamesDeployment>::get()
+		let stored_account = AllowedNameClaimerStorage::<DotNamesDeployment>::get();
+		log::trace!(target: LOG_TARGET, "Stored value for DotNames authorized account: {:#?}", stored_account);
+		stored_account
 	}
 }

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -434,6 +434,7 @@ impl pallet_did_lookup::Config for Runtime {
 	type Currency = Balances;
 	type Deposit = constants::did_lookup::DidLookupDeposit;
 
+	type AssociateOrigin = Self::EnsureOrigin;
 	type EnsureOrigin = did::EnsureDidOrigin<DidIdentifier, AccountId>;
 	type OriginSuccess = did::DidRawOrigin<AccountId, DidIdentifier>;
 	type BalanceMigrationManager = ();

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -446,6 +446,7 @@ impl pallet_did_lookup::Config for Runtime {
 impl pallet_web3_names::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = Self::OwnerOrigin;
 	type OwnerOrigin = did::EnsureDidOrigin<DidIdentifier, AccountId>;
 	type OriginSuccess = did::DidRawOrigin<AccountId, DidIdentifier>;
 	type Currency = Balances;

--- a/runtimes/peregrine/src/kilt/did.rs
+++ b/runtimes/peregrine/src/kilt/did.rs
@@ -154,6 +154,7 @@ pub type Web3Name =
 impl pallet_web3_names::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = Self::OwnerOrigin;
 	type OwnerOrigin = EnsureDidOrigin<DidIdentifier, AccountId>;
 	type OriginSuccess = DidRawOrigin<AccountId, DidIdentifier>;
 	type Currency = Balances;

--- a/runtimes/peregrine/src/kilt/did.rs
+++ b/runtimes/peregrine/src/kilt/did.rs
@@ -21,10 +21,12 @@ use did::{
 	DidVerificationKeyRelationship, EnsureDidOrigin, RelationshipDeriveError,
 };
 use frame_system::EnsureRoot;
-use runtime_common::{constants, AccountId, DidIdentifier, SendDustAndFeesToTreasury};
+use runtime_common::{constants, dot_names::AllowedNameClaimer, AccountId, DidIdentifier, SendDustAndFeesToTreasury};
 use sp_core::ConstBool;
 
-use crate::{weights, Balances, Migration, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin};
+use crate::{
+	weights, Balances, DotNames, Migration, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin,
+};
 
 impl DeriveDidCallAuthorizationVerificationKeyRelationship for RuntimeCall {
 	fn derive_verification_key_relationship(&self) -> DeriveDidCallKeyRelationshipResult {
@@ -176,6 +178,7 @@ pub(crate) type DotNamesDeployment = pallet_web3_names::Instance2;
 impl pallet_web3_names::Config<DotNamesDeployment> for Runtime {
 	type BalanceMigrationManager = ();
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = EnsureDidOrigin<DidIdentifier, AccountId, AllowedNameClaimer<DotNames>>;
 	type Currency = Balances;
 	type Deposit = constants::dot_names::Web3NameDeposit;
 	type MaxNameLength = constants::dot_names::MaxNameLength;

--- a/runtimes/spiritnet/src/kilt/did.rs
+++ b/runtimes/spiritnet/src/kilt/did.rs
@@ -154,6 +154,7 @@ pub type Web3Name =
 impl pallet_web3_names::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = Self::OwnerOrigin;
 	type OwnerOrigin = EnsureDidOrigin<DidIdentifier, AccountId>;
 	type OriginSuccess = DidRawOrigin<AccountId, DidIdentifier>;
 	type Currency = Balances;

--- a/runtimes/spiritnet/src/kilt/did.rs
+++ b/runtimes/spiritnet/src/kilt/did.rs
@@ -21,10 +21,12 @@ use did::{
 	DidVerificationKeyRelationship, EnsureDidOrigin, RelationshipDeriveError,
 };
 use frame_system::EnsureRoot;
-use runtime_common::{constants, AccountId, DidIdentifier, SendDustAndFeesToTreasury};
+use runtime_common::{constants, dot_names::AllowedNameClaimer, AccountId, DidIdentifier, SendDustAndFeesToTreasury};
 use sp_core::ConstBool;
 
-use crate::{weights, Balances, Migration, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin};
+use crate::{
+	weights, Balances, DotNames, Migration, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin,
+};
 
 impl DeriveDidCallAuthorizationVerificationKeyRelationship for RuntimeCall {
 	fn derive_verification_key_relationship(&self) -> DeriveDidCallKeyRelationshipResult {
@@ -176,6 +178,7 @@ pub(crate) type DotNamesDeployment = pallet_web3_names::Instance2;
 impl pallet_web3_names::Config<DotNamesDeployment> for Runtime {
 	type BalanceMigrationManager = ();
 	type BanOrigin = EnsureRoot<AccountId>;
+	type ClaimOrigin = EnsureDidOrigin<DidIdentifier, AccountId, AllowedNameClaimer<DotNames>>;
 	type Currency = Balances;
 	type Deposit = constants::dot_names::Web3NameDeposit;
 	type MaxNameLength = constants::dot_names::MaxNameLength;


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/3691.

This PR allows to dynamically (i.e., via the sudo origin) elect an account as the only authorised to submit `claim` extrinsic for any web3name pallet deployment, and `associate_account` and `associate_sender` extrinsics for any did-lookup deployment. 

I also updated our dotnames and unique linking deployments for both our runtimes to use this new feature, althought I had to rely on a trick with `storage_alias`es to avoid introducing a new pallet just for this. Unfortunately, the [pallet-parameters](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/parameters) was only introduced in 1.8.0, so we might want to migrate to using that once we update our codebase to 1.8.0. For now, I could not think of any other way to implement this feature without touching the pallets storage entries, which I did not want to.

For both our runtimes, these are the two new storage keys introduced:

* `0x8ea135058ec16554c8e3d230d658fbffd30ff375811804de60521a1654f58ebb` for the dotnames deployment authorization
* `0x41a63f711fa40ef5e1dc8f0ac115a906d4378bcb7f1d95ba1124c2140bfccdba` for the unique linking deployment authorization

These values can be updated with a `system.setStorage(key, value)` call, which must specify an account ID as the sole submitter of the extrinsics specified above. A `system.killStorage(keys)` call will set the relative entry to `None`, which means no gating is enforced and anyone can create. This is the default for our web3name and did linking deployments.

**Important: when deploying the new runtime, we will also need to set the storage value for these entries, and we don't need to wait for the new runtime to be live as writing it earlier has no effect on the rest of the runtime**.

## How to test

1. Spin up a chopsticks Peregrine setup
2. Set a desired account as the sole allowed submitter for dotnames
    * E.g., This call sets it to the sudo `0x000404808ea135058ec16554c8e3d230d658fbffd30ff375811804de60521a1654f58ebb80921cbc0ffe09a865dbf4ae1d0410aa17c656881fe86666da0f97939e3701b674` 
4. Try to claim a dotname with any DID while submitting the tx with an account different than the sudo account: this will not work
5. Try again with the sudo account and it will work.
6. Remove the authorised account with `killStorage`
    * This call removes it: `0x000504808ea135058ec16554c8e3d230d658fbffd30ff375811804de60521a1654f58ebb`
8. Try again with the first account: it will now work.