### PR TITLE
fix: do not allow lock states that are equivalent to unlocked

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -577,13 +577,7 @@ pub mod pallet {
 		pub fn set_lock(origin: OriginFor<T>, pool_id: T::PoolId, lock: Locks) -> DispatchResult {
 			let who = T::DefaultOrigin::ensure_origin(origin)?;
 
-			ensure!(
-				lock != (Locks {
-					allow_mint: true,
-					allow_burn: true,
-				}),
-				Error::<T>::InvalidInput
-			);
+			ensure!(lock.any_lock_set(), Error::<T>::InvalidInput);
 
 			Pools::<T>::try_mutate(&pool_id, |pool| -> DispatchResult {
 				let entry = pool.as_mut().ok_or(Error::<T>::PoolUnknown)?;

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -25,6 +25,12 @@ pub struct Locks {
 	pub allow_burn: bool,
 }
 
+impl Locks {
+	pub fn any_lock_set(&self) -> bool {
+		!(self.allow_mint && self.allow_burn)
+	}
+}
+
 /// Status of a pool.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
 pub enum PoolStatus<LockType> {

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -26,7 +26,7 @@ pub struct Locks {
 }
 
 impl Locks {
-	pub fn any_lock_set(&self) -> bool {
+	pub const fn any_lock_set(&self) -> bool {
 		!(self.allow_mint && self.allow_burn)
 	}
 }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3806

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
