### PR TITLE
test: add try-state tests for pallet-deposit-storage

### DIFF
--- a/pallets/pallet-deposit-storage/src/deposit/mock.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/mock.rs
@@ -158,6 +158,14 @@ impl ExtBuilder {
 		self
 	}
 
+	pub(crate) fn build_and_execute_with_sanity_tests(self, run: impl FnOnce()) {
+		let mut ext = self.build();
+		ext.execute_with(|| {
+			run();
+			crate::try_state::try_state::<TestRuntime>(System::block_number()).unwrap();
+		});
+	}
+
 	pub(crate) fn build(self) -> sp_io::TestExternalities {
 		let mut ext = sp_io::TestExternalities::default();
 

--- a/pallets/pallet-deposit-storage/src/deposit/tests/on_commitment_removed.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/tests/on_commitment_removed.rs
@@ -51,8 +51,7 @@ fn on_commitment_removed_successful() {
 				reason: HoldReason::Deposit.into(),
 			},
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert_eq!(
 				Pallet::<TestRuntime>::deposits(&namespace, &key),
 				Some(DepositEntry {
@@ -103,8 +102,7 @@ fn on_commitment_removed_different_owner_successful() {
 				reason: HoldReason::Deposit.into(),
 			},
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert_eq!(
 				Pallet::<TestRuntime>::deposits(&namespace, &key),
 				Some(DepositEntry {
@@ -139,7 +137,7 @@ fn on_commitment_removed_different_owner_successful() {
 
 #[test]
 fn on_commitment_removed_deposit_not_found() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder::default().build_and_execute_with_sanity_tests(|| {
 		assert_noop!(
 			<DepositCollectorHook::<TestRuntime> as ProviderHooks<TestRuntime>>::on_commitment_removed(
 				&SUBJECT,

--- a/pallets/pallet-deposit-storage/src/deposit/tests/on_identity_committed.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/tests/on_identity_committed.rs
@@ -37,8 +37,7 @@ use crate::{
 fn on_identity_committed_successful() {
 	ExtBuilder::default()
 		.with_balances(vec![(SUBMITTER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let namespace = DepositNamespaces::get();
 			let key: DepositKeyOf<TestRuntime> = (SUBJECT, SUBMITTER, 0 as IdentityCommitmentVersion)
 				.encode()
@@ -94,8 +93,7 @@ fn on_identity_committed_existing_deposit() {
 				},
 			},
 		)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert_noop!(
 				<DepositCollectorHook::<TestRuntime> as ProviderHooks<TestRuntime>>::on_identity_committed(
 					&SUBJECT,
@@ -110,7 +108,7 @@ fn on_identity_committed_existing_deposit() {
 
 #[test]
 fn on_identity_committed_insufficient_balance() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder::default().build_and_execute_with_sanity_tests(|| {
 		assert_noop!(
 			<DepositCollectorHook::<TestRuntime> as ProviderHooks<TestRuntime>>::on_identity_committed(
 				&SUBJECT,

--- a/pallets/pallet-deposit-storage/src/fungible/mod.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/mod.rs
@@ -35,6 +35,9 @@ const LOG_TARGET: &str = "runtime::pallet_deposit_storage::mutate-hold";
 #[cfg(test)]
 mod tests;
 
+#[cfg(any(test, feature = "try-runtime"))]
+pub(super) mod try_state;
+
 // This trait is implemented by forwarding everything to the `Currency`
 // implementation.
 impl<T> Inspect<T::AccountId> for Pallet<T>
@@ -88,7 +91,7 @@ impl<Namespace, Key> From<PalletDepositStorageReason<Namespace, Key>> for HoldRe
 	fn from(_value: PalletDepositStorageReason<Namespace, Key>) -> Self {
 		// All the deposits ever taken like this will count towards the same hold
 		// reason.
-		Self::Deposit
+		Self::FungibleImpl
 	}
 }
 

--- a/pallets/pallet-deposit-storage/src/fungible/tests/burn.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/burn.rs
@@ -36,8 +36,7 @@ use crate::{
 fn burn_held() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)
@@ -81,8 +80,7 @@ fn burn_held() {
 fn burn_all_held() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)

--- a/pallets/pallet-deposit-storage/src/fungible/tests/hold.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/hold.rs
@@ -33,8 +33,7 @@ use crate::{
 fn hold() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)
@@ -73,8 +72,7 @@ fn hold() {
 fn zero_hold() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 0)
 				.expect("Failed to hold amount for user.");
@@ -87,8 +85,7 @@ fn zero_hold() {
 fn hold_same_reason_different_user() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000), (OTHER_ACCOUNT, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 			assert_ok!(<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(
 				&reason, &OWNER, 10
@@ -104,8 +101,7 @@ fn hold_same_reason_different_user() {
 fn too_many_holds() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			// Occupy the only hold available with a different reason.
 			<Balances as MutateHold<AccountId32>>::hold(&TestRuntimeHoldReason::Else, &OWNER, 1)
 				.expect("Failed to hold amount for user.");

--- a/pallets/pallet-deposit-storage/src/fungible/tests/inspect_hold.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/inspect_hold.rs
@@ -31,8 +31,7 @@ use crate::{
 fn balance_on_hold() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason {
 				namespace: DepositNamespace::ExampleNamespace,
 				key: [0].to_vec().try_into().unwrap(),
@@ -66,8 +65,7 @@ fn balance_on_hold() {
 fn multiple_holds() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason {
 				namespace: DepositNamespace::ExampleNamespace,
 				key: [0].to_vec().try_into().unwrap(),

--- a/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
@@ -148,4 +148,12 @@ impl ExtBuilder {
 
 		ext
 	}
+
+	pub(crate) fn build_and_execute_with_sanity_tests(self, run: impl FnOnce()) {
+		let mut ext = self.build();
+		ext.execute_with(|| {
+			run();
+			crate::try_state::try_state::<TestRuntime>(System::block_number()).unwrap();
+		});
+	}
 }

--- a/pallets/pallet-deposit-storage/src/fungible/tests/release.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/release.rs
@@ -36,8 +36,7 @@ use crate::{
 fn release() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)
@@ -69,8 +68,7 @@ fn release() {
 fn release_different_reason() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason {
 				namespace: DepositNamespace::ExampleNamespace,
 				key: [0].to_vec().try_into().unwrap(),
@@ -93,8 +91,7 @@ fn release_different_reason() {
 fn release_all() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)

--- a/pallets/pallet-deposit-storage/src/fungible/tests/transfer.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/transfer.rs
@@ -36,8 +36,7 @@ use crate::{
 fn transfer_on_hold() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000), (OTHER_ACCOUNT, 1)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::hold(&reason, &OWNER, 10)
@@ -72,8 +71,7 @@ fn transfer_on_hold() {
 fn transfer_and_hold() {
 	ExtBuilder::default()
 		.with_balances(vec![(OWNER, 100_000), (OTHER_ACCOUNT, 1)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let reason = PalletDepositStorageReason::default();
 
 			<Pallet<TestRuntime> as MutateHold<AccountId32>>::transfer_and_hold(

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -1,0 +1,65 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use std::collections::BTreeMap;
+
+use frame_support::{ensure, traits::fungible::InspectHold};
+use frame_system::pallet_prelude::BlockNumberFor;
+use kilt_support::Deposit;
+use sp_runtime::{traits::CheckedAdd, TryRuntimeError};
+
+use crate::{deposit::DepositEntry, AccountIdOf, BalanceOf, Config, HoldReason, SystemDeposits};
+
+pub(crate) fn check_fungible_consistency<T>(_n: BlockNumberFor<T>) -> Result<(), TryRuntimeError>
+where
+	T: Config,
+{
+	// Sum together all the deposits stored as part of the `MutateHold`
+	// implementation, and fail if any of them does not have the expected
+	// `crate::HoldReason::FungibleImpl` reason.
+	let sum_of_deposits = SystemDeposits::<T>::iter_values().try_fold(
+		BTreeMap::<AccountIdOf<T>, BalanceOf<T>>::new(),
+		|mut sum,
+		 DepositEntry {
+		     reason,
+		     deposit: Deposit { amount, owner },
+		 }| {
+			ensure!(
+				reason == HoldReason::FungibleImpl.into(),
+				TryRuntimeError::Other("Found a deposit reason different than the expected `HoldReason::FungibleImpl`")
+			);
+
+			// Fold the deposit amount for the current user.
+			sum.entry(owner)
+				.and_modify(|s| *s = s.checked_add(&amount).expect("Failed to fold deposits for user."));
+
+			Ok::<_, TryRuntimeError>(sum)
+		},
+	)?;
+	// We verify that the total balance on hold for the `HoldReason::FungibleImpl`
+	// matches the amount of deposits stored in this pallet.
+	sum_of_deposits.into_iter().try_for_each(|(owner, deposit_sum)| {
+		ensure!(
+			<T::Currency as InspectHold<AccountIdOf<T>>>::balance_on_hold(&HoldReason::FungibleImpl.into(), &owner)
+				== deposit_sum,
+			TryRuntimeError::Other("Deposit sum for user less than the expected amount")
+		);
+		Ok::<_, TryRuntimeError>(())
+	})?;
+	Ok(())
+}

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -58,7 +58,7 @@ where
 		ensure!(
 			<T::Currency as InspectHold<AccountIdOf<T>>>::balance_on_hold(&HoldReason::FungibleImpl.into(), &owner)
 				== deposit_sum,
-			TryRuntimeError::Other("Deposit sum for user less than the expected amount")
+			TryRuntimeError::Other("Deposit sum for user different than the expected amount")
 		);
 		Ok::<_, TryRuntimeError>(())
 	})?;

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -25,6 +25,8 @@ use sp_runtime::{traits::CheckedAdd, TryRuntimeError};
 
 use crate::{deposit::DepositEntry, AccountIdOf, BalanceOf, Config, HoldReason, SystemDeposits};
 
+// Verify the state kept as part of the `MutateHold` implementation is
+// consistent with the state of the `Currency` type.
 pub(crate) fn check_fungible_consistency<T>(_n: BlockNumberFor<T>) -> Result<(), TryRuntimeError>
 where
 	T: Config,

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -46,8 +46,8 @@ where
 			);
 
 			// Fold the deposit amount for the current user.
-			sum.entry(owner)
-				.and_modify(|s| *s = s.checked_add(&amount).expect("Failed to fold deposits for user."));
+			let entry = sum.entry(owner).or_default();
+			*entry = entry.checked_add(&amount).expect("Failed to fold deposits for user.");
 
 			Ok::<_, TryRuntimeError>(sum)
 		},

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -33,7 +33,7 @@ where
 	// Sum together all the deposits stored as part of the `MutateHold`
 	// implementation, and fail if any of them does not have the expected
 	// `crate::HoldReason::FungibleImpl` reason.
-	let sum_of_deposits = SystemDeposits::<T>::iter_values().try_fold(
+	let users_deposits = SystemDeposits::<T>::iter_values().try_fold(
 		BTreeMap::<AccountIdOf<T>, BalanceOf<T>>::new(),
 		|mut sum,
 		 DepositEntry {
@@ -57,7 +57,7 @@ where
 	)?;
 	// We verify that the total balance on hold for the `HoldReason::FungibleImpl`
 	// matches the amount of deposits stored in this pallet.
-	sum_of_deposits
+	users_deposits
 		.into_iter()
 		.try_for_each(|(owner, deposit_sum)| -> Result<_, TryRuntimeError> {
 			ensure!(

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -48,7 +48,9 @@ where
 
 			// Fold the deposit amount for the current user.
 			let entry = sum.entry(owner).or_default();
-			*entry = entry.checked_add(&amount).expect("Failed to fold deposits for user.");
+			*entry = entry
+				.checked_add(&amount)
+				.ok_or(TryRuntimeError::Other("Failed to fold deposits for user."))?;
 
 			Ok(sum)
 		},

--- a/pallets/pallet-deposit-storage/src/fungible/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/try_state.rs
@@ -16,12 +16,11 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use std::collections::BTreeMap;
-
 use frame_support::{ensure, traits::fungible::InspectHold};
 use frame_system::pallet_prelude::BlockNumberFor;
 use kilt_support::Deposit;
 use sp_runtime::{traits::CheckedAdd, TryRuntimeError};
+use sp_std::collections::btree_map::BTreeMap;
 
 use crate::{deposit::DepositEntry, AccountIdOf, BalanceOf, Config, HoldReason, SystemDeposits};
 

--- a/pallets/pallet-deposit-storage/src/lib.rs
+++ b/pallets/pallet-deposit-storage/src/lib.rs
@@ -37,6 +37,9 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+#[cfg(any(test, feature = "try-runtime"))]
+mod try_state;
+
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
@@ -69,7 +72,7 @@ pub mod pallet {
 		pallet_prelude::*,
 		traits::{
 			fungible::{hold::Mutate, Inspect},
-			EnsureOrigin,
+			EnsureOrigin, Hooks,
 		},
 	};
 	use frame_system::pallet_prelude::*;
@@ -115,6 +118,7 @@ pub mod pallet {
 	#[pallet::composite_enum]
 	pub enum HoldReason {
 		Deposit,
+		FungibleImpl,
 	}
 
 	#[pallet::error]
@@ -192,6 +196,14 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			crate::try_state::try_state::<T>(n)
+		}
+	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/pallets/pallet-deposit-storage/src/mock.rs
+++ b/pallets/pallet-deposit-storage/src/mock.rs
@@ -152,6 +152,14 @@ impl ExtBuilder {
 		ext
 	}
 
+	pub(crate) fn build_and_execute_with_sanity_tests(self, run: impl FnOnce()) {
+		let mut ext = self.build();
+		ext.execute_with(|| {
+			run();
+			crate::try_state::try_state::<TestRuntime>(System::block_number()).unwrap();
+		});
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	pub(crate) fn build_with_keystore(self) -> sp_io::TestExternalities {
 		let mut ext = self.build();

--- a/pallets/pallet-deposit-storage/src/tests/add_deposit.rs
+++ b/pallets/pallet-deposit-storage/src/tests/add_deposit.rs
@@ -30,8 +30,7 @@ fn add_deposit_new() {
 	ExtBuilder::default()
 		//	Deposit amount + existential deposit
 		.with_balances(vec![(OWNER, 500 + 10_000)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			let deposit = DepositEntryOf::<TestRuntime> {
 				reason: HoldReason::Deposit.into(),
 				deposit: Deposit {
@@ -69,8 +68,7 @@ fn add_deposit_existing() {
 	let key = DepositKeyOf::<TestRuntime>::default();
 	ExtBuilder::default()
 		.with_deposits(vec![(namespace.clone(), key.clone(), deposit.clone())])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert_noop!(
 				Pallet::<TestRuntime>::add_deposit(namespace.clone(), key.clone(), deposit),
 				Error::<TestRuntime>::DepositExisting
@@ -80,7 +78,7 @@ fn add_deposit_existing() {
 
 #[test]
 fn add_deposit_failed_to_hold() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder::default().build_and_execute_with_sanity_tests(|| {
 		let deposit = DepositEntryOf::<TestRuntime> {
 			reason: HoldReason::Deposit.into(),
 			deposit: Deposit {

--- a/pallets/pallet-deposit-storage/src/tests/reclaim_deposit.rs
+++ b/pallets/pallet-deposit-storage/src/tests/reclaim_deposit.rs
@@ -39,8 +39,7 @@ fn reclaim_deposit_successful() {
 	let key = DepositKeyOf::<TestRuntime>::default();
 	ExtBuilder::default()
 		.with_deposits(vec![(namespace.clone(), key.clone(), deposit)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert!(Pallet::<TestRuntime>::deposits(&namespace, &key).is_some());
 			assert_eq!(Balances::balance_on_hold(&HoldReason::Deposit.into(), &OWNER), 10_000);
 
@@ -57,7 +56,7 @@ fn reclaim_deposit_successful() {
 
 #[test]
 fn reclaim_deposit_not_found() {
-	ExtBuilder::default().build().execute_with(|| {
+	ExtBuilder::default().build_and_execute_with_sanity_tests(|| {
 		assert_noop!(
 			Pallet::<TestRuntime>::reclaim_deposit(
 				RawOrigin::Signed(OWNER).into(),
@@ -82,8 +81,7 @@ fn reclaim_deposit_unauthorized() {
 	let key = DepositKeyOf::<TestRuntime>::default();
 	ExtBuilder::default()
 		.with_deposits(vec![(namespace.clone(), key.clone(), deposit)])
-		.build()
-		.execute_with(|| {
+		.build_and_execute_with_sanity_tests(|| {
 			assert_noop!(
 				Pallet::<TestRuntime>::reclaim_deposit(
 					RawOrigin::Signed(OTHER_ACCOUNT).into(),

--- a/pallets/pallet-deposit-storage/src/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/try_state.rs
@@ -83,7 +83,7 @@ where
 			ensure!(
 				<T::Currency as InspectHold<AccountIdOf<T>>>::balance_on_hold(&runtime_hold_reason, &owner)
 					== deposit_sum,
-				TryRuntimeError::Other("Deposit sum for user less than the expected amount")
+				TryRuntimeError::Other("Deposit sum for user different than the expected amount")
 			);
 			Ok::<_, TryRuntimeError>(())
 		})?;

--- a/pallets/pallet-deposit-storage/src/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/try_state.rs
@@ -51,7 +51,7 @@ where
 	// Sum together all the deposits stored not part of the `MutateHold`
 	// implementation, and fail if any of them has the unexpected
 	// `crate::HoldReason::FungibleImpl` reason.
-	let sum_of_deposits = Deposits::<T>::iter_values().try_fold(
+	let users_deposits = Deposits::<T>::iter_values().try_fold(
 		// We can't use `T::RuntimeHoldReason` as a key because it does not implement `Ord`, so we `.encode()` it here.
 		BTreeMap::<(AccountIdOf<T>, Vec<u8>), BalanceOf<T>>::new(),
 		|mut sum,
@@ -78,7 +78,7 @@ where
 	)?;
 	// We verify that the total balance on hold for each hold reason matches the
 	// amount of deposits stored in this pallet.
-	sum_of_deposits.into_iter().try_for_each(
+	users_deposits.into_iter().try_for_each(
 		|((owner, encoded_runtime_hold_reason), deposit_sum)| -> Result<_, TryRuntimeError> {
 			let runtime_hold_reason = T::RuntimeHoldReason::decode(&mut encoded_runtime_hold_reason.as_slice()).or(
 				Err(TryRuntimeError::Other("Failed to decode stored `RuntimeHoldReason`.")),

--- a/pallets/pallet-deposit-storage/src/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/try_state.rs
@@ -67,8 +67,8 @@ where
 			);
 
 			// Fold the deposit amount for the current user.
-			sum.entry((owner, reason.encode()))
-				.and_modify(|s| *s = s.checked_add(&amount).expect("Failed to fold deposits for user."));
+			let entry = sum.entry((owner, reason.encode())).or_default();
+			*entry = entry.checked_add(&amount).expect("Failed to fold deposits for user.");
 
 			Ok::<_, TryRuntimeError>(sum)
 		},

--- a/pallets/pallet-deposit-storage/src/try_state.rs
+++ b/pallets/pallet-deposit-storage/src/try_state.rs
@@ -1,0 +1,36 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2024 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+//! Pallet to store namespaced deposits for the configured `Currency`. It allows
+//! the original payer of a deposit to claim it back, triggering a hook to
+//! optionally perform related actions somewhere else in the runtime.
+//! Each deposit is identified by a namespace and a key. There cannot be two
+//! equal keys under the same namespace, but the same key can be present under
+//! different namespaces.
+
+use frame_system::pallet_prelude::BlockNumberFor;
+use sp_runtime::TryRuntimeError;
+
+use crate::Config;
+
+pub(crate) fn try_state<T>(n: BlockNumberFor<T>) -> Result<(), TryRuntimeError>
+where
+	T: Config,
+{
+	crate::fungible::try_state::check_fungible_consistency::<T>(n)
+}


### PR DESCRIPTION
Based on top of https://github.com/KILTprotocol/kilt-node/pull/823.

It adds `try-runtime` checks for both the `MutateHold` implementation as well as the rest of the deposits, so that one feature does not interfere with the other.