### PR TITLE
fix: make sure the reset_team trait actually sets the owner

### DIFF
--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -379,11 +379,13 @@ mod benchmarks {
 			freezer: freezer.clone(),
 		};
 
+		let pool_id_for_call = pool_id.clone();
+
 		let max_currencies = T::MaxCurrenciesPerPool::get();
 		#[extrinsic_call]
 		_(
 			origin as T::RuntimeOrigin,
-			pool_id.clone(),
+			pool_id_for_call,
 			fungibles_team,
 			max_currencies,
 		);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -20,6 +20,7 @@ use frame_system::RawOrigin;
 
 use crate::{
 	mock::{runtime::*, *},
+	traits::ResetTeam,
 	types::{PoolManagingTeam, PoolStatus},
 	AccountIdOf, Error as BondingPalletErrors,
 };
@@ -56,6 +57,57 @@ fn resets_team() {
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
+		})
+}
+
+#[test]
+fn resets_owner_if_changed() {
+	let pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+		None,
+	);
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
+			Assets::reset_team(
+				DEFAULT_BONDED_CURRENCY_ID,
+				ACCOUNT_00,
+				pool_id.clone(),
+				pool_id.clone(),
+				pool_id.clone(),
+			)
+			.expect("Failed to use reset_team trait");
+
+			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
+			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
+			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
+
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::reset_team(
+				manager_origin,
+				pool_id.clone(),
+				PoolManagingTeam {
+					admin: pool_id.clone(),
+					freezer: pool_id.clone(),
+				},
+				0
+			));
+
+			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
+			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
 		})

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -99,13 +99,11 @@ where
 		freezer: AccountIdOf<T>,
 	) -> DispatchResult {
 		let current_owner = AssetsPallet::<T, I>::owner(id.clone()).ok_or(DispatchError::Unavailable)?;
-		if current_owner != owner {
-			AssetsPallet::<T, I>::transfer_ownership(
-				RawOrigin::Signed(current_owner).into(),
-				id.clone().into(),
-				owner.clone().into(),
-			)?;
-		}
+		AssetsPallet::<T, I>::transfer_ownership(
+			RawOrigin::Signed(current_owner).into(),
+			id.clone().into(),
+			owner.clone().into(),
+		)?;
 		AssetsPallet::<T, I>::set_team(
 			RawOrigin::Signed(owner).into(),
 			id.into(),

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -87,14 +87,24 @@ where
 {
 	fn reset_team(
 		id: Self::AssetId,
-		_owner: AccountIdOf<T>,
+		owner: AccountIdOf<T>,
 		admin: AccountIdOf<T>,
 		issuer: AccountIdOf<T>,
 		freezer: AccountIdOf<T>,
 	) -> DispatchResult {
-		let owner = AssetsPallet::<T, I>::owner(id.clone()).ok_or(DispatchError::Unavailable)?;
-		let origin = RawOrigin::Signed(owner);
-		AssetsPallet::<T, I>::set_team(origin.into(), id.into(), issuer.into(), admin.into(), freezer.into())
+		let current_owner = AssetsPallet::<T, I>::owner(id.clone()).ok_or(DispatchError::Unavailable)?;
+		AssetsPallet::<T, I>::transfer_ownership(
+			RawOrigin::Signed(current_owner).into(),
+			id.clone().into(),
+			owner.clone().into(),
+		)?;
+		AssetsPallet::<T, I>::set_team(
+			RawOrigin::Signed(owner).into(),
+			id.into(),
+			issuer.into(),
+			admin.into(),
+			freezer.into(),
+		)
 	}
 }
 

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -93,11 +93,13 @@ where
 		freezer: AccountIdOf<T>,
 	) -> DispatchResult {
 		let current_owner = AssetsPallet::<T, I>::owner(id.clone()).ok_or(DispatchError::Unavailable)?;
-		AssetsPallet::<T, I>::transfer_ownership(
-			RawOrigin::Signed(current_owner).into(),
-			id.clone().into(),
-			owner.clone().into(),
-		)?;
+		if current_owner != owner {
+			AssetsPallet::<T, I>::transfer_ownership(
+				RawOrigin::Signed(current_owner).into(),
+				id.clone().into(),
+				owner.clone().into(),
+			)?;
+		}
 		AssetsPallet::<T, I>::set_team(
 			RawOrigin::Signed(owner).into(),
 			id.into(),

--- a/pallets/pallet-bonded-coins/src/traits.rs
+++ b/pallets/pallet-bonded-coins/src/traits.rs
@@ -60,8 +60,10 @@ where
 	}
 }
 
-/// Copy from the Polkadot SDK. once we are at version 1.13.0, we can remove
-/// this.
+/// Copy of a trait from a later version of the Polkadot SDK
+/// (frame_support::traits::tokens::fungibles::roles::ResetTeam). Once we
+/// upgraded to Polkadot SDK version 1.13.0, this can be retired in favor of the
+/// original trait.
 pub trait ResetTeam<AccountId>: Inspect<AccountId> {
 	/// Reset the team for the asset with the given `id`.
 	///
@@ -80,6 +82,10 @@ pub trait ResetTeam<AccountId>: Inspect<AccountId> {
 	) -> DispatchResult;
 }
 
+/// Implementation of the back-ported ResetTeam trait for the assets pallet,
+/// relying on its `transfer_ownership` and `set_team` calls. Later versions of
+/// the assets pallet implement the original trait, so this is a stop-gap
+/// solution until we upgraded to at least Polkadot SDK version 1.13.0.
 impl<T, I: 'static> ResetTeam<AccountIdOf<T>> for AssetsPallet<T, I>
 where
 	T: AssetConfig<I>,


### PR DESCRIPTION
### Fixes https://github.com/KILTprotocol/ticket/issues/3802

Changes the reset_team trait to actually set the owner passed to the function.

The trait implementation is a back-port of a trait implemented in latest versions of pallet-assets (https://docs.rs/pallet-assets/41.0.0/pallet_assets/pallet/struct.Pallet.html#impl-ResetTeam%3C%3CT+as+Config%3E::AccountId%3E-for-Pallet%3CT,+I%3E). Changing ownership of an asset is part of this trait but was not implemented here as not needed.
Nevertheless, we're adding this now to avoid mismatched expectations.

### TBD

- [x] Update benchmarking to cover the case where the current owner != the desired owner.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
