### PR TITLE
feat: flag to disallow asset management changes

### DIFF
--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -232,6 +232,7 @@ mod benchmarks {
 			denomination,
 			bonded_currencies: BoundedVec::truncate_from(bonded_coin_ids.clone()),
 			transferable: true,
+			enable_asset_management: true,
 			min_operation_balance: 1u128.saturated_into(),
 			deposit: Pallet::<T>::calculate_pool_deposit(bonded_coin_ids.len()),
 		};
@@ -274,6 +275,7 @@ mod benchmarks {
 			currencies,
 			10,
 			true,
+			true,
 			1,
 		);
 
@@ -312,6 +314,7 @@ mod benchmarks {
 			currencies,
 			10,
 			true,
+			true,
 			1,
 		);
 
@@ -348,6 +351,7 @@ mod benchmarks {
 			collateral_id,
 			currencies,
 			10,
+			true,
 			true,
 			1,
 		);

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -32,6 +32,7 @@ use crate::{
 		square_root::{SquareRootParameters, SquareRootParametersInput},
 		Curve, CurveInput,
 	},
+	types::CurrencySettings,
 	Call, CollateralAssetIdOf, CollateralBalanceOf, Config, CurveParameterTypeOf, FungiblesAssetIdOf,
 	FungiblesBalanceOf, Pallet,
 };
@@ -229,11 +230,13 @@ mod benchmarks {
 			owner,
 			state,
 			collateral,
-			denomination,
 			bonded_currencies: BoundedVec::truncate_from(bonded_coin_ids.clone()),
-			transferable: true,
-			enable_asset_management: true,
-			min_operation_balance: 1u128.saturated_into(),
+			currency_settings: CurrencySettings {
+				denomination,
+				transferable: true,
+				enable_asset_management: true,
+				min_operation_balance: 1u128.saturated_into(),
+			},
 			deposit: Pallet::<T>::calculate_pool_deposit(bonded_coin_ids.len()),
 		};
 		Pools::<T>::insert(&pool_id, pool_details);
