### PR TITLE
fix: increase MaxConsumers to allow accounts to hold more than 15 different bonded coins

### DIFF
--- a/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
+++ b/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
@@ -251,7 +251,7 @@ mod dip_did_proof_with_verified_relay_state_root {
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
+++ b/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
@@ -71,7 +71,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -261,7 +261,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/ctype/src/mock.rs
+++ b/pallets/ctype/src/mock.rs
@@ -100,7 +100,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/delegation/src/mock.rs
+++ b/pallets/delegation/src/mock.rs
@@ -247,7 +247,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -105,7 +105,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-asset-switch/src/mock.rs
+++ b/pallets/pallet-asset-switch/src/mock.rs
@@ -66,7 +66,7 @@ impl frame_system::Config for MockRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -226,7 +226,7 @@ pub mod runtime {
 		type Hash = Hash;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/pallets/pallet-configuration/src/mock.rs
+++ b/pallets/pallet-configuration/src/mock.rs
@@ -79,7 +79,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/pallet-deposit-storage/src/deposit/mock.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/mock.rs
@@ -73,7 +73,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
@@ -75,7 +75,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/mock.rs
+++ b/pallets/pallet-deposit-storage/src/mock.rs
@@ -60,7 +60,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -80,7 +80,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-dip-consumer/src/mock.rs
+++ b/pallets/pallet-dip-consumer/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-dip-provider/src/mock.rs
+++ b/pallets/pallet-dip-provider/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-inflation/src/mock.rs
+++ b/pallets/pallet-inflation/src/mock.rs
@@ -82,7 +82,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-migration/src/mock.rs
+++ b/pallets/pallet-migration/src/mock.rs
@@ -114,7 +114,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-relay-store/src/mock.rs
+++ b/pallets/pallet-relay-store/src/mock.rs
@@ -53,7 +53,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-web3-names/src/mock.rs
+++ b/pallets/pallet-web3-names/src/mock.rs
@@ -114,7 +114,7 @@ pub(crate) mod runtime {
 		type SystemWeightInfo = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 		type RuntimeTask = RuntimeTask;
 	}
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -92,7 +92,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 1;

--- a/pallets/public-credentials/src/mock.rs
+++ b/pallets/public-credentials/src/mock.rs
@@ -302,7 +302,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = ConstU16<38>;
 		type OnSetCode = ();
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtimes/common/src/dip/deposit/mock.rs
+++ b/runtimes/common/src/dip/deposit/mock.rs
@@ -52,7 +52,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -74,7 +74,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/fees.rs
+++ b/runtimes/common/src/fees.rs
@@ -219,7 +219,7 @@ mod tests {
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -198,7 +198,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	/// The set code logic, just the default since we're not a parachain.
 	type OnSetCode = ();
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 }
 
 /// Maximum number of nominators per validator.

--- a/runtimes/peregrine/src/system/mod.rs
+++ b/runtimes/peregrine/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/runtimes/spiritnet/src/system/mod.rs
+++ b/runtimes/spiritnet/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3798

Increases consumers limits to 100 for peregrine, spiritnet, mocks & tests.
Configs for dip-templates are left as-is.

It's hard for me to tell if this is going to have an impact on benchmarking / transaction weights though, how can we check this?

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
