### PR TITLE
fix: remove messageQueue

### DIFF
--- a/integration-tests/chopsticks/src/tests/switchPallet/fullFlow/config.ts
+++ b/integration-tests/chopsticks/src/tests/switchPallet/fullFlow/config.ts
@@ -175,7 +175,7 @@ export const testCases: TestConfiguration[] = [
 				foreign: {
 					transfer: [{ section: 'polkadotXcm', method: 'Sent' }],
 					receive: {
-						foreign: ['foreignAssets', { section: 'messageQueue', method: 'Processed' }],
+						foreign: ['foreignAssets'],
 						native: [
 							{ section: 'balances', method: 'Burned' },
 							{ section: 'balances', method: 'Minted' },

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/failingOnReceiver/__snapshots__/index.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/failingOnReceiver/__snapshots__/index.test.ts.snap
@@ -28,26 +28,6 @@ exports[`Switch KILTs while receiver can not handle them > V4 LIVE > Switch on n
 ]
 `;
 
-exports[`Switch KILTs while receiver can not handle them > V4 LIVE > Switch on receiver chain: {"section":"messageQueue","method":"Processed"} 1`] = `
-[
-  {
-    "data": {
-      "id": "(hash)",
-      "origin": {
-        "Sibling": "(rounded 2100)",
-      },
-      "success": false,
-      "weightUsed": {
-        "proofSize": "(rounded 24000)",
-        "refTime": "(rounded 1500000000)",
-      },
-    },
-    "method": "Processed",
-    "section": "messageQueue",
-  },
-]
-`;
-
 exports[`Switch KILTs while receiver can not handle them > V4 LIVE > assetSwitchPool1 Finalization 1`] = `
 [
   {

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/failingOnReceiver/config.ts
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/failingOnReceiver/config.ts
@@ -71,12 +71,7 @@ export const testCases: TestConfiguration[] = [
 			tx: tx.switchPallet.switchV4(),
 			events: {
 				sender: ['assetSwitchPool1'],
-				receiver: [
-					{
-						section: 'messageQueue',
-						method: 'Processed',
-					},
-				],
+				receiver: [],
 			},
 		},
 		sovereignAccount: mainChains.kilt.chainInfo.sovereignAccountOnSiblingChains,

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/noSwitchPair/__snapshots__/index.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/noSwitchPair/__snapshots__/index.test.ts.snap
@@ -1,25 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Switch eKILTs while no pair set > V4 LIVE > Switch eKILTs on receiver chain: {"section":"messageQueue","method":"Processed"} 1`] = `
-[
-  {
-    "data": {
-      "id": "(hash)",
-      "origin": {
-        "Sibling": 1000,
-      },
-      "success": false,
-      "weightUsed": {
-        "proofSize": 0,
-        "refTime": 200000000,
-      },
-    },
-    "method": "Processed",
-    "section": "messageQueue",
-  },
-]
-`;
-
 exports[`Switch eKILTs while no pair set > V4 LIVE > Switch eKILTs on sender chain: {"section":"polkadotXcm","method":"Sent"} 1`] = `
 [
   {

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/noSwitchPair/config.ts
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/noSwitchPair/config.ts
@@ -84,12 +84,7 @@ export const testCases: TestConfiguration[] = [
 						method: 'Sent',
 					},
 				],
-				receiver: [
-					{
-						section: 'messageQueue',
-						method: 'Processed',
-					},
-				],
+				receiver: [],
 			},
 		},
 	},

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/otherReserveLocation/__snapshots__/index.test.ts.snap
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/otherReserveLocation/__snapshots__/index.test.ts.snap
@@ -1,19 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Switch other reserve location > V4 LIVE > Switch eKILTs from untrusted location receiver: {"section":"messageQueue","method":"ProcessingFailed"} 1`] = `
-[
-  {
-    "data": {
-      "error": "Unsupported",
-      "id": "(hash)",
-      "origin": "Parent",
-    },
-    "method": "ProcessingFailed",
-    "section": "messageQueue",
-  },
-]
-`;
-
 exports[`Switch other reserve location > V4 LIVE > Switch eKILTs from untrusted location sender: {"section":"xcmPallet","method":"Sent"} 1`] = `
 [
   {

--- a/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/otherReserveLocation/config.ts
+++ b/integration-tests/chopsticks/src/tests/switchPallet/switchConfig/otherReserveLocation/config.ts
@@ -63,12 +63,7 @@ export const testCases: TestConfiguration[] = [
 						method: 'Sent',
 					},
 				],
-				receiver: [
-					{
-						section: 'messageQueue',
-						method: 'ProcessingFailed',
-					},
-				],
+				receiver: [],
 			},
 		},
 	},


### PR DESCRIPTION
## fixes Chopsticks 

We decided to remove the `messageQueue` pallet from the snapshot tests since its events are not reliably reproducible and cause flaky tests. This PR removes all occurrences.
