### PR TITLE
fix: benchmarks script

### DIFF
--- a/scripts/run_benches_for_runtime.sh
+++ b/scripts/run_benches_for_runtime.sh
@@ -50,9 +50,7 @@ pallets=(
 	pallet-technical-committee-collective
 	# `pallet-did-lookup` instances
 	pallet-did-lookup
-	pallet-unique-linking
 	# `pallet-web3-names` instances
-	pallet-dot-names
 	pallet-web3-names
 )
 


### PR DESCRIPTION
Fixes the benchmark scripts. The unique-linking and dot-names pallet do not exist anymore. 