### PR TITLE
fix: ensure at least one currency in pool

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -315,6 +315,8 @@ pub mod pallet {
 		Slippage,
 		/// The calculated collateral is zero.
 		ZeroCollateral,
+		/// A pool has to contain at least one bonded currency.
+		ZeroBondedCurrency,
 	}
 
 	#[pallet::call]
@@ -372,6 +374,7 @@ pub mod pallet {
 			let checked_curve = curve.try_into().map_err(|_| Error::<T>::InvalidInput)?;
 
 			let currency_length = currencies.len();
+			ensure!(!currency_length.is_zero(), Error::<T>::ZeroBondedCurrency);
 
 			let currency_ids = T::NextAssetIds::try_get(currency_length.saturated_into())
 				.map_err(|e| e.into())


### PR DESCRIPTION
## fixes [#3747](https://github.com/KILTprotocol/ticket/issues/3747)

The pool_id is based on the bonded currency IDs. If you attempt to create a pool twice without associating any bonded currencies, the pool_id will collide, resulting in an internal error.