### PR TITLE
fix: check return asset ids from hook

### DIFF
--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -179,17 +179,12 @@ pub mod runtime {
 		FungiblesAssetIdOf<T>: From<AssetId>,
 	{
 		type Error = DispatchError;
-		fn try_get(n: u32) -> Result<BoundedVec<FungiblesAssetIdOf<T>, T::MaxCurrenciesPerPool>, Self::Error> {
+		fn try_get(n: u32) -> Result<Vec<FungiblesAssetIdOf<T>>, Self::Error> {
 			let next_asset_id = NextAssetId::<BondingPallet>::get();
 
 			let new_next_asset_id = next_asset_id.checked_add(n).ok_or(ArithmeticError::Overflow)?;
-
-			let asset_ids = (next_asset_id..(next_asset_id + n))
-				.map(|id| id.into())
-				.collect::<Vec<FungiblesAssetIdOf<T>>>();
-
 			NextAssetId::<BondingPallet>::set(new_next_asset_id);
-			Ok(BoundedVec::try_from(asset_ids).expect("should be able to create bounded vec"))
+			Ok((next_asset_id..new_next_asset_id).map(|id| id.into()).collect())
 		}
 	}
 

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -18,8 +18,8 @@
 use frame_support::{dispatch::DispatchResult, traits::fungibles::roles::Inspect};
 use frame_system::RawOrigin;
 use pallet_assets::{Config as AssetConfig, Pallet as AssetsPallet};
-use sp_runtime::{traits::StaticLookup, BoundedVec, DispatchError};
-use sp_std::{fmt::Debug, prelude::*};
+use sp_runtime::{traits::StaticLookup, DispatchError};
+use sp_std::{fmt::Debug, prelude::*, vec::Vec};
 
 use crate::{AccountIdOf, Config, FungiblesAssetIdOf};
 
@@ -103,5 +103,5 @@ pub trait NextAssetIds<T: Config> {
 	/// Generic error type.
 	type Error: Into<DispatchError>;
 	/// Get the next `n` asset ids.
-	fn try_get(n: u32) -> Result<BoundedVec<FungiblesAssetIdOf<T>, T::MaxCurrenciesPerPool>, Self::Error>;
+	fn try_get(n: u32) -> Result<Vec<FungiblesAssetIdOf<T>>, Self::Error>;
 }


### PR DESCRIPTION
Based on the discussion: https://github.com/KILTprotocol/kilt-node/pull/818#discussion_r1869222126, we have to check whether the `NextAssetIds` hook is returning the right amount of asset ids. 