### PR TITLE
ci: fix tag

### DIFF
--- a/.maintain/build-image.sh
+++ b/.maintain/build-image.sh
@@ -7,10 +7,10 @@ target_tag=$1
 # Build the builder image and push it in the background
 docker build \
     --target builder \
-    --cache-from $CI_REGISTRY/kilt-node:builder \
-    -t $CI_REGISTRY/kilt-node:builder \
+    --cache-from $CI_REGISTRY/$ORGANIZATION/kilt-node:builder \
+    -t $CI_REGISTRY/$ORGANIZATION/kilt-node:builder \
     . &
-docker push $CI_REGISTRY/kilt-node:builder &
+docker push $CI_REGISTRY/$ORGANIZATION/kilt-node:builder &
 
 wait
 
@@ -21,8 +21,8 @@ build_and_tag() {
     local cache_image=$3
 
     docker build \
-        --cache-from $CI_REGISTRY/kilt-node:builder \
-        --cache-from $CI_REGISTRY/$cache_image:$target_tag \
+        --cache-from $CI_REGISTRY/$ORGANIZATION/kilt-node:builder \
+        --cache-from $CI_REGISTRY/$ORGANIZATION/$cache_image:$target_tag \
         --build-arg NODE_TYPE=$node_type \
         -t local/$image_name:$target_tag \
         .


### PR DESCRIPTION
## fixes NO TICKET
The `Organisation` was missing from the docker tag


## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
