### PR TITLE
refactor: batch updating of asset team

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -449,18 +449,17 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Changes the managing team of a bonded currency which is issued by
-		/// this pool. The new team will be set to the provided team. The
-		/// currency index is used to select the currency that the team will
-		/// manage. The origin account must be a manager of the pool.
+		/// Changes the managing team of all bonded currencies issued by this
+		/// pool, setting it to the provided `team`. The origin account must be
+		/// a manager of the pool.
 		///
 		/// # Parameters
 		/// - `origin`: The origin of the call, requiring the caller to be a
 		///   manager of the pool.
 		/// - `pool_id`: The identifier of the pool.
 		/// - `team`: The new managing team.
-		/// - `currency_idx`: The index of the currency in the bonded currencies
-		///   vector.
+		/// - `currency_count`: The number of bonded currencies vector linked to
+		///   the pool. Required for weight estimations.
 		///
 		/// # Returns
 		/// - `DispatchResult`: The result of the dispatch.
@@ -469,8 +468,8 @@ pub mod pallet {
 		/// - `Error::<T>::PoolUnknown`: If the pool does not exist.
 		/// - `Error::<T>::NoPermission`: If the caller is not a manager of the
 		///   pool.
-		/// - `Error::<T>::IndexOutOfBounds`: If the currency index is out of
-		///   bounds.
+		/// - `Error::<T>::CurrencyCount`: If the actual number of currencies in
+		///   the pool is larger than `currency_count`.
 		/// - Other errors depending on the types in the config.
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::reset_team())]

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -51,13 +51,57 @@ fn resets_team() {
 					admin: ACCOUNT_00,
 					freezer: ACCOUNT_01,
 				},
-				0
+				1
 			));
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
+		})
+}
+
+#[test]
+fn resets_team_for_all() {
+	let currencies = vec![DEFAULT_BONDED_CURRENCY_ID, DEFAULT_BONDED_CURRENCY_ID + 1];
+
+	let pool_details = generate_pool_details(
+		currencies.clone(),
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+		None,
+	);
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&currencies);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::reset_team(
+				manager_origin,
+				pool_id.clone(),
+				PoolManagingTeam {
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				},
+				2
+			));
+
+			assert_eq!(Assets::admin(currencies[0]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[0]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[0]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[0]), Some(pool_id.clone()));
+
+			assert_eq!(Assets::admin(currencies[1]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[1]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[1]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[1]), Some(pool_id));
 		})
 }
 
@@ -89,7 +133,7 @@ fn does_not_change_team_when_not_live() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::PoolNotLive
 			);
@@ -130,7 +174,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -143,7 +187,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -153,7 +197,7 @@ fn only_manager_can_change_team() {
 }
 
 #[test]
-fn handles_currency_idx_out_of_bounds() {
+fn handles_currency_number_incorrect() {
 	let pool_details = generate_pool_details(
 		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
@@ -180,9 +224,9 @@ fn handles_currency_idx_out_of_bounds() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					2
+					0
 				),
-				BondingPalletErrors::<Test>::IndexOutOfBounds
+				BondingPalletErrors::<Test>::CurrencyCount
 			);
 		})
 }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3801

Changes the `reset_team` extrinsic to perform batch updates in order to avoid that asset management teams differ between assets of one pool.

Recommended by auditors and desired by our team - see linked ticket.

### TBD

- [x] Update benchmarks to account for different numbers of currencies on a pool.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