@@ -273,10 +276,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			true,
-			1,
+			CurrencySettings {
+				denomination: 10,
+				enable_asset_management: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify
@@ -312,10 +317,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			true,
-			1,
+			CurrencySettings {
+				denomination: 10,
+				enable_asset_management: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify
@@ -350,10 +357,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			true,
-			1,
+			CurrencySettings {
+				denomination: 10,
+				enable_asset_management: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -32,7 +32,7 @@ use crate::{
 		square_root::{SquareRootParameters, SquareRootParametersInput},
 		Curve, CurveInput,
 	},
-	types::CurrencySettings,
+	types::BondedCurrenciesSettings,
 	Call, CollateralAssetIdOf, CollateralBalanceOf, Config, CurveParameterTypeOf, FungiblesAssetIdOf,
 	FungiblesBalanceOf, Pallet,
 };
@@ -231,10 +231,10 @@ mod benchmarks {
 			state,
 			collateral,
 			bonded_currencies: BoundedVec::truncate_from(bonded_coin_ids.clone()),
-			currency_settings: CurrencySettings {
+			currencies_settings: BondedCurrenciesSettings {
 				denomination,
 				transferable: true,
-				enable_asset_management: true,
+				allow_reset_team: true,
 				min_operation_balance: 1u128.saturated_into(),
 			},
 			deposit: Pallet::<T>::calculate_pool_deposit(bonded_coin_ids.len()),
@@ -276,9 +276,9 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			CurrencySettings {
+			BondedCurrenciesSettings {
 				denomination: 10,
-				enable_asset_management: true,
+				allow_reset_team: true,
 				transferable: true,
 				min_operation_balance: 1,
 			},
@@ -317,9 +317,9 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			CurrencySettings {
+			BondedCurrenciesSettings {
 				denomination: 10,
-				enable_asset_management: true,
+				allow_reset_team: true,
 				transferable: true,
 				min_operation_balance: 1,
 			},
@@ -357,9 +357,9 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			CurrencySettings {
+			BondedCurrenciesSettings {
 				denomination: 10,
-				enable_asset_management: true,
+				allow_reset_team: true,
 				transferable: true,
 				min_operation_balance: 1,
 			},

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -369,6 +369,7 @@ pub mod pallet {
 			currencies: BoundedVec<TokenMetaOf<T>, T::MaxCurrenciesPerPool>,
 			denomination: u8,
 			transferable: bool,
+			enable_asset_management: bool,
 			min_operation_balance: u128,
 		) -> DispatchResult {
 			let who = T::PoolCreateOrigin::ensure_origin(origin)?;
@@ -450,6 +451,7 @@ pub mod pallet {
 					collateral_id,
 					currency_ids,
 					transferable,
+					enable_asset_management,
 					denomination,
 					min_operation_balance,
 					deposit_amount,
@@ -498,7 +500,10 @@ pub mod pallet {
 			let number_of_currencies = Self::get_currencies_number(&pool_details);
 			ensure!(number_of_currencies <= currency_count, Error::<T>::CurrencyCount);
 
-			ensure!(pool_details.is_manager(&who), Error::<T>::NoPermission);
+			ensure!(
+				pool_details.enable_asset_management && pool_details.is_manager(&who),
+				Error::<T>::NoPermission
+			);
 			ensure!(pool_details.state.is_live(), Error::<T>::PoolNotLive);
 
 			let pool_id_account = pool_id.into();

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -36,7 +36,7 @@ mod types;
 #[cfg(feature = "runtime-benchmarks")]
 pub use benchmarking::BenchmarkHelper;
 
-pub use types::{PoolDetails, Round};
+pub use types::{BondedCurrenciesSettings, PoolDetails, Round};
 
 pub use default_weights::WeightInfo;
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -190,7 +190,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type BaseDeposit: Get<DepositBalanceOf<Self>>;
 
-		/// The origin for most permissionless and priviledged operations.
+		/// The origin for most permissionless and privileged operations.
 		type DefaultOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
 		/// The dedicated origin for creating new bonded currency pools
 		/// (typically permissionless).
@@ -340,9 +340,15 @@ pub mod pallet {
 		/// - `currencies`: A bounded vector of token metadata for the bonded
 		///   currencies. Note that no two currencies may use the same name or
 		///   symbol.
-		/// - `denomination`: The denomination for the bonded currencies.
-		/// - `transferable`: A boolean indicating if the bonded currencies are
-		///   transferable.
+		/// - `currencies_settings`: Options and settings shared by all bonded
+		///   currencies. These cannot be changed after the pool is created.
+		///   - `denomination`: The denomination for the bonded currencies.
+		///   - `transferable`: A boolean indicating if the bonded currencies
+		///     are transferable.
+		///   - `allow_reset_team`: Whether asset management team changes are
+		///     allowed for this pool.
+		///   - `min_operation_balance`: The minimum amount that can be
+		///     minted/burnt.
 		///
 		/// # Returns
 		/// - `DispatchResult`: The result of the dispatch.
@@ -485,8 +491,9 @@ pub mod pallet {
 		///
 		/// # Errors
 		/// - `Error::<T>::PoolUnknown`: If the pool does not exist.
-		/// - `Error::<T>::NoPermission`: If the caller is not a manager of the
-		///   pool.
+		/// - `Error::<T>::NoPermission`: If this pool does not allow changing
+		///   the asset management team, or if the caller is not a manager of
+		///   the pool.
 		/// - `Error::<T>::CurrencyCount`: If the actual number of currencies in
 		///   the pool is larger than `currency_count`.
 		/// - Other errors depending on the types in the config.

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -97,6 +97,9 @@ pub mod pallet {
 		WeightInfo,
 	};
 
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	pub(crate) type AccountIdLookupOf<T> =
 		<<T as frame_system::Config>::Lookup as sp_runtime::traits::StaticLookup>::Source;
 
@@ -228,6 +231,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -69,7 +69,7 @@ pub mod runtime {
 	use crate::{
 		self as pallet_bonded_coins,
 		traits::NextAssetIds,
-		types::{CurrencySettings, Locks, PoolStatus},
+		types::{BondedCurrenciesSettings, Locks, PoolStatus},
 		AccountIdOf, Config, DepositBalanceOf, FungiblesAssetIdOf, FungiblesBalanceOf, PoolDetailsOf,
 	};
 
@@ -121,8 +121,8 @@ pub mod runtime {
 			bonded_currencies,
 			state,
 			collateral,
-			currency_settings: CurrencySettings {
-				enable_asset_management: true,
+			currencies_settings: BondedCurrenciesSettings {
+				allow_reset_team: true,
 				transferable,
 				min_operation_balance,
 				denomination: DEFAULT_BONDED_DENOMINATION,
@@ -449,7 +449,7 @@ pub mod runtime {
 						pool_details
 							.bonded_currencies
 							.iter()
-							.map(|id| (*id, vec![], vec![], pool_details.currency_settings.denomination))
+							.map(|id| (*id, vec![], vec![], pool_details.currencies_settings.denomination))
 							.collect::<Vec<(u32, Vec<u8>, Vec<u8>, u8)>>()
 					})
 					.chain(

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -119,6 +119,7 @@ pub mod runtime {
 			curve,
 			manager,
 			transferable,
+			enable_asset_management: true,
 			bonded_currencies,
 			state,
 			collateral,

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -69,7 +69,7 @@ pub mod runtime {
 	use crate::{
 		self as pallet_bonded_coins,
 		traits::NextAssetIds,
-		types::{Locks, PoolStatus},
+		types::{CurrencySettings, Locks, PoolStatus},
 		AccountIdOf, Config, DepositBalanceOf, FungiblesAssetIdOf, FungiblesBalanceOf, PoolDetailsOf,
 	};
 
@@ -118,14 +118,16 @@ pub mod runtime {
 		PoolDetailsOf::<Test> {
 			curve,
 			manager,
-			transferable,
-			enable_asset_management: true,
 			bonded_currencies,
 			state,
 			collateral,
-			denomination: DEFAULT_BONDED_DENOMINATION,
+			currency_settings: CurrencySettings {
+				enable_asset_management: true,
+				transferable,
+				min_operation_balance,
+				denomination: DEFAULT_BONDED_DENOMINATION,
+			},
 			owner,
-			min_operation_balance,
 			deposit: BondingPallet::calculate_pool_deposit(currencies.len()),
 		}
 	}
@@ -447,7 +449,7 @@ pub mod runtime {
 						pool_details
 							.bonded_currencies
 							.iter()
-							.map(|id| (*id, vec![], vec![], pool_details.denomination))
+							.map(|id| (*id, vec![], vec![], pool_details.currency_settings.denomination))
 							.collect::<Vec<(u32, Vec<u8>, Vec<u8>, u8)>>()
 					})
 					.chain(

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -27,7 +27,7 @@ use sp_runtime::{assert_eq_error_rate, bounded_vec, traits::Scale, TokenError};
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{Locks, PoolStatus},
+	types::{CurrencySettings, Locks, PoolStatus},
 	AccountIdOf, Error, PoolDetailsOf,
 };
 
@@ -55,14 +55,16 @@ fn burn_first_coin() {
 			PoolDetailsOf::<Test> {
 				curve: get_linear_bonding_curve(),
 				manager: None,
-				transferable: true,
-				enable_asset_management: true,
 				bonded_currencies: bounded_vec![DEFAULT_BONDED_CURRENCY_ID],
 				state: PoolStatus::Active,
 				collateral: DEFAULT_COLLATERAL_CURRENCY_ID,
-				denomination: 0,
+				currency_settings: CurrencySettings {
+					transferable: true,
+					enable_asset_management: true,
+					denomination: 0,
+					min_operation_balance: 1,
+				},
 				owner: ACCOUNT_99,
-				min_operation_balance: 1,
 				deposit: BondingPallet::calculate_pool_deposit(1),
 			},
 		)])

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -27,7 +27,7 @@ use sp_runtime::{assert_eq_error_rate, bounded_vec, traits::Scale, TokenError};
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{CurrencySettings, Locks, PoolStatus},
+	types::{BondedCurrenciesSettings, Locks, PoolStatus},
 	AccountIdOf, Error, PoolDetailsOf,
 };
 
@@ -58,9 +58,9 @@ fn burn_first_coin() {
 				bonded_currencies: bounded_vec![DEFAULT_BONDED_CURRENCY_ID],
 				state: PoolStatus::Active,
 				collateral: DEFAULT_COLLATERAL_CURRENCY_ID,
-				currency_settings: CurrencySettings {
+				currencies_settings: BondedCurrenciesSettings {
 					transferable: true,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					denomination: 0,
 					min_operation_balance: 1,
 				},

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -56,6 +56,7 @@ fn burn_first_coin() {
 				curve: get_linear_bonding_curve(),
 				manager: None,
 				transferable: true,
+				enable_asset_management: true,
 				bonded_currencies: bounded_vec![DEFAULT_BONDED_CURRENCY_ID],
 				state: PoolStatus::Active,
 				collateral: DEFAULT_COLLATERAL_CURRENCY_ID,

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -28,7 +28,7 @@ use sp_std::ops::Sub;
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{Locks, PoolStatus},
+	types::{CurrencySettings, Locks, PoolStatus},
 	AccountIdOf, Error, Event as BondingPalletEvents, Pools, TokenMetaOf,
 };
 
@@ -55,10 +55,12 @@ fn single_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				true,
-				1,
+				CurrencySettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					enable_asset_management: true,
+					transferable: true,
+					min_operation_balance: 1
+				},
 			));
 
 			let pool_id: AccountIdOf<Test> = calculate_pool_id(&[new_asset_id]);
@@ -67,7 +69,7 @@ fn single_currency() {
 
 			assert!(details.is_owner(&ACCOUNT_00));
 			assert!(details.is_manager(&ACCOUNT_00));
-			assert!(details.transferable);
+			assert!(details.currency_settings.transferable);
 			assert_eq!(
 				details.state,
 				PoolStatus::Locked(Locks {
@@ -75,7 +77,7 @@ fn single_currency() {
 					allow_burn: false,
 				})
 			);
-			assert_eq!(details.denomination, DEFAULT_BONDED_DENOMINATION);
+			assert_eq!(details.currency_settings.denomination, DEFAULT_BONDED_DENOMINATION);
 			assert_eq!(details.collateral, DEFAULT_COLLATERAL_CURRENCY_ID);
 			assert_eq!(details.bonded_currencies, vec![new_asset_id]);
 
@@ -138,10 +140,12 @@ fn multi_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				true,
-				1
+				CurrencySettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					enable_asset_management: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 3);
@@ -190,10 +194,12 @@ fn multi_currency_with_empty_metadata() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				true,
-				1
+				CurrencySettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					enable_asset_management: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 3);
@@ -241,10 +247,12 @@ fn can_create_identical_pools() {
 				curve.clone(),
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token.clone()],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				true,
-				1
+				CurrencySettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					enable_asset_management: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_ok!(BondingPallet::create_pool(
@@ -252,10 +260,12 @@ fn can_create_identical_pools() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				true,
-				1
+				CurrencySettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					enable_asset_management: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 2);
@@ -307,10 +317,12 @@ fn cannot_reuse_names() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					true,
-					1
+					CurrencySettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						enable_asset_management: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				Error::<Test>::InvalidInput
 			);
@@ -351,10 +363,12 @@ fn cannot_reuse_symbols() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					true,
-					1
+					CurrencySettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						enable_asset_management: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				Error::<Test>::InvalidInput
 			);
@@ -381,10 +395,12 @@ fn fails_if_collateral_not_exists() {
 					curve,
 					100,
 					bounded_vec![bonded_token],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					true,
-					1
+					CurrencySettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						enable_asset_management: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -414,10 +430,12 @@ fn cannot_create_circular_pool() {
 					// try specifying the id of the currency to be created as collateral
 					next_asset_id,
 					bounded_vec![bonded_token],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					true,
-					1
+					CurrencySettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						enable_asset_management: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -448,10 +466,12 @@ fn handles_asset_id_overflow() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bounded_vec![bonded_token; 2],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					true,
-					1
+					CurrencySettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						enable_asset_management: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				ArithmeticError::Overflow
 			);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -28,7 +28,7 @@ use sp_std::ops::Sub;
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{CurrencySettings, Locks, PoolStatus},
+	types::{BondedCurrenciesSettings, Locks, PoolStatus},
 	AccountIdOf, Error, Event as BondingPalletEvents, Pools, TokenMetaOf,
 };
 
@@ -55,9 +55,9 @@ fn single_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				CurrencySettings {
+				BondedCurrenciesSettings {
 					denomination: DEFAULT_BONDED_DENOMINATION,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					transferable: true,
 					min_operation_balance: 1
 				},
@@ -69,7 +69,7 @@ fn single_currency() {
 
 			assert!(details.is_owner(&ACCOUNT_00));
 			assert!(details.is_manager(&ACCOUNT_00));
-			assert!(details.currency_settings.transferable);
+			assert!(details.currencies_settings.transferable);
 			assert_eq!(
 				details.state,
 				PoolStatus::Locked(Locks {
@@ -77,7 +77,7 @@ fn single_currency() {
 					allow_burn: false,
 				})
 			);
-			assert_eq!(details.currency_settings.denomination, DEFAULT_BONDED_DENOMINATION);
+			assert_eq!(details.currencies_settings.denomination, DEFAULT_BONDED_DENOMINATION);
 			assert_eq!(details.collateral, DEFAULT_COLLATERAL_CURRENCY_ID);
 			assert_eq!(details.bonded_currencies, vec![new_asset_id]);
 
@@ -140,9 +140,9 @@ fn multi_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				CurrencySettings {
+				BondedCurrenciesSettings {
 					denomination: DEFAULT_BONDED_DENOMINATION,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					transferable: true,
 					min_operation_balance: 1
 				}
@@ -194,9 +194,9 @@ fn multi_currency_with_empty_metadata() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				CurrencySettings {
+				BondedCurrenciesSettings {
 					denomination: DEFAULT_BONDED_DENOMINATION,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					transferable: true,
 					min_operation_balance: 1
 				}
@@ -247,9 +247,9 @@ fn can_create_identical_pools() {
 				curve.clone(),
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token.clone()],
-				CurrencySettings {
+				BondedCurrenciesSettings {
 					denomination: DEFAULT_BONDED_DENOMINATION,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					transferable: true,
 					min_operation_balance: 1
 				}
@@ -260,9 +260,9 @@ fn can_create_identical_pools() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				CurrencySettings {
+				BondedCurrenciesSettings {
 					denomination: DEFAULT_BONDED_DENOMINATION,
-					enable_asset_management: true,
+					allow_reset_team: true,
 					transferable: true,
 					min_operation_balance: 1
 				}
@@ -317,9 +317,9 @@ fn cannot_reuse_names() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					CurrencySettings {
+					BondedCurrenciesSettings {
 						denomination: DEFAULT_BONDED_DENOMINATION,
-						enable_asset_management: true,
+						allow_reset_team: true,
 						transferable: true,
 						min_operation_balance: 1
 					}
@@ -363,9 +363,9 @@ fn cannot_reuse_symbols() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					CurrencySettings {
+					BondedCurrenciesSettings {
 						denomination: DEFAULT_BONDED_DENOMINATION,
-						enable_asset_management: true,
+						allow_reset_team: true,
 						transferable: true,
 						min_operation_balance: 1
 					}
@@ -395,9 +395,9 @@ fn fails_if_collateral_not_exists() {
 					curve,
 					100,
 					bounded_vec![bonded_token],
-					CurrencySettings {
+					BondedCurrenciesSettings {
 						denomination: DEFAULT_BONDED_DENOMINATION,
-						enable_asset_management: true,
+						allow_reset_team: true,
 						transferable: true,
 						min_operation_balance: 1
 					}
@@ -430,9 +430,9 @@ fn cannot_create_circular_pool() {
 					// try specifying the id of the currency to be created as collateral
 					next_asset_id,
 					bounded_vec![bonded_token],
-					CurrencySettings {
+					BondedCurrenciesSettings {
 						denomination: DEFAULT_BONDED_DENOMINATION,
-						enable_asset_management: true,
+						allow_reset_team: true,
 						transferable: true,
 						min_operation_balance: 1
 					}
@@ -466,9 +466,9 @@ fn handles_asset_id_overflow() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bounded_vec![bonded_token; 2],
-					CurrencySettings {
+					BondedCurrenciesSettings {
 						denomination: DEFAULT_BONDED_DENOMINATION,
-						enable_asset_management: true,
+						allow_reset_team: true,
 						transferable: true,
 						min_operation_balance: 1
 					}

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -57,6 +57,7 @@ fn single_currency() {
 				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
 				true,
+				true,
 				1,
 			));
 
@@ -139,6 +140,7 @@ fn multi_currency() {
 				bonded_tokens,
 				DEFAULT_BONDED_DENOMINATION,
 				true,
+				true,
 				1
 			));
 
@@ -190,6 +192,7 @@ fn multi_currency_with_empty_metadata() {
 				bonded_tokens,
 				DEFAULT_BONDED_DENOMINATION,
 				true,
+				true,
 				1
 			));
 
@@ -240,6 +243,7 @@ fn can_create_identical_pools() {
 				bounded_vec![bonded_token.clone()],
 				DEFAULT_BONDED_DENOMINATION,
 				true,
+				true,
 				1
 			));
 
@@ -249,6 +253,7 @@ fn can_create_identical_pools() {
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
 				DEFAULT_BONDED_DENOMINATION,
+				true,
 				true,
 				1
 			));
@@ -304,6 +309,7 @@ fn cannot_reuse_names() {
 					bonded_tokens,
 					DEFAULT_BONDED_DENOMINATION,
 					true,
+					true,
 					1
 				),
 				Error::<Test>::InvalidInput
@@ -347,6 +353,7 @@ fn cannot_reuse_symbols() {
 					bonded_tokens,
 					DEFAULT_BONDED_DENOMINATION,
 					true,
+					true,
 					1
 				),
 				Error::<Test>::InvalidInput
@@ -375,6 +382,7 @@ fn fails_if_collateral_not_exists() {
 					100,
 					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
+					true,
 					true,
 					1
 				),
@@ -408,6 +416,7 @@ fn cannot_create_circular_pool() {
 					bounded_vec![bonded_token],
 					DEFAULT_BONDED_DENOMINATION,
 					true,
+					true,
 					1
 				),
 				AssetsPalletErrors::<Test>::Unknown
@@ -440,6 +449,7 @@ fn handles_asset_id_overflow() {
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bounded_vec![bonded_token; 2],
 					DEFAULT_BONDED_DENOMINATION,
+					true,
 					true,
 					1
 				),

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -262,7 +262,7 @@ fn fails_if_asset_team_flag_not_set() {
 		Some(ACCOUNT_00),
 		None,
 	);
-	pool_details.enable_asset_management = false;
+	pool_details.currency_settings.enable_asset_management = false;
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -249,6 +249,46 @@ fn only_manager_can_change_team() {
 }
 
 #[test]
+fn fails_if_asset_team_flag_not_set() {
+	let curve = get_linear_bonding_curve();
+
+	let mut pool_details = generate_pool_details(
+		vec![DEFAULT_BONDED_CURRENCY_ID],
+		curve,
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		Some(ACCOUNT_00),
+		None,
+	);
+	pool_details.enable_asset_management = false;
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_native_balances(vec![(ACCOUNT_00, ONE_HUNDRED_KILT)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_err!(
+				BondingPallet::reset_team(
+					manager_origin,
+					pool_id.clone(),
+					PoolManagingTeam {
+						admin: ACCOUNT_00,
+						freezer: ACCOUNT_00,
+					},
+					1
+				),
+				BondingPalletErrors::<Test>::NoPermission
+			);
+
+			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
+		})
+}
+
+#[test]
 fn handles_currency_number_incorrect() {
 	let pool_details = generate_pool_details(
 		vec![DEFAULT_BONDED_CURRENCY_ID],

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -262,7 +262,7 @@ fn fails_if_asset_team_flag_not_set() {
 		Some(ACCOUNT_00),
 		None,
 	);
-	pool_details.currency_settings.enable_asset_management = false;
+	pool_details.currencies_settings.allow_reset_team = false;
 	let pool_id: AccountIdOf<Test> = calculate_pool_id(&[DEFAULT_BONDED_CURRENCY_ID]);
 	ExtBuilder::default()
 		.with_pools(vec![(pool_id.clone(), pool_details)])

--- a/pallets/pallet-bonded-coins/src/try_state.rs
+++ b/pallets/pallet-bonded-coins/src/try_state.rs
@@ -18,7 +18,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 			owner,
 			bonded_currencies,
 			state,
-			denomination,
+			currency_settings,
 			..
 		} = pool_details;
 
@@ -61,7 +61,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 					// The Currency in the fungibles pallet should always match with the
 					// denomination stored in the pool.
 					let currency_denomination = T::Fungibles::decimals(currency_id.clone());
-					assert_eq!(currency_denomination, denomination);
+					assert_eq!(currency_denomination, currency_settings.denomination);
 
 					// if currency has on-zero supply -> collateral in pool account must be
 					// non-zero.

--- a/pallets/pallet-bonded-coins/src/try_state.rs
+++ b/pallets/pallet-bonded-coins/src/try_state.rs
@@ -18,7 +18,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 			owner,
 			bonded_currencies,
 			state,
-			currency_settings,
+			currencies_settings,
 			..
 		} = pool_details;
 
@@ -61,7 +61,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 					// The Currency in the fungibles pallet should always match with the
 					// denomination stored in the pool.
 					let currency_denomination = T::Fungibles::decimals(currency_id.clone());
-					assert_eq!(currency_denomination, currency_settings.denomination);
+					assert_eq!(currency_denomination, currencies_settings.denomination);
 
 					// if currency has on-zero supply -> collateral in pool account must be
 					// non-zero.

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -101,6 +101,8 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	pub min_operation_balance: u128,
 	/// The deposit to be returned upon destruction of this pool.
 	pub deposit: DepositBalance,
+	/// Whether asset management changes are allowed.
+	pub enable_asset_management: bool,
 }
 
 impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
@@ -116,6 +118,7 @@ where
 		collateral: BaseCurrencyId,
 		bonded_currencies: Currencies,
 		transferable: bool,
+		enable_asset_management: bool,
 		denomination: u8,
 		min_operation_balance: u128,
 		deposit: DepositBalance,
@@ -127,6 +130,7 @@ where
 			collateral,
 			bonded_currencies,
 			transferable,
+			enable_asset_management,
 			state: PoolStatus::default(),
 			denomination,
 			min_operation_balance,

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -78,9 +78,22 @@ impl<LockType> PoolStatus<LockType> {
 	}
 }
 
+#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
+pub struct CurrencySettings {
+	/// The minimum amount that can be minted/burnt.
+	pub min_operation_balance: u128,
+	/// The denomination of the pool.
+	pub denomination: u8,
+	/// Whether asset management changes are allowed.
+	pub enable_asset_management: bool,
+	/// Whether the pool is transferable or not.
+	pub transferable: bool,
+}
+
 /// Details of a pool.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance> {
+pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, BondedCurrencySettings>
+{
 	/// The owner of the pool.
 	pub owner: AccountId,
 	/// The manager of the pool. If a manager is set, the pool is permissioned.
@@ -93,20 +106,14 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	pub bonded_currencies: Currencies,
 	/// The status of the pool.
 	pub state: PoolStatus<Locks>,
-	/// Whether the pool is transferable or not.
-	pub transferable: bool,
-	/// The denomination of the pool.
-	pub denomination: u8,
-	/// The minimum amount that can be minted/burnt.
-	pub min_operation_balance: u128,
+
+	pub currency_settings: BondedCurrencySettings,
 	/// The deposit to be returned upon destruction of this pool.
 	pub deposit: DepositBalance,
-	/// Whether asset management changes are allowed.
-	pub enable_asset_management: bool,
 }
 
 impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
-	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
+	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, CurrencySettings>
 where
 	AccountId: PartialEq + Clone,
 {
@@ -129,11 +136,13 @@ where
 			curve,
 			collateral,
 			bonded_currencies,
-			transferable,
-			enable_asset_management,
+			currency_settings: CurrencySettings {
+				transferable,
+				enable_asset_management,
+				denomination,
+				min_operation_balance,
+			},
 			state: PoolStatus::default(),
-			denomination,
-			min_operation_balance,
 			deposit,
 		}
 	}

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -79,21 +79,20 @@ impl<LockType> PoolStatus<LockType> {
 }
 
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub struct CurrencySettings {
+pub struct BondedCurrenciesSettings {
 	/// The minimum amount that can be minted/burnt.
 	pub min_operation_balance: u128,
 	/// The denomination of the pool.
 	pub denomination: u8,
 	/// Whether asset management changes are allowed.
-	pub enable_asset_management: bool,
+	pub allow_reset_team: bool,
 	/// Whether the pool is transferable or not.
 	pub transferable: bool,
 }
 
 /// Details of a pool.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, BondedCurrencySettings>
-{
+pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, SharedSettings> {
 	/// The owner of the pool.
 	pub owner: AccountId,
 	/// The manager of the pool. If a manager is set, the pool is permissioned.
@@ -107,13 +106,13 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	/// The status of the pool.
 	pub state: PoolStatus<Locks>,
 
-	pub currency_settings: BondedCurrencySettings,
+	pub currencies_settings: SharedSettings,
 	/// The deposit to be returned upon destruction of this pool.
 	pub deposit: DepositBalance,
 }
 
 impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
-	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, CurrencySettings>
+	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, BondedCurrenciesSettings>
 where
 	AccountId: PartialEq + Clone,
 {
@@ -125,7 +124,7 @@ where
 		collateral: BaseCurrencyId,
 		bonded_currencies: Currencies,
 		transferable: bool,
-		enable_asset_management: bool,
+		allow_reset_team: bool,
 		denomination: u8,
 		min_operation_balance: u128,
 		deposit: DepositBalance,
@@ -136,9 +135,9 @@ where
 			curve,
 			collateral,
 			bonded_currencies,
-			currency_settings: CurrencySettings {
+			currencies_settings: BondedCurrenciesSettings {
 				transferable,
-				enable_asset_management,
+				allow_reset_team,
 				denomination,
 				min_operation_balance,
 			},

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -82,11 +82,11 @@ impl<LockType> PoolStatus<LockType> {
 pub struct BondedCurrenciesSettings {
 	/// The minimum amount that can be minted/burnt.
 	pub min_operation_balance: u128,
-	/// The denomination of the pool.
+	/// The denomination of all bonded assets the pool.
 	pub denomination: u8,
-	/// Whether asset management changes are allowed.
+	/// Whether asset management team changes are allowed.
 	pub allow_reset_team: bool,
-	/// Whether the pool is transferable or not.
+	/// Whether assets are transferable or not.
 	pub transferable: bool,
 }
 
@@ -95,7 +95,7 @@ pub struct BondedCurrenciesSettings {
 pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, SharedSettings> {
 	/// The owner of the pool.
 	pub owner: AccountId,
-	/// The manager of the pool. If a manager is set, the pool is permissioned.
+	/// The manager of the pool, who can execute privileged transactions.
 	pub manager: Option<AccountId>,
 	/// The curve of the pool.
 	pub curve: ParametrizedCurve,
@@ -105,7 +105,7 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	pub bonded_currencies: Currencies,
 	/// The status of the pool.
 	pub state: PoolStatus<Locks>,
-
+	/// Shared settings of the currencies in the pool.
 	pub currencies_settings: SharedSettings,
 	/// The deposit to be returned upon destruction of this pool.
 	pub deposit: DepositBalance,

--- a/runtime-api/bonded-coins/src/pool_details.rs
+++ b/runtime-api/bonded-coins/src/pool_details.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use pallet_bonded_coins::{curves::Curve, PoolDetails};
+use pallet_bonded_coins::{curves::Curve, BondedCurrenciesSettings, PoolDetails};
 use parity_scale_codec::{alloc::string::String, Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
@@ -28,8 +28,14 @@ pub type CurveOf = Curve<String>;
 pub type CurrenciesOf<AssetId, Balance> = Vec<BondedCurrencyDetails<AssetId, Balance>>;
 
 /// Human readable pool details.
-pub type PoolDetailsOf<AccountId, Balance, AssetId, CollateralAssetId> =
-	PoolDetails<AccountId, CurveOf, CurrenciesOf<AssetId, Balance>, CollateralDetails<CollateralAssetId>, Balance>;
+pub type PoolDetailsOf<AccountId, Balance, AssetId, CollateralAssetId> = PoolDetails<
+	AccountId,
+	CurveOf,
+	CurrenciesOf<AssetId, Balance>,
+	CollateralDetails<CollateralAssetId>,
+	Balance,
+	BondedCurrenciesSettings,
+>;
 
 /// Collateral currency details used for the runtime API.
 #[derive(Decode, Encode, TypeInfo)]

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -162,7 +162,7 @@ pub mod bonded_coins {
 	use super::*;
 
 	/// The size is checked in the runtime by a test.
-	pub const MAX_POOL_BYTE_LENGTH: u32 = 986;
+	pub const MAX_POOL_BYTE_LENGTH: u32 = 987;
 	pub const BASE_DEPOSIT: Balance = deposit(1, MAX_POOL_BYTE_LENGTH);
 	const ASSET_ID_BYTE_LENGTH: u32 = 8;
 	/// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/assets/src/types.rs#L188

--- a/runtimes/peregrine/src/runtime_apis.rs
+++ b/runtimes/peregrine/src/runtime_apis.rs
@@ -22,8 +22,7 @@ use pallet_bonded_coins::{
 	curves::{
 		balance_to_fixed, fixed_to_balance, lmsr::LMSRParameters, polynomial::PolynomialParameters,
 		square_root::SquareRootParameters, BondingFunction, Curve,
-	},
-	PoolDetailsOf, Pools, Round,
+	}, PoolDetailsOf, Pools, Round,
 };
 use pallet_bonded_coins_runtime_api::{
 	BondedCurrencyDetails, Coefficient, CollateralDetails, PoolDetailsOf as PoolDetails,
@@ -521,7 +520,8 @@ impl_runtime_apis! {
 			high: Balance,
 		) -> Result<Balance, BondedCurrencyError> {
 			let pool = Pools::<Runtime>::get(pool_id).ok_or(BondedCurrencyError::PoolNotFound)?;
-			let PoolDetailsOf::<Runtime> { curve, bonded_currencies, denomination, collateral, .. } = pool;
+			let PoolDetailsOf::<Runtime> { curve, bonded_currencies, currencies_settings, collateral, .. } = pool;
+			let denomination = currencies_settings.denomination;
 			let currency_id = bonded_currencies.get(currency_idx.saturated_into::<usize>()).ok_or(BondedCurrencyError::CurrencyNotFound)?;
 
 			let collateral_denomination = NativeAndForeignAssets::decimals(collateral);
@@ -578,15 +578,13 @@ impl_runtime_apis! {
 			let pool = Pools::<Runtime>::get(pool_id).ok_or(BondedCurrencyError::PoolNotFound)?;
 			let PoolDetailsOf::<Runtime> {
 				curve,
+				currencies_settings,
 				bonded_currencies,
 				owner,
 				collateral,
-				denomination,
 				deposit,
-				min_operation_balance,
 				manager,
 				state,
-				transferable,
 			} = pool;
 
 			let currencies = bonded_currencies.iter().map(|currency_id| -> Result<BondedCurrencyDetails<BondedAssetId, Balance>, BondedCurrencyError> {
@@ -629,12 +627,10 @@ impl_runtime_apis! {
 				curve: fmt_curve,
 				collateral: collateral_details,
 				owner,
-				denomination,
 				deposit,
-				min_operation_balance,
 				manager,
 				state,
-				transferable,
+				currencies_settings
 			})
 		}
 

--- a/runtimes/peregrine/src/runtime_apis.rs
+++ b/runtimes/peregrine/src/runtime_apis.rs
@@ -22,7 +22,8 @@ use pallet_bonded_coins::{
 	curves::{
 		balance_to_fixed, fixed_to_balance, lmsr::LMSRParameters, polynomial::PolynomialParameters,
 		square_root::SquareRootParameters, BondingFunction, Curve,
-	}, PoolDetailsOf, Pools, Round,
+	},
+	PoolDetailsOf, Pools, Round,
 };
 use pallet_bonded_coins_runtime_api::{
 	BondedCurrencyDetails, Coefficient, CollateralDetails, PoolDetailsOf as PoolDetails,


### PR DESCRIPTION
## re/ KILTProtocol/ticket#3800

Addresses potential centralisation concerns around manager permissions. Having this additional flag could make the extent of centralisation of powers in a pool more transparent. If it is set to `false` the reset_team() transaction cannot be used on this pool, in which case the manager has much more limited privileges (locking/unlocking and initiating refunding). This flag can only be set on pool creation and not changed.

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
