### PR TITLE
chore: try runtime

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -27,6 +27,9 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+#[cfg(any(feature = "try-runtime", test))]
+mod try_state;
+
 mod curves;
 mod default_weights;
 pub mod traits;
@@ -232,6 +235,11 @@ pub mod pallet {
 				that the maximum scaling factor `10^MaxDenomination` is smaller than the fractional \
 				capacity `2^frac_nbits` of `CurveParameterType`",
 			);
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			crate::try_state::do_try_state::<T>()
 		}
 	}
 

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -83,6 +83,8 @@ pub mod runtime {
 	pub(crate) const ACCOUNT_00: AccountId = AccountId::new([0u8; 32]);
 	pub(crate) const ACCOUNT_01: AccountId = AccountId::new([1u8; 32]);
 	pub(crate) const ACCOUNT_99: AccountId = AccountId::new([99u8; 32]);
+	// Only used internally for setting up the test instance.
+	const ACCOUNT_100: AccountId = AccountId::new([100u8; 32]);
 	// assets
 	pub(crate) const DEFAULT_BONDED_CURRENCY_ID: AssetId = 1;
 	pub(crate) const DEFAULT_COLLATERAL_CURRENCY_ID: AssetId = 0;
@@ -109,7 +111,7 @@ pub mod runtime {
 	) -> PoolDetailsOf<Test> {
 		let bonded_currencies = BoundedVec::truncate_from(currencies.clone());
 		let state = state.unwrap_or(PoolStatus::Active);
-		let owner = owner.unwrap_or(ACCOUNT_99);
+		let owner = owner.unwrap_or(ACCOUNT_100);
 		let collateral_id = collateral_id.unwrap_or(DEFAULT_COLLATERAL_CURRENCY_ID);
 		let min_operation_balance = min_operation_balance.unwrap_or(1);
 		PoolDetailsOf::<Test> {
@@ -347,11 +349,14 @@ pub mod runtime {
 
 		pub(crate) fn build(self) -> sp_io::TestExternalities {
 			let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-			pallet_balances::GenesisConfig::<Test> {
-				balances: self.native_assets.clone(),
-			}
-			.assimilate_storage(&mut storage)
-			.expect("assimilate should not fail");
+
+			// Add default account with balance
+			let mut balances = self.native_assets.clone();
+			balances.push((ACCOUNT_100, ONE_HUNDRED_KILT));
+
+			pallet_balances::GenesisConfig::<Test> { balances }
+				.assimilate_storage(&mut storage)
+				.expect("assimilate should not fail");
 
 			let collateral_assets = self.collaterals.iter().map(|id| (*id, ACCOUNT_99, true, 1));
 
@@ -400,13 +405,12 @@ pub mod runtime {
 				System::set_block_number(System::block_number() + 1);
 
 				self.pools.into_iter().for_each(|(pool_id, pool)| {
-					// try to continue if we can't create the hold - might not be needed for all
-					// tests
-					let _ = <Test as crate::Config>::DepositCurrency::hold(
+					<Test as crate::Config>::DepositCurrency::hold(
 						&HoldReason::Deposit.into(),
 						&pool.owner,
 						BondingPallet::calculate_pool_deposit(pool.bonded_currencies.len()),
-					);
+					)
+					.expect("Creating deposit should not fail.");
 					crate::Pools::<Test>::insert(pool_id, pool);
 				});
 
@@ -414,6 +418,13 @@ pub mod runtime {
 			});
 
 			ext
+		}
+
+		pub fn build_and_execute_with_sanity_tests(self, test: impl FnOnce()) {
+			self.build().execute_with(|| {
+				test();
+				crate::try_state::do_try_state::<Test>().expect("Sanity test for attestation failed.");
+			})
 		}
 
 		#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -423,7 +423,7 @@ pub mod runtime {
 		pub fn build_and_execute_with_sanity_tests(self, test: impl FnOnce()) {
 			self.build().execute_with(|| {
 				test();
-				crate::try_state::do_try_state::<Test>().expect("Sanity test for attestation failed.");
+				crate::try_state::do_try_state::<Test>().expect("Sanity test for pallet-bonded-coins failed.");
 			})
 		}
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -44,7 +44,7 @@ fn burn_first_coin() {
 		(2 * amount_to_burn.pow(2) + 3 * amount_to_burn) * 10u128.pow(DEFAULT_COLLATERAL_DENOMINATION.into());
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT), (ACCOUNT_99, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), LARGE_BALANCE),
@@ -65,8 +65,7 @@ fn burn_first_coin() {
 				deposit: BondingPallet::calculate_pool_deposit(1),
 			},
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::burn_into(
@@ -119,8 +118,7 @@ fn burn_to_other() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let holder_origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let broke_origin = RawOrigin::Signed(ACCOUNT_01).into();
 
@@ -188,8 +186,7 @@ fn burn_large_supply() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::burn_into(
@@ -246,8 +243,7 @@ fn burn_large_quantity() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::burn_into(
@@ -306,8 +302,7 @@ fn burn_multiple_currencies() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::burn_into(
@@ -396,8 +391,7 @@ fn multiple_burns_vs_combined_burn() {
 				),
 			),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// pool 1: 1 burn of 10 * amount
@@ -472,8 +466,7 @@ fn multiple_mints_vs_combined_burn() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// step one: 10 mints of amount
@@ -536,8 +529,7 @@ fn burn_with_frozen_balance() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::burn_into(
@@ -625,8 +617,7 @@ fn burn_on_locked_pool() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
 
@@ -651,8 +642,7 @@ fn burn_on_locked_pool() {
 fn burn_invalid_pool_id() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let invalid_pool_id = calculate_pool_id(&[999]); // Nonexistent pool
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
@@ -681,8 +671,9 @@ fn burn_in_refunding_pool() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			assert_err!(
 				BondingPallet::burn_into(origin, pool_id, 0, ACCOUNT_00, 1, 2, 1),
@@ -711,8 +702,7 @@ fn burn_not_hitting_minimum() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// burn operation would return less than minimum return
@@ -741,8 +731,8 @@ fn burn_invalid_currency_index() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Index beyond array length
@@ -777,8 +767,7 @@ fn burn_beyond_balance() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -38,8 +38,7 @@ fn single_currency() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, initial_balance)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let curve = get_linear_bonding_curve_input();
 
@@ -109,8 +108,7 @@ fn multi_currency() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, initial_balance)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let curve = get_linear_bonding_curve_input();
 
@@ -162,8 +160,7 @@ fn can_create_identical_pools() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, initial_balance)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 			let curve = get_linear_bonding_curve_input();
 
@@ -214,8 +211,7 @@ fn can_create_identical_pools() {
 fn fails_if_collateral_not_exists() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let curve = get_linear_bonding_curve_input();
 
@@ -244,8 +240,7 @@ fn fails_if_collateral_not_exists() {
 fn cannot_create_circular_pool() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let curve = get_linear_bonding_curve_input();
 
@@ -279,8 +274,7 @@ fn handles_asset_id_overflow() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, initial_balance)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			NextAssetId::<BondingPallet>::set(u32::MAX);
 
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();

--- a/pallets/pallet-bonded-coins/src/tests/transactions/finish_destroy.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/finish_destroy.rs
@@ -48,8 +48,7 @@ fn anyone_can_call_finish_destroy() {
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT), (ACCOUNT_01, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Assets need to be in destroying state if pool is in destroying state
 			<Assets as Destroy<_>>::start_destroy(DEFAULT_BONDED_CURRENCY_ID, None)
 				.expect("failed to set up test state: asset cannot be set to destroying");
@@ -100,8 +99,7 @@ fn owner_receives_collateral() {
 			pool_id.clone(),
 			remaining_collateral,
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Assets need to be in destroying state if pool is in destroying state
 			<Assets as Destroy<_>>::start_destroy(DEFAULT_BONDED_CURRENCY_ID, None)
 				.expect("failed to set up test state: asset cannot be set to destroying");
@@ -136,8 +134,7 @@ fn works_if_asset_is_gone() {
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT), (ACCOUNT_01, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Assets need to be in destroying state if pool is in destroying state
 			<Assets as Destroy<_>>::start_destroy(DEFAULT_BONDED_CURRENCY_ID, None)
 				.expect("failed to set up test state: asset cannot be set to destroying");
@@ -176,8 +173,7 @@ fn fails_on_incorrect_state() {
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Assets need to be in destroying state if pool is in destroying state
 			<Assets as Destroy<_>>::start_destroy(DEFAULT_BONDED_CURRENCY_ID, None)
 				.expect("failed to set up test state: asset cannot be set to destroying");
@@ -224,8 +220,7 @@ fn fails_if_assets_cannot_be_destroyed() {
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Fails because asset is not in destroying state
 			BondingPallet::finish_destroy(origin.clone(), pool_id.clone(), 1)
 				.expect_err("Pool destruction should fail if any asset is not in destroying state.");
@@ -272,8 +267,7 @@ fn fails_on_invalid_arguments() {
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		// .with_bonded_balance(vec![(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// All assets need to be in destroying state if pool is in destroying state
 			currencies.into_iter().for_each(|id| {
 				<Assets as Destroy<_>>::start_destroy(id, None)

--- a/pallets/pallet-bonded-coins/src/tests/transactions/mint_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/mint_into.rs
@@ -60,8 +60,7 @@ fn mint_first_coin() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::mint_into(
@@ -133,8 +132,7 @@ fn mint_large_quantity() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::mint_into(
@@ -184,8 +182,7 @@ fn mint_to_other() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let holder_origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let broke_origin = RawOrigin::Signed(ACCOUNT_01).into();
 
@@ -258,8 +255,7 @@ fn mint_multiple_currencies() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::mint_into(
@@ -338,8 +334,7 @@ fn mint_large_supply() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::mint_into(
@@ -379,7 +374,7 @@ fn multiple_mints_vs_combined_mint() {
 	let account_collateral = 10u128.pow(20);
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_COLLATERAL_CURRENCY_ID, ACCOUNT_00, account_collateral)])
 		.with_pools(vec![
@@ -410,8 +405,7 @@ fn multiple_mints_vs_combined_mint() {
 				),
 			),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// pool 1: 1 mint of 10 * amount
@@ -476,8 +470,7 @@ fn mint_with_frozen_balance() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::mint_into(
@@ -560,8 +553,7 @@ fn mint_on_locked_pool() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
 
@@ -594,8 +586,7 @@ fn mint_on_locked_pool() {
 fn mint_invalid_pool_id() {
 	ExtBuilder::default()
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let invalid_pool_id = calculate_pool_id(&[999]); // Assume 999 is an invalid currency ID
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
@@ -624,8 +615,9 @@ fn mint_in_refunding_pool() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			assert_err!(
 				BondingPallet::mint_into(origin, pool_id, 0, ACCOUNT_00, 1, 2, 1),
@@ -654,8 +646,7 @@ fn mint_exceeding_max_collateral_cost() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Mint operation would cost more than allowed max_cost
@@ -695,8 +686,7 @@ fn mint_with_zero_cost() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(
@@ -724,8 +714,8 @@ fn mint_invalid_currency_index() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Index beyond array length
@@ -757,8 +747,7 @@ fn mint_without_collateral() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(
@@ -806,8 +795,7 @@ fn mint_more_than_fixed_can_represent() {
 				None,
 			),
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// repeatedly mint until we hit balance that cannot be represented

--- a/pallets/pallet-bonded-coins/src/tests/transactions/refund_account.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/refund_account.rs
@@ -47,14 +47,13 @@ fn refund_account_works() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), total_collateral),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, total_collateral * 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			assert_ok!(BondingPallet::refund_account(origin, pool_id.clone(), ACCOUNT_01, 0, 1));
@@ -89,14 +88,13 @@ fn refund_account_works_on_frozen() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), total_collateral),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, total_collateral * 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			<Assets as FreezeAccounts<_, _>>::freeze(&DEFAULT_BONDED_CURRENCY_ID, &ACCOUNT_01)
 				.expect("failed to freeze account prior to testing");
 
@@ -135,15 +133,14 @@ fn refund_account_works_with_large_supply() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), total_collateral),
 			(currencies[0], ACCOUNT_01, u128::MAX / 3 * 2),
 			(currencies[1], ACCOUNT_01, u128::MAX / 3 * 2),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_01).into();
 
 			assert_ok!(BondingPallet::refund_account(
@@ -204,8 +201,7 @@ fn balance_is_burnt_even_if_no_collateral_received() {
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, 20),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, 1), // 10 / 21 = 0.48 -> no collateral for you
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			assert_ok!(BondingPallet::refund_account(origin, pool_id.clone(), ACCOUNT_01, 0, 1));
@@ -246,8 +242,7 @@ fn refund_below_min_balance() {
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, 2000),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, 2000),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// change collateral to one that has a minimum balance
 			let collateral_id = 101;
 			assert_ok!(<Assets as Create<_>>::create(
@@ -295,8 +290,7 @@ fn refund_account_fails_when_pool_not_refunding() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), ONE_HUNDRED_KILT),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, ONE_HUNDRED_KILT),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_01).into();
 
 			// Ensure the refund_account call fails due to pool not being in refunding state
@@ -329,8 +323,7 @@ fn refund_account_no_balance() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), ONE_HUNDRED_KILT),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, ONE_HUNDRED_KILT),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			// Ensure the refund_account call fails when there is no balance to be
@@ -359,14 +352,13 @@ fn nothing_to_refund() {
 	// no collateral left
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, ACCOUNT_00, 100_000),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, 100_000),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			assert_err!(
@@ -395,14 +387,13 @@ fn unknown_pool_or_currency() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), total_collateral),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, total_collateral * 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_01).into();
 
 			// using some other pool id

--- a/pallets/pallet-bonded-coins/src/tests/transactions/refund_account.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/refund_account.rs
@@ -358,7 +358,8 @@ fn nothing_to_refund() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, ACCOUNT_00, 100_000),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, 100_000),
 		])
-		.build_and_execute_with_sanity_tests(|| {
+		.build()
+		.execute_with(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			assert_err!(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_manager.rs
@@ -41,8 +41,8 @@ fn changes_manager() {
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details.clone())])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 			assert_ok!(BondingPallet::reset_manager(origin, pool_id.clone(), Some(ACCOUNT_01)));
 
@@ -78,8 +78,9 @@ fn only_manager_can_change_manager() {
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.build_and_execute_with_sanity_tests(|| {
 			let owner_origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let other_origin = RawOrigin::Signed(ACCOUNT_01).into();
 

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -40,8 +40,8 @@ fn resets_team() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::reset_team(
@@ -76,9 +76,9 @@ fn does_not_change_team_when_not_live() {
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 
 	ExtBuilder::default()
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(
@@ -116,8 +116,9 @@ fn only_manager_can_change_team() {
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.build()
-		.execute_with(|| {
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let owner_origin = RawOrigin::Signed(ACCOUNT_00).into();
 			let other_origin = RawOrigin::Signed(ACCOUNT_01).into();
 
@@ -167,8 +168,8 @@ fn handles_currency_idx_out_of_bounds() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.build()
-		.execute_with(|| {
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
 			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/set_lock.rs
@@ -40,14 +40,13 @@ fn set_lock_works() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::set_lock(origin, pool_id.clone(), Default::default()));
@@ -91,14 +90,13 @@ fn set_lock_works_when_locked() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::set_lock(origin, pool_id.clone(), new_state.clone()));
@@ -134,14 +132,13 @@ fn set_lock_fails_when_not_authorized() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_01, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_01, ONE_HUNDRED_KILT), (ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_01, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Does not work for owner
 			assert_err!(
 				BondingPallet::set_lock(
@@ -179,14 +176,13 @@ fn set_lock_fails_when_not_live() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the unlock call fails due to the pool not being in a 'live' state

--- a/pallets/pallet-bonded-coins/src/tests/transactions/start_destroy.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/start_destroy.rs
@@ -43,8 +43,7 @@ fn start_destroy_works() {
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::start_destroy(origin, pool_id.clone(), 1));
@@ -85,8 +84,7 @@ fn start_destroy_works_when_nothing_to_refund() {
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::start_destroy(origin, pool_id.clone(), 1));
@@ -119,8 +117,7 @@ fn start_destroy_works_when_no_collateral() {
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::start_destroy(origin, pool_id.clone(), 1));
@@ -153,8 +150,7 @@ fn start_destroy_works_when_refunding() {
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::start_destroy(origin, pool_id.clone(), 1));
@@ -190,8 +186,7 @@ fn start_destroy_fails_when_pool_has_active_currencies() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), ONE_HUNDRED_KILT),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, ONE_HUNDRED_KILT),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the start_destroy call fails due to pool being actively used
@@ -222,8 +217,7 @@ fn start_destroy_fails_when_pool_destroying() {
 		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the start_destroy call fails due to pool not being active
@@ -262,8 +256,7 @@ fn start_destroy_fails_when_currency_no_low() {
 			pool_id.clone(),
 			ONE_HUNDRED_KILT,
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(
@@ -303,8 +296,7 @@ fn force_start_destroy_works() {
 			pool_id.clone(),
 			ONE_HUNDRED_KILT,
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Root.into();
 
 			assert_ok!(BondingPallet::force_start_destroy(origin, pool_id.clone(), 1));
@@ -340,8 +332,7 @@ fn force_start_destroy_works_even_with_nonzero_supply() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), ONE_HUNDRED_KILT),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, ONE_HUNDRED_KILT),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Root.into();
 
 			assert_ok!(BondingPallet::force_start_destroy(origin, pool_id.clone(), 1));
@@ -377,8 +368,7 @@ fn force_start_destroy_fails_when_not_root() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), ONE_HUNDRED_KILT),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, ONE_HUNDRED_KILT),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the force_start_destroy call fails due to non-root origin
@@ -414,8 +404,7 @@ fn force_start_destroy_fails_when_currency_no_low() {
 			pool_id.clone(),
 			ONE_HUNDRED_KILT,
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Root.into();
 
 			assert_err!(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/start_refund.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/start_refund.rs
@@ -294,6 +294,38 @@ fn start_refund_fails_when_nothing_to_refund() {
 }
 
 #[test]
+fn start_refund_fails_when_no_collateral() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+		None,
+	);
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+	let currency_count = 10;
+
+	ExtBuilder::default()
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.with_bonded_balance(vec![(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX)])
+		.build()
+		.execute_with(|| {
+			let origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			// Ensure the start_refund call fails due to nothing to refund
+			assert_err!(
+				BondingPallet::start_refund(origin, pool_id, currency_count),
+				Error::<Test>::NothingToRefund
+			);
+		});
+}
+
+#[test]
 fn pool_does_not_exist() {
 	let pool_details = generate_pool_details(
 		vec![DEFAULT_BONDED_CURRENCY_ID],

--- a/pallets/pallet-bonded-coins/src/tests/transactions/start_refund.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/start_refund.rs
@@ -42,14 +42,13 @@ fn start_refund_works() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::start_refund(origin, pool_id.clone(), currency_count));
@@ -79,15 +78,14 @@ fn start_refund_fails_when_pool_not_live() {
 	let currency_count = 1;
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the start_refund call fails due to pool not being live
@@ -131,15 +129,14 @@ fn start_refund_fails_when_currency_no_low() {
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&currencies);
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(
@@ -172,15 +169,14 @@ fn force_start_refund_works() {
 	let currency_count = 10;
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Root.into();
 
 			assert_ok!(BondingPallet::force_start_refund(
@@ -214,15 +210,14 @@ fn force_start_refund_fails_when_not_root() {
 	let currency_count = 10;
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the force_start_refund call fails due to non-root origin
@@ -249,15 +244,14 @@ fn start_refund_fails_when_no_permission() {
 	let currency_count = 10;
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_01).into();
 
 			// Ensure the start_refund call fails due to ALICE not having permission
@@ -284,44 +278,11 @@ fn start_refund_fails_when_nothing_to_refund() {
 	let currency_count = 10;
 
 	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_pools(vec![(pool_id.clone(), pool_details)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX)])
-		.build()
-		.execute_with(|| {
-			let origin = RawOrigin::Signed(ACCOUNT_00).into();
-
-			// Ensure the start_refund call fails due to nothing to refund
-			assert_err!(
-				BondingPallet::start_refund(origin, pool_id, currency_count),
-				Error::<Test>::NothingToRefund
-			);
-		});
-}
-
-#[test]
-fn start_refund_fails_when_no_collateral() {
-	let pool_details = generate_pool_details(
-		vec![DEFAULT_BONDED_CURRENCY_ID],
-		get_linear_bonding_curve(),
-		false,
-		Some(PoolStatus::Active),
-		Some(ACCOUNT_00),
-		None,
-		None,
-		None,
-	);
-	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
-	let currency_count = 10;
-
-	ExtBuilder::default()
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
-		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
-		.with_bonded_balance(vec![(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the start_refund call fails due to nothing to refund
@@ -349,14 +310,13 @@ fn pool_does_not_exist() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id, u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_err!(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/unlock.rs
@@ -46,8 +46,7 @@ fn unlock_works() {
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin = RawOrigin::Signed(ACCOUNT_00).into();
 
 			assert_ok!(BondingPallet::unlock(origin, pool_id.clone()));
@@ -77,14 +76,13 @@ fn unlock_works_only_for_manager() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX / 2)])
+		.with_native_balances(vec![(ACCOUNT_00, u128::MAX / 3), (ACCOUNT_01, u128::MAX / 3)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Does not work for owner
 			assert_err!(
 				BondingPallet::unlock(RawOrigin::Signed(ACCOUNT_01).into(), pool_id.clone()),
@@ -114,14 +112,13 @@ fn unlock_fails_when_not_live() {
 
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])
-		.with_native_balances(vec![(ACCOUNT_00, u128::MAX)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
 		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
 		.with_bonded_balance(vec![
 			(DEFAULT_COLLATERAL_CURRENCY_ID, pool_id.clone(), u128::MAX / 10),
 			(DEFAULT_BONDED_CURRENCY_ID, ACCOUNT_00, u128::MAX / 10),
 		])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let origin: OriginFor<Test> = RawOrigin::Signed(ACCOUNT_00).into();
 
 			// Ensure the unlock call fails due to the pool not being in a 'live' state

--- a/pallets/pallet-bonded-coins/src/try_state.rs
+++ b/pallets/pallet-bonded-coins/src/try_state.rs
@@ -24,8 +24,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 		let pool_account = pool_id.into();
 
 		// Deposit checks
-		let balance_on_hold_user =
-			T::DepositCurrency::balance_on_hold(&T::RuntimeHoldReason::from(HoldReason::Deposit), &owner);
+		let balance_on_hold_user = T::DepositCurrency::balance_on_hold(&HoldReason::Deposit.into(), &owner);
 		assert!(balance_on_hold_user >= deposit);
 
 		// Collateral checks

--- a/pallets/pallet-bonded-coins/src/try_state.rs
+++ b/pallets/pallet-bonded-coins/src/try_state.rs
@@ -1,0 +1,83 @@
+use frame_support::traits::{
+	fungible::InspectHold,
+	fungibles::{metadata::Inspect as InspectMetadata, roles::Inspect as InspectRoles, Inspect},
+};
+use sp_runtime::{traits::Zero, TryRuntimeError};
+
+use crate::{types::PoolDetails, Config, FungiblesAssetIdOf, HoldReason, Pools};
+
+pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
+	// checked currency ids. Each Currency should only be associated with one pool.
+	let mut checked_currency_ids = Vec::<FungiblesAssetIdOf<T>>::new();
+
+	Pools::<T>::iter().try_for_each(|(pool_id, pool_details)| {
+		let PoolDetails {
+			collateral_id,
+			deposit,
+			owner,
+			bonded_currencies,
+			state,
+			denomination,
+			..
+		} = pool_details;
+
+		let pool_account = pool_id.into();
+
+		// Collateral checks
+		let collateral_exists = T::Collaterals::asset_exists(collateral_id.clone());
+		assert!(collateral_exists);
+		let collateral_issuance = T::Collaterals::total_issuance(collateral_id);
+
+		// Deposit checks
+		let balance_on_hold_user =
+			T::DepositCurrency::balance_on_hold(&T::RuntimeHoldReason::from(HoldReason::Deposit), &owner);
+		assert!(balance_on_hold_user >= deposit);
+
+		// Bonded currencies checks
+		bonded_currencies
+			.iter()
+			.try_for_each(|currency_id| -> Result<(), TryRuntimeError> {
+				// check if currency is already associated with another pool
+				if checked_currency_ids.contains(currency_id) {
+					return Err(TryRuntimeError::Other(
+						"Currency is already associated with another pool",
+					));
+				}
+
+				checked_currency_ids.push(currency_id.clone());
+
+				// if Pool is live, all underlying assets should be live too
+				// Other states are not checked because there is no trait to gather the
+				// information.
+				if state.is_live() {
+					let asset_exists = T::Fungibles::asset_exists(currency_id.clone());
+					assert!(asset_exists);
+
+					// the owner and issuer should always be the pool account. Admins and Freezer
+					// can be changed.
+					let owner = T::Fungibles::owner(currency_id.clone()).unwrap();
+					assert_eq!(&owner, &pool_account);
+
+					let issuer = T::Fungibles::issuer(currency_id.clone()).unwrap();
+					assert_eq!(&issuer, &pool_account);
+
+					// The Currency in the fungibles pallet should always match with the
+					// denomination stored in the pool.
+					let currency_denomination = T::Fungibles::decimals(currency_id.clone());
+					assert_eq!(currency_denomination, denomination);
+
+					// if currency has issuance -> collateral issuance must exists.
+					let bonded_issuance = T::Fungibles::total_issuance(currency_id.clone());
+					if bonded_issuance > Zero::zero() && collateral_issuance == Zero::zero() {
+						return Err(TryRuntimeError::Other(
+							"Collateral issuance must exists if bonded currency has issuance",
+						));
+					}
+				}
+
+				Ok(())
+			})?;
+
+		Ok(())
+	})
+}


### PR DESCRIPTION
## fixes [#3693](https://github.com/KILTprotocol/ticket/issues/3693)

I removed one test that was breaking the pallet's invariant.
The state of the bonded currencies cannot be queried, nor can the accounts holding funds.