### PR TITLE
feat: disallow re-using token names and symbols within a pool

### DIFF
--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -233,11 +233,11 @@ mod benchmarks {
 
 	fn generate_token_metadata<T: Config>(c: u32) -> BoundedVec<TokenMetaOf<T>, T::MaxCurrenciesPerPool> {
 		let mut token_meta = Vec::new();
-		for _ in 1..=c {
+		for i in 1..=c {
 			token_meta.push(TokenMetaOf::<T> {
 				min_balance: 1u128.saturated_into(),
-				name: BoundedVec::try_from(b"BTC".to_vec()).expect("Failed to create BoundedVec"),
-				symbol: BoundedVec::try_from(b"BTC".to_vec()).expect("Failed to create BoundedVec"),
+				name: BoundedVec::try_from(format!("Coin_{}", &i).into_bytes()).expect("Failed to create BoundedVec"),
+				symbol: BoundedVec::try_from(format!("BTC_{}", &i).into_bytes()).expect("Failed to create BoundedVec"),
 			})
 		}
 		BoundedVec::try_from(token_meta).expect("creating bounded Vec should not fail")

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -17,6 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 use frame_benchmarking::v2::*;
 use frame_support::traits::fungibles::roles::Inspect as InspectRoles;
+use scale_info::prelude::format;
 use sp_core::U256;
 use sp_std::{
 	ops::{AddAssign, BitOrAssign, ShlAssign},

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -426,10 +426,7 @@ pub mod pallet {
 					// insert() returns true if the set did not contain the inserted value
 					let name_ok = name.is_empty() || names_seen.insert(name.clone());
 					let symbol_ok = symbol.is_empty() || symbols_seen.insert(symbol.clone());
-
-					if !name_ok || !symbol_ok {
-						return Err(Error::<T>::InvalidInput.into());
-					};
+					ensure!(name_ok && symbol_ok, Error::<T>::InvalidInput);
 
 					T::Fungibles::create(asset_id.clone(), pool_account.to_owned(), false, min_balance)?;
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -338,7 +338,8 @@ pub mod pallet {
 		/// - `curve`: The curve parameters for the pool.
 		/// - `collateral_id`: The ID of the collateral currency.
 		/// - `currencies`: A bounded vector of token metadata for the bonded
-		///   currencies.
+		///   currencies. Note that no two currencies may use the same name or
+		///   symbol.
 		/// - `denomination`: The denomination for the bonded currencies.
 		/// - `transferable`: A boolean indicating if the bonded currencies are
 		///   transferable.
@@ -347,8 +348,10 @@ pub mod pallet {
 		/// - `DispatchResult`: The result of the dispatch.
 		///
 		/// # Errors
-		/// - `Error::<T>::InvalidInput`: If the denomination is greater than
-		///   the maximum allowed or if the curve input is invalid.
+		/// - `Error::<T>::InvalidInput`: If either
+		///   - the denomination is greater than the maximum allowed
+		///   - the curve input is invalid
+		///   - two currencies use the same name or symbol
 		/// - `Error::<T>::Internal`: If the conversion to `BoundedVec` fails.
 		/// - Other errors depending on the types in the config.
 		#[pallet::call_index(0)]
@@ -408,6 +411,7 @@ pub mod pallet {
 			// currency to it. This should also verify that the currency actually exists.
 			T::Collaterals::touch(collateral_id.clone(), pool_account, &who)?;
 
+			// Enforce unique names and symbols by recording seen values in a set
 			let mut names_seen = BTreeSet::<StringInputOf<T>>::new();
 			let mut symbols_seen = BTreeSet::<StringInputOf<T>>::new();
 
@@ -419,6 +423,7 @@ pub mod pallet {
 						symbol,
 					} = token_metadata;
 
+					// insert() returns true if the set did not contain the inserted value
 					let name_ok = name.is_empty() || names_seen.insert(name.clone());
 					let symbol_ok = symbol.is_empty() || symbols_seen.insert(symbol.clone());
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -70,7 +70,6 @@ pub mod pallet {
 		Hashable, Parameter,
 	};
 	use frame_system::pallet_prelude::*;
-	use parity_scale_codec::alloc::collections::HashSet;
 	use sp_arithmetic::ArithmeticError;
 	use sp_core::U256;
 	use sp_runtime::{
@@ -80,6 +79,7 @@ pub mod pallet {
 		BoundedVec, DispatchError, TokenError,
 	};
 	use sp_std::{
+		collections::btree_set::BTreeSet,
 		iter::Iterator,
 		ops::{AddAssign, BitOrAssign, ShlAssign},
 		prelude::*,
@@ -408,8 +408,8 @@ pub mod pallet {
 			// currency to it. This should also verify that the currency actually exists.
 			T::Collaterals::touch(collateral_id.clone(), pool_account, &who)?;
 
-			let mut names_seen = HashSet::<StringInputOf<T>>::with_capacity(currencies.len());
-			let mut symbols_seen = HashSet::<StringInputOf<T>>::with_capacity(currencies.len());
+			let mut names_seen = BTreeSet::<StringInputOf<T>>::new();
+			let mut symbols_seen = BTreeSet::<StringInputOf<T>>::new();
 
 			currencies.into_iter().zip(currency_ids.iter()).try_for_each(
 				|(token_metadata, asset_id)| -> DispatchResult {


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3803

Disallows re-using the same token symbol or name. Empty names and symbols are always allowed.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
