### PR TITLE
feat: add support for metadata hash checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build-production-wasm:
     - export AUTHORIZE_UPGRADE_PREFIX=0x02
     - export AUTHORIZE_UPGRADE_CHECK_VERSION=true
     - export VERBOSE=true
+    - export DEFAULT_FEATURES="--features metadata-hash"
     - cp -r * /build
     - /srtool/build build
     - subwasm meta --format=json+scale /out/${RUNTIME}_runtime.compact.wasm > /out/${RUNTIME}-metadata.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6200,6 +6200,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.3",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8724,6 +8738,7 @@ dependencies = [
  "enum-iterator",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -12295,6 +12310,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12319,6 +12357,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -13785,6 +13829,7 @@ dependencies = [
  "enum-iterator",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -14233,12 +14278,21 @@ name = "substrate-wasm-builder"
 version = "18.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-crates-io-v1.7.0#e046d3b2caaca6c43a60f26594052c5c806b980e"
 dependencies = [
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version",
  "strum 0.24.1",
  "tempfile",
  "toml 0.8.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ xcm-emulator                      = { git = "https://github.com/paritytech/polka
 frame-benchmarking                         = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
 frame-benchmarking-cli                     = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
 frame-executive                            = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
+frame-metadata-hash-extension              = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
 frame-support                              = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
 frame-system                               = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }
 frame-system-rpc-runtime-api               = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-crates-io-v1.7.0" }

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -70,31 +70,32 @@ sp-transaction-pool = { workspace = true }
 sp-version          = { workspace = true }
 sp-weights          = { workspace = true }
 
-frame-executive            = { workspace = true }
-frame-support              = { workspace = true }
-frame-system               = { workspace = true }
-pallet-assets              = { workspace = true }
-pallet-aura                = { workspace = true }
-pallet-authorship          = { workspace = true }
-pallet-balances            = { workspace = true }
-pallet-collective          = { workspace = true }
-pallet-democracy           = { workspace = true }
-pallet-indices             = { workspace = true }
-pallet-membership          = { workspace = true }
-pallet-message-queue       = { workspace = true }
-pallet-multisig            = { workspace = true }
-pallet-preimage            = { workspace = true }
-pallet-proxy               = { workspace = true }
-pallet-scheduler           = { workspace = true }
-pallet-session             = { workspace = true }
-pallet-sudo                = { workspace = true }
-pallet-timestamp           = { workspace = true }
-pallet-tips                = { workspace = true }
-pallet-transaction-payment = { workspace = true }
-pallet-treasury            = { workspace = true }
-pallet-utility             = { workspace = true }
-pallet-vesting             = { workspace = true }
-sp-genesis-builder         = { workspace = true }
+frame-executive               = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
+frame-support                 = { workspace = true }
+frame-system                  = { workspace = true }
+pallet-assets                 = { workspace = true }
+pallet-aura                   = { workspace = true }
+pallet-authorship             = { workspace = true }
+pallet-balances               = { workspace = true }
+pallet-collective             = { workspace = true }
+pallet-democracy              = { workspace = true }
+pallet-indices                = { workspace = true }
+pallet-membership             = { workspace = true }
+pallet-message-queue          = { workspace = true }
+pallet-multisig               = { workspace = true }
+pallet-preimage               = { workspace = true }
+pallet-proxy                  = { workspace = true }
+pallet-scheduler              = { workspace = true }
+pallet-session                = { workspace = true }
+pallet-sudo                   = { workspace = true }
+pallet-timestamp              = { workspace = true }
+pallet-tips                   = { workspace = true }
+pallet-transaction-payment    = { workspace = true }
+pallet-treasury               = { workspace = true }
+pallet-utility                = { workspace = true }
+pallet-vesting                = { workspace = true }
+sp-genesis-builder            = { workspace = true }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext         = { workspace = true }
@@ -126,6 +127,7 @@ frame-try-runtime = { workspace = true, optional = true }
 [features]
 default = ["std"]
 fast-gov = ["runtime-common/fast-gov"]
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
 runtime-benchmarks = [
   "attestation/runtime-benchmarks",
   "ctype/runtime-benchmarks",
@@ -190,6 +192,7 @@ std = [
   "did/std",
   "frame-benchmarking?/std",
   "frame-executive/std",
+  "frame-metadata-hash-extension/std",
   "frame-support/std",
   "frame-system-benchmarking?/std",
   "frame-system-rpc-runtime-api/std",

--- a/runtimes/peregrine/build.rs
+++ b/runtimes/peregrine/build.rs
@@ -19,9 +19,14 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
+	let builder = WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
-		.import_memory()
-		.build()
+		.import_memory();
+
+	#[cfg(feature = "metadata-hash")]
+	// TODO: Can we re-use some consts?
+	let builder = builder.enable_metadata_hash("PILT", 15);
+
+	builder.build()
 }

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -33,6 +33,7 @@ use core::str;
 
 // Polkadot-sdk crates
 use cumulus_pallet_parachain_system::register_validate_block;
+use frame_metadata_hash_extension::CheckMetadataHash;
 use frame_support::construct_runtime;
 use frame_system::{
 	ChainContext, CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion, CheckWeight,
@@ -217,4 +218,5 @@ pub type SignedExtra = (
 	CheckNonce<Runtime>,
 	CheckWeight<Runtime>,
 	ChargeTransactionPayment<Runtime>,
+	CheckMetadataHash<Runtime>,
 );

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -68,29 +68,30 @@ sp-transaction-pool = { workspace = true }
 sp-version          = { workspace = true }
 sp-weights          = { workspace = true }
 
-frame-executive            = { workspace = true }
-frame-support              = { workspace = true }
-frame-system               = { workspace = true }
-pallet-assets              = { workspace = true }
-pallet-aura                = { workspace = true }
-pallet-authorship          = { workspace = true }
-pallet-balances            = { workspace = true }
-pallet-collective          = { workspace = true }
-pallet-democracy           = { workspace = true }
-pallet-indices             = { workspace = true }
-pallet-membership          = { workspace = true }
-pallet-message-queue       = { workspace = true }
-pallet-multisig            = { workspace = true }
-pallet-preimage            = { workspace = true }
-pallet-proxy               = { workspace = true }
-pallet-scheduler           = { workspace = true }
-pallet-session             = { workspace = true }
-pallet-timestamp           = { workspace = true }
-pallet-tips                = { workspace = true }
-pallet-transaction-payment = { workspace = true }
-pallet-treasury            = { workspace = true }
-pallet-utility             = { workspace = true }
-pallet-vesting             = { workspace = true }
+frame-executive               = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
+frame-support                 = { workspace = true }
+frame-system                  = { workspace = true }
+pallet-assets                 = { workspace = true }
+pallet-aura                   = { workspace = true }
+pallet-authorship             = { workspace = true }
+pallet-balances               = { workspace = true }
+pallet-collective             = { workspace = true }
+pallet-democracy              = { workspace = true }
+pallet-indices                = { workspace = true }
+pallet-membership             = { workspace = true }
+pallet-message-queue          = { workspace = true }
+pallet-multisig               = { workspace = true }
+pallet-preimage               = { workspace = true }
+pallet-proxy                  = { workspace = true }
+pallet-scheduler              = { workspace = true }
+pallet-session                = { workspace = true }
+pallet-timestamp              = { workspace = true }
+pallet-tips                   = { workspace = true }
+pallet-transaction-payment    = { workspace = true }
+pallet-treasury               = { workspace = true }
+pallet-utility                = { workspace = true }
+pallet-vesting                = { workspace = true }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext         = { workspace = true }
@@ -123,6 +124,7 @@ frame-try-runtime = { workspace = true, optional = true }
 [features]
 default = ["std"]
 fast-gov = ["runtime-common/fast-gov"]
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
 runtime-benchmarks = [
   "attestation/runtime-benchmarks",
   "ctype/runtime-benchmarks",
@@ -187,6 +189,7 @@ std = [
   "did/std",
   "frame-benchmarking?/std",
   "frame-executive/std",
+  "frame-metadata-hash-extension/std",
   "frame-support/std",
   "frame-system-benchmarking?/std",
   "frame-system-rpc-runtime-api/std",

--- a/runtimes/spiritnet/build.rs
+++ b/runtimes/spiritnet/build.rs
@@ -19,9 +19,14 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
+	let builder = WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
-		.import_memory()
-		.build()
+		.import_memory();
+
+	#[cfg(feature = "metadata-hash")]
+	// TODO: Can we re-use some consts?
+	let builder = builder.enable_metadata_hash("PILT", 15);
+
+	builder.build()
 }

--- a/runtimes/spiritnet/build.rs
+++ b/runtimes/spiritnet/build.rs
@@ -26,7 +26,7 @@ fn main() {
 
 	#[cfg(feature = "metadata-hash")]
 	// TODO: Can we re-use some consts?
-	let builder = builder.enable_metadata_hash("PILT", 15);
+	let builder = builder.enable_metadata_hash("KILT", 15);
 
 	builder.build()
 }

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -33,6 +33,7 @@ use core::str;
 
 // Polkadot-sdk crates
 use cumulus_pallet_parachain_system::register_validate_block;
+use frame_metadata_hash_extension::CheckMetadataHash;
 use frame_support::construct_runtime;
 use frame_system::{
 	ChainContext, CheckEra, CheckGenesis, CheckNonZeroSender, CheckNonce, CheckSpecVersion, CheckTxVersion, CheckWeight,
@@ -212,4 +213,5 @@ pub type SignedExtra = (
 	CheckNonce<Runtime>,
 	CheckWeight<Runtime>,
 	ChargeTransactionPayment<Runtime>,
+	CheckMetadataHash<Runtime>,
 );


### PR DESCRIPTION
We introduce a new feature for peregrine and spiritnet runtimes, which adds the metadata hash signed extension, for wallets that need it.

The Gitlab build pipeline has also been updated to include the new feature only when building the production WASMs.

## How to test

Change any integration tests in the SDK based on this PR (https://github.com/KILTprotocol/sdk-js/pull/924), and verify the metadata is verified (e.g., by enabling logs via a Chopsticks deployment).