### PR TITLE
chore: add XCM migration

### DIFF
--- a/runtimes/peregrine/src/migrations/mod.rs
+++ b/runtimes/peregrine/src/migrations/mod.rs
@@ -25,8 +25,10 @@ parameter_types! {
 	pub const DmpPalletName: &'static str = "DmpQueue";
 }
 
-pub type RuntimeMigrations =
-	frame_support::migrations::RemovePallet<DmpPalletName, <Runtime as frame_system::Config>::DbWeight>;
+pub type RuntimeMigrations = (
+	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
+	frame_support::migrations::RemovePallet<DmpPalletName, <Runtime as frame_system::Config>::DbWeight>,
+);
 
 impl pallet_migration::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/runtimes/spiritnet/src/migrations/mod.rs
+++ b/runtimes/spiritnet/src/migrations/mod.rs
@@ -25,8 +25,10 @@ parameter_types! {
 	pub const DmpPalletName: &'static str = "DmpQueue";
 }
 
-pub type RuntimeMigrations =
-	frame_support::migrations::RemovePallet<DmpPalletName, <Runtime as frame_system::Config>::DbWeight>;
+pub type RuntimeMigrations = (
+	frame_support::migrations::RemovePallet<DmpPalletName, <Runtime as frame_system::Config>::DbWeight>,
+	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
+);
 
 impl pallet_migration::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
Not important for the current runtime upgrade, but the `MigrateToLatestXcmVersion` can be permanently added to the runtime migrations: https://github.com/paritytech/polkadot-sdk/blob/f798111afc15f464a772cd7ed37910cc6208b713/polkadot/xcm/pallet-xcm/src/migration.rs#L385