### PR TITLE
feat: emit additional event on reset_team

### DIFF
--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -282,7 +282,8 @@ pub mod pallet {
 		/// The asset managing team of a pool has been reset.
 		TeamChanged {
 			id: T::PoolId,
-			team: PoolManagingTeam<T::AccountId>,
+			admin: T::AccountId,
+			freezer: T::AccountId,
 		},
 	}
 
@@ -508,7 +509,7 @@ pub mod pallet {
 
 			let pool_id_account = pool_id.clone().into();
 
-			let PoolManagingTeam { ref freezer, ref admin } = team;
+			let PoolManagingTeam { freezer, admin } = team;
 
 			pool_details.bonded_currencies.into_iter().try_for_each(|asset_id| {
 				T::Fungibles::reset_team(
@@ -520,7 +521,11 @@ pub mod pallet {
 				)
 			})?;
 
-			Self::deposit_event(Event::TeamChanged { id: pool_id, team });
+			Self::deposit_event(Event::TeamChanged {
+				id: pool_id,
+				admin,
+				freezer,
+			});
 
 			Ok(())
 		}

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -280,7 +280,7 @@ pub mod pallet {
 			manager: Option<T::AccountId>,
 		},
 		/// The asset managing team of a pool has been reset.
-		TeamReset {
+		TeamChanged {
 			id: T::PoolId,
 			team: PoolManagingTeam<T::AccountId>,
 		},
@@ -520,7 +520,7 @@ pub mod pallet {
 				)
 			})?;
 
-			Self::deposit_event(Event::TeamReset { id: pool_id, team });
+			Self::deposit_event(Event::TeamChanged { id: pool_id, team });
 
 			Ok(())
 		}

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -22,7 +22,7 @@ use crate::{
 	mock::{runtime::*, *},
 	traits::ResetTeam,
 	types::{PoolManagingTeam, PoolStatus},
-	AccountIdOf, Error as BondingPalletErrors,
+	AccountIdOf, Error as BondingPalletErrors, Event,
 };
 
 #[test]
@@ -54,6 +54,18 @@ fn resets_team() {
 				},
 				1
 			));
+
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamReset {
+					id: pool_id.clone(),
+					team: PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_01,
+					},
+				}
+				.into(),
+			);
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
@@ -106,6 +118,18 @@ fn resets_owner_if_changed() {
 				1
 			));
 
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamReset {
+					id: pool_id.clone(),
+					team: PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_01,
+					},
+				}
+				.into(),
+			);
+
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
@@ -144,6 +168,18 @@ fn resets_team_for_all() {
 				},
 				2
 			));
+
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamReset {
+					id: pool_id.clone(),
+					team: PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_01,
+					},
+				}
+				.into(),
+			);
 
 			assert_eq!(Assets::admin(currencies[0]), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(currencies[0]), Some(ACCOUNT_01));

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -57,7 +57,7 @@ fn resets_team() {
 
 			// Ensure the event is emitted
 			System::assert_has_event(
-				Event::TeamReset {
+				Event::TeamChanged {
 					id: pool_id.clone(),
 					team: PoolManagingTeam {
 						admin: ACCOUNT_00,
@@ -120,7 +120,7 @@ fn resets_owner_if_changed() {
 
 			// Ensure the event is emitted
 			System::assert_has_event(
-				Event::TeamReset {
+				Event::TeamChanged {
 					id: pool_id.clone(),
 					team: PoolManagingTeam {
 						admin: ACCOUNT_00,
@@ -171,7 +171,7 @@ fn resets_team_for_all() {
 
 			// Ensure the event is emitted
 			System::assert_has_event(
-				Event::TeamReset {
+				Event::TeamChanged {
 					id: pool_id.clone(),
 					team: PoolManagingTeam {
 						admin: ACCOUNT_00,

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -123,8 +123,8 @@ fn resets_owner_if_changed() {
 				Event::TeamChanged {
 					id: pool_id.clone(),
 					team: PoolManagingTeam {
-						admin: ACCOUNT_00,
-						freezer: ACCOUNT_01,
+						admin: pool_id.clone(),
+						freezer: pool_id.clone(),
 					},
 				}
 				.into(),

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -59,10 +59,8 @@ fn resets_team() {
 			System::assert_has_event(
 				Event::TeamChanged {
 					id: pool_id.clone(),
-					team: PoolManagingTeam {
-						admin: ACCOUNT_00,
-						freezer: ACCOUNT_01,
-					},
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
 				}
 				.into(),
 			);
@@ -122,10 +120,8 @@ fn resets_owner_if_changed() {
 			System::assert_has_event(
 				Event::TeamChanged {
 					id: pool_id.clone(),
-					team: PoolManagingTeam {
-						admin: pool_id.clone(),
-						freezer: pool_id.clone(),
-					},
+					admin: pool_id.clone(),
+					freezer: pool_id.clone(),
 				}
 				.into(),
 			);
@@ -173,10 +169,8 @@ fn resets_team_for_all() {
 			System::assert_has_event(
 				Event::TeamChanged {
 					id: pool_id.clone(),
-					team: PoolManagingTeam {
-						admin: ACCOUNT_00,
-						freezer: ACCOUNT_01,
-					},
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
 				}
 				.into(),
 			);


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3813

Following recommendations by OAK, this adds another event to be emitted on calling `reset_team`. This is emitted in addition to the events emitted by the assets pallet itself.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
